### PR TITLE
chore(backend): validate request body size limits to prevent abuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,11 @@ LOG_LEVEL=info
 # Profiling
 # -----------------------------------------------------------------------------
 GATEWAY_PROFILING_ENABLED=false
+
+# -----------------------------------------------------------------------------
+# Body size limits
+# REQUEST_BODY_LIMIT  — max JSON/form body for general API routes (default: 100kb)
+# GATEWAY_BODY_LIMIT  — max body the gateway router will accept before proxying (default: 1mb)
+# -----------------------------------------------------------------------------
+REQUEST_BODY_LIMIT=100kb
+GATEWAY_BODY_LIMIT=1mb

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -911,14 +911,73 @@ describe('Route precedence and ordering', () => {
 
   test('errorHandler is registered last and catches all errors', async () => {
     const app = createApp();
-    
+
     // Test that errors from any route are caught
     const res = await request(app)
       .get('/api/developers/analytics?from=invalid&to=invalid')
       .set('x-user-id', 'dev-1');
-    
+
     assert.equal(res.status, 400);
     assert.ok(res.body.error);
     assert.equal(typeof res.body.error, 'string');
+  });
+});
+
+describe('body size limits (REQUEST_BODY_LIMIT)', () => {
+  // These tests rely on the default REQUEST_BODY_LIMIT of '100kb'.
+  // Body parsing happens before auth, so auth is irrelevant to the 413 outcome.
+
+  test('returns 413 when JSON body exceeds the configured limit', async () => {
+    const app = createApp();
+    // ~200 KB – exceeds the 100kb default
+    const oversizedBody = JSON.stringify({ data: 'x'.repeat(200 * 1024) });
+
+    const res = await request(app)
+      .post('/api/developers/apis')
+      .set('Content-Type', 'application/json')
+      .send(oversizedBody);
+
+    assert.equal(res.status, 413);
+  });
+
+  test('returns a JSON error body with a descriptive message on 413', async () => {
+    const app = createApp();
+    const oversizedBody = JSON.stringify({ data: 'x'.repeat(200 * 1024) });
+
+    const res = await request(app)
+      .post('/api/developers/apis')
+      .set('Content-Type', 'application/json')
+      .send(oversizedBody);
+
+    assert.equal(res.status, 413);
+    assert.ok(res.headers['content-type']?.includes('application/json'));
+    assert.equal(res.body.error, 'Request body too large');
+  });
+
+  test('accepts JSON bodies within the configured limit', async () => {
+    const app = createApp();
+    // ~1 KB – well within the 100kb default
+    const smallBody = { name: 'tiny' };
+
+    const res = await request(app)
+      .post('/api/developers/apis')
+      .set('Content-Type', 'application/json')
+      .send(smallBody);
+
+    // Any status except 413 confirms body parsing succeeded (401 is fine — auth hasn't run yet)
+    assert.notEqual(res.status, 413);
+  });
+
+  test('returns 413 for oversized URL-encoded bodies', async () => {
+    const app = createApp();
+    // Build a URL-encoded value that exceeds 100kb
+    const oversizedValue = 'x'.repeat(200 * 1024);
+
+    const res = await request(app)
+      .post('/api/developers/apis')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(`data=${oversizedValue}`);
+
+    assert.equal(res.status, 413);
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -196,7 +196,9 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
       optionsSuccessStatus: 204, // No content for preflight
     }),
   );
-  app.use(express.json());
+  const requestBodyLimit = process.env.REQUEST_BODY_LIMIT ?? '100kb';
+  app.use(express.json({ limit: requestBodyLimit }));
+  app.use(express.urlencoded({ extended: false, limit: requestBodyLimit }));
 
   /**
    * GET /api/health

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -98,6 +98,10 @@ const envSchema = z
       .string()
       .transform((v) => v === 'true')
       .default(false),
+
+    // Body size limits
+    REQUEST_BODY_LIMIT: z.string().default('100kb'),
+    GATEWAY_BODY_LIMIT: z.string().default('1mb'),
   })
   .superRefine((values, ctx) => {
     if (values.SOROBAN_RPC_ENABLED && !values.SOROBAN_RPC_URL) {

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -27,8 +27,20 @@ export function errorHandler(
   res: Response<ErrorResponseBody>,
   _next: NextFunction
 ): void {
-  const statusCode = isAppError(err) ? err.statusCode : 500;
-  const message = err instanceof Error ? err.message : 'Internal server error';
+  // AppError subclasses carry statusCode; Express body-parser errors carry status (e.g. 413)
+  const statusCode = isAppError(err)
+    ? err.statusCode
+    : typeof (err as Record<string, unknown>).status === 'number'
+      ? (err as { status: number }).status
+      : 500;
+
+  const message =
+    statusCode === 413
+      ? 'Request body too large'
+      : err instanceof Error
+        ? err.message
+        : 'Internal server error';
+
   const code = isAppError(err) ? err.code : undefined;
   const requestId = (req as any).id || 'unknown';
 

--- a/src/routes/gatewayRoutes.test.ts
+++ b/src/routes/gatewayRoutes.test.ts
@@ -2,6 +2,7 @@ import express from "express";
 import request from "supertest";
 import { createGatewayRouter } from "./gatewayRoutes.js";
 import { createRateLimiter } from "../services/rateLimiter.js";
+import { errorHandler } from "../middleware/errorHandler.js";
 
 describe("gateway route - rate limiting", () => {
   beforeEach(() => {
@@ -33,7 +34,7 @@ describe("gateway route - rate limiting", () => {
     } as any;
 
     const app = express();
-    app.use(express.json());
+    // The gateway router supplies its own body parser; no outer express.json() needed
     app.use("/gateway", createGatewayRouter(deps));
 
     const res = await request(app)
@@ -46,5 +47,145 @@ describe("gateway route - rate limiting", () => {
     expect(res.body).toHaveProperty("error", "Too Many Requests");
     expect(res.body).toHaveProperty("retryAfterMs", windowMs);
     expect(res.body).toHaveProperty("requestId");
+  });
+});
+
+describe("gateway route - body size limits", () => {
+  function buildApp(maxBodySize?: string) {
+    const apiKey = "test-key";
+    const apiId = "my-api";
+    const apiKeys = new Map<string, any>();
+    apiKeys.set(apiKey, { key: "k1", apiId, developerId: "dev1" });
+
+    const deps = {
+      billing: { deductCredit: async () => ({ success: true, balance: 100 }) },
+      rateLimiter: { check: () => ({ allowed: true }) },
+      usageStore: { record: () => true },
+      upstreamUrl: "http://example.invalid",
+      apiKeys,
+      maxBodySize,
+    } as any;
+
+    const app = express();
+    // No outer express.json() — the gateway router enforces its own limit
+    app.use("/gateway", createGatewayRouter(deps));
+    app.use(errorHandler);
+    return { app, apiKey, apiId };
+  }
+
+  test("accepts POST bodies within the configured size limit", async () => {
+    const apiKey = "test-key";
+    const apiId = "my-api";
+    const apiKeys = new Map<string, any>();
+    apiKeys.set(apiKey, { key: "k1", apiId, developerId: "dev1" });
+
+    const deps = {
+      // Returning { success: false } causes a 402 before any upstream fetch,
+      // keeping the test fast while still proving the body was parsed (not 413).
+      billing: { deductCredit: async () => ({ success: false, balance: 0 }) },
+      rateLimiter: { check: () => ({ allowed: true }) },
+      usageStore: { record: () => true },
+      upstreamUrl: "http://example.invalid",
+      apiKeys,
+      maxBodySize: "1kb",
+    } as any;
+
+    const app = express();
+    app.use("/gateway", createGatewayRouter(deps));
+    app.use(errorHandler);
+
+    // 50 bytes — well within the 1kb limit
+    const smallBody = { data: "x".repeat(50) };
+
+    const res = await request(app)
+      .post(`/gateway/${apiId}`)
+      .set("x-api-key", apiKey)
+      .send(smallBody);
+
+    // Body parsed successfully; billing refused (402) — not a body-size rejection
+    expect(res.status).toBe(402);
+    expect(res.status).not.toBe(413);
+  });
+
+  test("returns 413 when POST body exceeds the configured size limit", async () => {
+    const { app, apiKey, apiId } = buildApp("100b");
+    // 300 bytes — over the 100-byte test limit
+    const largeBody = { data: "x".repeat(300) };
+
+    const res = await request(app)
+      .post(`/gateway/${apiId}`)
+      .set("x-api-key", apiKey)
+      .send(largeBody);
+
+    expect(res.status).toBe(413);
+  });
+
+  test("returns 413 without requiring a valid API key when body exceeds the limit", async () => {
+    // Body parsing runs before auth; a 413 must be returned even with a missing key
+    const { app, apiId } = buildApp("100b");
+    const largeBody = { data: "x".repeat(300) };
+
+    const res = await request(app)
+      .post(`/gateway/${apiId}`)
+      // no x-api-key header
+      .send(largeBody);
+
+    expect(res.status).toBe(413);
+  });
+
+  test("defaults to 1mb limit when maxBodySize is not specified", async () => {
+    const apiKey = "test-key";
+    const apiId = "my-api";
+    const apiKeys = new Map<string, any>();
+    apiKeys.set(apiKey, { key: "k1", apiId, developerId: "dev1" });
+
+    const deps = {
+      // Fail billing fast so we never attempt the upstream fetch
+      billing: { deductCredit: async () => ({ success: false, balance: 0 }) },
+      rateLimiter: { check: () => ({ allowed: true }) },
+      usageStore: { record: () => true },
+      upstreamUrl: "http://example.invalid",
+      apiKeys,
+      // no maxBodySize → defaults to 1mb
+    } as any;
+
+    const app = express();
+    app.use("/gateway", createGatewayRouter(deps));
+    app.use(errorHandler);
+
+    // 500 KB — under the 1mb default limit
+    const body = { data: "x".repeat(500 * 1024) };
+
+    const res = await request(app)
+      .post(`/gateway/${apiId}`)
+      .set("x-api-key", apiKey)
+      .send(body);
+
+    expect(res.status).not.toBe(413);
+  });
+
+  test("rejects GET requests not affected — limit only applies to bodies", async () => {
+    // GET requests have no body; ensure they are unaffected by the size limit
+    const { app, apiKey, apiId } = buildApp("1b"); // absurdly small limit
+
+    const res = await request(app)
+      .get(`/gateway/${apiId}`)
+      .set("x-api-key", apiKey);
+
+    expect(res.status).not.toBe(413);
+  });
+
+  test("returns 413 error response with JSON content-type when error handler is present", async () => {
+    const { app, apiKey, apiId } = buildApp("100b");
+    const largeBody = { data: "x".repeat(300) };
+
+    const res = await request(app)
+      .post(`/gateway/${apiId}`)
+      .set("x-api-key", apiKey)
+      .send(largeBody);
+
+    expect(res.status).toBe(413);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body).toHaveProperty("error", "Request body too large");
   });
 });

--- a/src/routes/gatewayRoutes.ts
+++ b/src/routes/gatewayRoutes.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { Router, type Request, type Response } from 'express';
+import express, { Router, type Request, type Response } from 'express';
 import { z } from 'zod';
 import { startUpstreamTimer, type UpstreamOutcome } from '../metrics.js';
 import { validate } from '../middleware/validate.js';
@@ -7,6 +7,7 @@ import type { GatewayDeps } from '../types/gateway.js';
 
 const CREDIT_COST_PER_CALL = 1;
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BODY_SIZE = '1mb';
 
 const apiIdParamsSchema = z.object({
   apiId: z.string().min(1, 'API ID is required').max(50, 'API ID too long'),
@@ -15,7 +16,14 @@ const apiIdParamsSchema = z.object({
 export function createGatewayRouter(deps: GatewayDeps): Router {
   const { billing, rateLimiter, usageStore, upstreamUrl } = deps;
   const apiKeys = deps.apiKeys ?? new Map();
+  const maxBodySize = deps.maxBodySize ?? DEFAULT_MAX_BODY_SIZE;
   const router = Router();
+
+  // Enforce body size limits at the router level so the gateway is self-contained
+  // regardless of whether a global body parser is present. Oversized bodies surface
+  // as 413 via the app-level error handler.
+  router.use(express.json({ limit: maxBodySize }));
+  router.use(express.urlencoded({ extended: false, limit: maxBodySize }));
 
   router.all(
     '/:apiId',

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -96,6 +96,8 @@ export interface GatewayDeps {
   upstreamUrl: string;
   apiKeys?: Map<string, ApiKey>;
   authMiddleware?: RequestHandler;
+  /** Maximum allowed request body size (Express size string, e.g. '1mb', '512kb'). Default: '1mb'. */
+  maxBodySize?: string;
 }
 
 /** Dependencies injected into the proxy router factory. */


### PR DESCRIPTION
closes #228 

- Apply configurable JSON and URL-encoded body size limits in createApp via REQUEST_BODY_LIMIT env var (default 100kb)
- Add self-contained body parser with configurable maxBodySize option to createGatewayRouter (default 1mb) so the gateway enforces its own limit regardless of outer middleware
- Fix errorHandler to surface 413 from Express body-parser (which sets err.status, not err.statusCode) and return a clean JSON error message
- Add REQUEST_BODY_LIMIT and GATEWAY_BODY_LIMIT to env schema and document both in .env.example
- Cover success and failure modes with 10 new unit tests across gatewayRoutes.test.ts and app.test.ts