### PR TITLE
feat: graceful shutdown (#58)

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -60,9 +60,8 @@ export async function initializeDb() {
 }
 
 // Graceful shutdown
-process.on('SIGINT', () => {
+// Export close function for graceful shutdown
+export function closeDb() {
   sqlite.close();
-  process.exit(0);
-});
-
+}
 export { schema };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,14 @@ import express from 'express';
 import webhookRouter from './webhooks/webhook.routes.js';
 import { calloraEvents } from './events/event.emitter.js';
 import helmet from 'helmet';
-import { db, initializeDb, schema } from './db/index.js';
+import { db, initializeDb, schema, closeDb } from './db/index.js';
 import { eq, desc, and, type SQL } from 'drizzle-orm';
 import { requireAuth, type AuthenticatedLocals } from './middleware/requireAuth.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { BadRequestError, NotFoundError, UnauthorizedError, ForbiddenError } from './errors/index.js';
 import * as developerRepository from './repositories/developerRepository.js';
 import type { Response } from 'express';
+import type { Socket } from 'net';
 
 import { createDeveloperRouter } from './routes/developerRoutes.js';
 import { createGatewayRouter } from './routes/gatewayRoutes.js';
@@ -100,9 +101,66 @@ if (isDirectExecution) {
   async function startServer() {
     try {
       await initializeDb();
-      app.listen(PORT, () => {
+      
+      const server = app.listen(PORT, () => {
         console.log(`Callora backend listening on http://localhost:${PORT}`);
       });
+
+      // Track active connections so we can wait for them to finish
+      const activeConnections = new Set<Socket>();
+
+      server.on('connection', (socket: Socket) => {
+        activeConnections.add(socket);
+        socket.once('close', () => activeConnections.delete(socket));
+      });
+
+      async function gracefulShutdown(signal: string) {
+        console.log(`\n[shutdown] Received ${signal}. Starting graceful shutdown...`);
+
+        // 1. Stop accepting new requests
+        server.close(() => {
+          console.log('[shutdown] HTTP server closed. No new requests accepted.');
+        });
+
+        // 2. Wait for in-flight requests to finish (max 30s)
+        const TIMEOUT_MS = 30_000;
+        const deadline = setTimeout(() => {
+          console.warn('[shutdown] Timeout reached. Forcing exit.');
+          process.exit(1);
+        }, TIMEOUT_MS);
+        deadline.unref();
+
+        // 3. Wait until all active connections are gone
+        await new Promise<void>((resolve) => {
+          if (activeConnections.size === 0) return resolve();
+          console.log(`[shutdown] Waiting for ${activeConnections.size} in-flight connection(s)...`);
+          const interval = setInterval(() => {
+            if (activeConnections.size === 0) {
+              clearInterval(interval);
+              resolve();
+            }
+          }, 200);
+        });
+
+        // 4. Close the database
+        console.log('[shutdown] Closing database...');
+        try {
+          closeDb();
+          console.log('[shutdown] Database closed.');
+        } catch (err) {
+          console.error('[shutdown] Error closing database:', err);
+        }
+
+        // 5. Exit cleanly
+        console.log('[shutdown] Shutdown complete. Exiting.');
+        clearTimeout(deadline);
+        process.exit(0);
+      }
+
+      // Register shutdown signals
+      process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+      process.on('SIGINT',  () => gracefulShutdown('SIGINT'));
+
     } catch (error) {
       console.error('Failed to start server:', error);
       process.exit(1);


### PR DESCRIPTION
## Summary
This PR implements a robust graceful shutdown mechanism to ensure the backend safely drains in-flight requests and closes database connections on `SIGTERM` and `SIGINT` signals, preventing 502 errors during deployments or restarts.

Fixes #58 

## Changes Made
* **Signal Handlers:** Registered listeners for `SIGTERM` and `SIGINT` inside `src/index.ts`.
* **Load Balancer Draining:** Calls `server.close()` immediately to stop accepting new HTTP requests.
* **In-Flight Request Tracking:** Implemented raw TCP socket tracking using a `Set` (`activeConnections`) to ensure critical billing and settlement requests are fully processed before the server exits.
* **Database Teardown:** Extracted `closeDb()` in `src/db/index.ts` and integrated it into the shutdown sequence to safely close the SQLite connection.
* **Timeout Safety Net:** Added a 30-second maximum shutdown timeout (`TIMEOUT_MS`) to force-exit the process if connections hang indefinitely.

## Testing
- Verified server stops accepting new connections immediately on `CTRL+C`.
- Verified the event loop waits for active connections to drop to `0`.
- Verified the database closes successfully before `process.exit(0)`.