### PR TITLE
feat: Global error handler, developer profile, and developer update API

### DIFF
--- a/migrations/0004_create_developers.sql
+++ b/migrations/0004_create_developers.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `developers` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `user_id` text NOT NULL UNIQUE,
+  `name` text,
+  `website` text,
+  `description` text,
+  `category` text,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  `updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `idx_developers_user_id` ON `developers` (`user_id`);

--- a/package.json
+++ b/package.json
@@ -8,18 +8,18 @@
     "dev": "tsx watch src/index.ts",
     "db:generate": "drizzle-kit generate:sqlite",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
     "test": "jest --runInBand",
-    "validate:issue-9": "node scripts/validate-issue-9.mjs"
+    "validate:issue-9": "node scripts/validate-issue-9.mjs",
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "express": "^4.18.2",
-    "helmet": "^8.1.0"
+    "helmet": "^8.1.0",
     "drizzle-orm": "^0.29.0",
-    "better-sqlite3": "^9.2.2"
+    "better-sqlite3": "^9.2.2",
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
@@ -39,7 +39,7 @@
     "@types/better-sqlite3": "^8.6.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
-    "drizzle-kit": "^0.20.7"
+    "drizzle-kit": "^0.20.7",
     "@types/pg": "^8.16.0",
     "@types/supertest": "^6.0.3",
     "@types/uuid": "^10.0.0",

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -58,6 +58,8 @@ test('GET /api/developers/analytics returns 401 when unauthenticated', async () 
   const app = createApp({ usageEventsRepository: seedRepository() });
   const response = await request(app).get('/api/developers/analytics');
   assert.equal(response.status, 401);
+  assert.equal(typeof response.body.error, 'string');
+  assert.equal(response.body.code, 'UNAUTHORIZED');
 });
 
 test('GET /api/developers/analytics validates query params', async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import {
 } from './repositories/usageEventsRepository.js';
 import { requireAuth, type AuthenticatedLocals } from './middleware/requireAuth.js';
 import { buildDeveloperAnalytics } from './services/developerAnalytics.js';
+import { errorHandler } from './middleware/errorHandler.js';
 
 interface AppDependencies {
   usageEventsRepository: UsageEventsRepository;
@@ -91,5 +92,6 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     res.json(analytics);
   });
 
+  app.use(errorHandler);
   return app;
 };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -25,28 +25,35 @@ export async function initializeDb() {
 
     if (!tableExists) {
       console.log('Running initial migration...');
-      
-      // Read and execute the migration SQL
       const migrationSQL = readFileSync(
-        join(__dirname, '..', '..', 'migrations', '0000_initial_apis_tables.sql'), 
+        join(__dirname, '..', '..', 'migrations', '0000_initial_apis_tables.sql'),
         'utf8'
       );
-      
-      // Split by semicolon and execute each statement
       const statements = migrationSQL.split(';').filter(stmt => stmt.trim());
-      
       sqlite.exec('BEGIN TRANSACTION');
-      
       for (const statement of statements) {
-        if (statement.trim()) {
-          sqlite.exec(statement);
-        }
+        if (statement.trim()) sqlite.exec(statement);
       }
-      
       sqlite.exec('COMMIT');
-      console.log('✅ Database migration completed successfully');
-    } else {
-      console.log('Database already initialized');
+      console.log('✅ Initial migration completed');
+    }
+
+    const developersExists = sqlite.prepare(`
+      SELECT name FROM sqlite_master WHERE type='table' AND name='developers'
+    `).get();
+    if (!developersExists) {
+      console.log('Running developers migration...');
+      const devSQL = readFileSync(
+        join(__dirname, '..', '..', 'migrations', '0004_create_developers.sql'),
+        'utf8'
+      );
+      const statements = devSQL.split(';').filter(stmt => stmt.trim());
+      sqlite.exec('BEGIN TRANSACTION');
+      for (const statement of statements) {
+        if (statement.trim()) sqlite.exec(statement);
+      }
+      sqlite.exec('COMMIT');
+      console.log('✅ Developers migration completed');
     }
   } catch (error) {
     console.error('Failed to run database migrations:', error);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,21 @@
 import { sql } from 'drizzle-orm';
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 
+// Developers table (one profile per user; user_id from auth e.g. x-user-id)
+export const developers = sqliteTable('developers', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  user_id: text('user_id').notNull().unique(),
+  name: text('name'),
+  website: text('website'),
+  description: text('description'),
+  category: text('category'),
+  created_at: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  updated_at: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+});
+
+export type Developer = typeof developers.$inferSelect;
+export type NewDeveloper = typeof developers.$inferInsert;
+
 // Status enum for APIs
 export const apiStatusEnum = ['draft', 'active', 'paused', 'archived'] as const;
 export type ApiStatus = typeof apiStatusEnum[number];

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Custom error classes for consistent HTTP error handling.
+ * Use these in routes/services; the global error handler maps them to status codes and JSON.
+ */
+
+export class AppError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number = 500,
+    public readonly code?: string
+  ) {
+    super(message);
+    this.name = 'AppError';
+    Object.setPrototypeOf(this, AppError.prototype);
+  }
+}
+
+export class BadRequestError extends AppError {
+  constructor(message: string = 'Bad request', code?: string) {
+    super(message, 400, code ?? 'BAD_REQUEST');
+    this.name = 'BadRequestError';
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message: string = 'Unauthorized', code?: string) {
+    super(message, 401, code ?? 'UNAUTHORIZED');
+    this.name = 'UnauthorizedError';
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message: string = 'Forbidden', code?: string) {
+    super(message, 403, code ?? 'FORBIDDEN');
+    this.name = 'ForbiddenError';
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message: string = 'Not found', code?: string) {
+    super(message, 404, code ?? 'NOT_FOUND');
+    this.name = 'NotFoundError';
+  }
+}
+
+export function isAppError(err: unknown): err is AppError {
+  return err instanceof AppError;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,19 @@ import { calloraEvents } from './events/event.emitter';
 import helmet from 'helmet';
 import { db, initializeDb, schema } from './db/index.js';
 import { eq, desc } from 'drizzle-orm';
+import { requireAuth, type AuthenticatedLocals } from './middleware/requireAuth.js';
+import { errorHandler } from './middleware/errorHandler.js';
+import { BadRequestError, NotFoundError, UnauthorizedError, ForbiddenError } from './errors/index.js';
+import * as developerRepository from './repositories/developerRepository.js';
+import type { Response } from 'express';
 
 const app = express();
-const PORT = process.env.PORT ?? 3000;
+
+function asyncHandler<T>(fn: (req: express.Request, res: Response<T, AuthenticatedLocals>, next: express.NextFunction) => Promise<void>) {
+  return (req: express.Request, res: Response<T, AuthenticatedLocals>, next: express.NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -185,6 +195,78 @@ app.get('/api/usage', (_req, res) => {
   res.json({ calls: 0, period: 'current' });
 });
 
+// Developer profile: get current user's profile
+app.get('/api/developers/me', requireAuth, asyncHandler(async (req, res) => {
+  const user = res.locals.authenticatedUser;
+  if (!user) throw new UnauthorizedError();
+  const developer = await developerRepository.findByUserId(user.id);
+  if (!developer) throw new NotFoundError('Developer profile not found');
+  res.json({ developer });
+}));
+
+// Developer profile: create or update (upsert)
+app.post('/api/developers', requireAuth, asyncHandler(async (req, res) => {
+  const user = res.locals.authenticatedUser;
+  if (!user) throw new UnauthorizedError();
+  const { name, website, description, category } = req.body ?? {};
+  const developer = await developerRepository.upsert(user.id, {
+    name: name ?? null,
+    website: website ?? null,
+    description: description ?? null,
+    category: category ?? null,
+  });
+  res.status(201).json({ developer });
+}));
+
+// Update API owned by current developer (PATCH /api/developers/apis/:id)
+app.patch('/api/developers/apis/:id', requireAuth, asyncHandler(async (req, res) => {
+  const user = res.locals.authenticatedUser;
+  if (!user) throw new UnauthorizedError();
+  const developer = await developerRepository.findByUserId(user.id);
+  if (!developer) throw new ForbiddenError('Developer profile required');
+  const apiId = parseInt(req.params.id, 10);
+  if (Number.isNaN(apiId)) throw new BadRequestError('Invalid API id');
+  const [apiRow] = await db.select().from(schema.apis).where(eq(schema.apis.id, apiId)).limit(1);
+  if (!apiRow) throw new NotFoundError('API not found');
+  if (apiRow.developer_id !== developer.id) throw new ForbiddenError('API does not belong to your developer account');
+
+  const { name, description, base_url, category, status, endpoints } = req.body ?? {};
+  const updates: Record<string, unknown> = { updated_at: new Date() };
+  if (name !== undefined) updates.name = name;
+  if (description !== undefined) updates.description = description;
+  if (base_url !== undefined) updates.base_url = base_url;
+  if (category !== undefined) updates.category = category;
+  if (status !== undefined) {
+    if (!['draft', 'active', 'paused', 'archived'].includes(String(status))) throw new BadRequestError('Invalid status');
+    updates.status = status;
+  }
+
+  const [updatedApi] = await db.update(schema.apis).set(updates as Record<string, unknown>).where(eq(schema.apis.id, apiId)).returning();
+  if (!updatedApi) throw new Error('Update failed');
+
+  if (Array.isArray(endpoints)) {
+    await db.delete(schema.apiEndpoints).where(eq(schema.apiEndpoints.api_id, apiId));
+    for (const ep of endpoints) {
+      const path = ep?.path;
+      if (path == null || typeof path !== 'string') continue;
+      const method = (ep?.method ?? 'GET').toUpperCase();
+      const price = ep?.price_per_call_usdc ?? '0.01';
+      const descText = ep?.description ?? null;
+      const methodVal = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].includes(method) ? method : 'GET';
+      await db.insert(schema.apiEndpoints).values({
+        api_id: apiId,
+        path,
+        method: methodVal,
+        price_per_call_usdc: String(price),
+        description: descText,
+      });
+    }
+  }
+
+  const endpointsList = await db.select().from(schema.apiEndpoints).where(eq(schema.apiEndpoints.api_id, apiId)).orderBy(desc(schema.apiEndpoints.created_at));
+  res.json({ api: updatedApi, endpoints: endpointsList });
+}));
+
 // Webhook registration and management routes
 app.use('/api/webhooks', webhookRouter);
 
@@ -200,6 +282,9 @@ if (process.env.NODE_ENV !== 'production') {
     return res.json({ triggered: event, developerId });
   });
 }
+
+// Global error handler (must be after all routes)
+app.use(errorHandler);
 
 app.listen(PORT, () => {
   console.log(`Callora backend listening on http://localhost:${PORT}`);
@@ -225,3 +310,4 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 export default app;
+}

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,0 +1,45 @@
+import type { Request, Response, NextFunction } from 'express';
+import { isAppError } from '../errors/index.js';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+/**
+ * Standard JSON body for error responses: { error: string, code?: string }
+ */
+export interface ErrorResponseBody {
+  error: string;
+  code?: string;
+}
+
+/**
+ * Global error-handling middleware (4-arg form).
+ * - Catches errors thrown in routes/services
+ * - Maps known AppError subclasses to HTTP status codes
+ * - Returns consistent JSON: { error, code? }
+ * - Never sends stack traces to the client in production
+ * - Logs full error server-side
+ */
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response<ErrorResponseBody>,
+  _next: NextFunction
+): void {
+  const statusCode = isAppError(err) ? err.statusCode : 500;
+  const message = err instanceof Error ? err.message : 'Internal server error';
+  const code = isAppError(err) ? err.code : undefined;
+
+  const body: ErrorResponseBody = { error: message };
+  if (code) body.code = code;
+
+  if (!res.headersSent) {
+    res.status(statusCode).json(body);
+  }
+
+  // Log full error server-side (including stack in dev)
+  if (isProduction) {
+    console.error('[errorHandler]', statusCode, message, err instanceof Error ? err.stack : String(err));
+  } else {
+    console.error('[errorHandler]', err);
+  }
+}

--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -1,6 +1,7 @@
 import type { NextFunction, Request, Response } from 'express';
 
 import type { AuthenticatedUser } from '../types/auth.js';
+import { UnauthorizedError } from '../errors/index.js';
 
 export interface AuthenticatedLocals {
   authenticatedUser?: AuthenticatedUser;
@@ -13,7 +14,7 @@ export const requireAuth = (
 ): void => {
   const userId = req.header('x-user-id');
   if (!userId) {
-    res.status(401).json({ error: 'Unauthorized' });
+    next(new UnauthorizedError());
     return;
   }
 

--- a/src/repositories/developerRepository.ts
+++ b/src/repositories/developerRepository.ts
@@ -1,0 +1,51 @@
+import { eq } from 'drizzle-orm';
+import { db, schema } from '../db/index.js';
+import type { Developer, NewDeveloper } from '../db/schema.js';
+
+export async function findByUserId(userId: string): Promise<Developer | undefined> {
+  const rows = await db
+    .select()
+    .from(schema.developers)
+    .where(eq(schema.developers.user_id, userId))
+    .limit(1);
+  return rows[0];
+}
+
+export async function upsert(userId: string, data: {
+  name?: string | null;
+  website?: string | null;
+  description?: string | null;
+  category?: string | null;
+}): Promise<Developer> {
+  const existing = await findByUserId(userId);
+  const now = new Date();
+
+  if (existing) {
+    const [updated] = await db
+      .update(schema.developers)
+      .set({
+        name: data.name ?? existing.name,
+        website: data.website ?? existing.website,
+        description: data.description ?? existing.description,
+        category: data.category ?? existing.category,
+        updated_at: now,
+      })
+      .where(eq(schema.developers.id, existing.id))
+      .returning();
+    if (!updated) throw new Error('Developer update failed');
+    return updated;
+  }
+
+  const [inserted] = await db
+    .insert(schema.developers)
+    .values({
+      user_id: userId,
+      name: data.name ?? null,
+      website: data.website ?? null,
+      description: data.description ?? null,
+      category: data.category ?? null,
+    } as NewDeveloper)
+    .returning();
+  if (!inserted) throw new Error('Developer insert failed');
+  return inserted;
+}


### PR DESCRIPTION
## Summary

Implements three features: a central error-handling middleware (Issue #4), REST developer register/profile (Issue #33), and REST developer update API (Issue #35).

## Changes

### Issue #4 – Global error handler middleware

- **Custom errors** (`src/errors/index.ts`): `AppError`, `BadRequestError`, `UnauthorizedError`, `ForbiddenError`, `NotFoundError` with optional `code`.
- **Error handler** (`src/middleware/errorHandler.ts`): 4-arg Express middleware that:
  - Maps known error types to HTTP status codes
  - Returns consistent JSON: `{ error: string, code?: string }`
  - Logs full error server-side; no stack traces sent to the client in production
- Error handler mounted after all routes in `src/app.ts` and `src/index.ts`.
- `requireAuth` updated to call `next(new UnauthorizedError())` so 401 responses use the same JSON shape.

### Issue #33 – REST developer register and profile

- **Schema**: New `developers` table (`user_id` unique, `name`, `website`, `description`, `category`) and migration `0004_create_developers.sql`.
- **Repository**: `src/repositories/developerRepository.ts` with `findByUserId` and `upsert` (one profile per user).
- **Routes** (authenticated via `x-user-id`):
  - `POST /api/developers` – body `name`, `website`, `description`, `category`; create or update current user’s developer profile; returns `{ developer }` (201).
  - `GET /api/developers/me` – returns current user’s developer profile (404 if none).

### Issue #35 – REST developer update API

- **Route**: `PATCH /api/developers/apis/:id` (authenticated).
- Verifies the API belongs to the current user’s developer account (403 otherwise).
- Body: `name`, `description`, `base_url`, `category`, `status`, `endpoints`.
- **Endpoints**: If `endpoints` is provided, existing endpoints for the API are **fully replaced** with the given array (each item: `path` required; optional `method`, `price_per_call_usdc`, `description`).
- Response: `{ api, endpoints }`.

## Testing

- `src/app.test.ts`: Unauthenticated request to `/api/developers/analytics` asserts 401 and error response shape (`error`, `code: 'UNAUTHORIZED'`).

## Notes

- `package.json`: Fixed missing commas so the file is valid JSON.
- `src/index.ts`: Added `asyncHandler` for async routes and fixed the top-level `if` block closing brace.