### PR TITLE
chore(backend): add tests for negative/zero usage quantities (should …

### DIFF
--- a/src/services/billing.test.ts
+++ b/src/services/billing.test.ts
@@ -128,6 +128,28 @@ describe('billingInternals', () => {
       { message: 'amountUsdc must be a positive decimal with at most 7 fractional digits' }
     );
   });
+
+  test('rejects all zero decimal forms', () => {
+    const zeroForms = ['0.0', '0.00', '0.0000000'];
+    for (const zero of zeroForms) {
+      assert.throws(
+        () => billingInternals.parseUsdcToContractUnits(zero),
+        { message: 'amountUsdc must be greater than zero' },
+        `expected "${zero}" to be rejected as zero`
+      );
+    }
+  });
+
+  test('rejects negative values and malformed inputs', () => {
+    const invalids = ['-0', '-0.0', '-0.0000001', '-1', '-1.0000000', '', '   ', 'NaN', 'Infinity', '-'];
+    for (const val of invalids) {
+      assert.throws(
+        () => billingInternals.parseUsdcToContractUnits(val),
+        { message: 'amountUsdc must be a positive decimal with at most 7 fractional digits' },
+        `expected "${val}" to be rejected as invalid format`
+      );
+    }
+  });
 });
 
 describe('BillingService.deduct', () => {
@@ -345,6 +367,61 @@ describe('BillingService.deduct', () => {
     assert.equal(result.usageEventId, '99');
     assert.equal(result.alreadyProcessed, true);
   });
+});
+
+describe('BillingService.deduct — non-positive quantity rejection', () => {
+  // A pool that fails the test if connect() is ever called, confirming that
+  // invalid-amount requests are rejected before any DB or Soroban work begins.
+  function poolThatMustNotConnect(): Pool {
+    return {
+      connect: async () => {
+        throw new Error('pool.connect() must not be called for non-positive amounts');
+      },
+    } as unknown as Pool;
+  }
+
+  function sorobanThatMustNotBeCalled(): SorobanClient {
+    return {
+      getBalance: async () => {
+        throw new Error('soroban.getBalance() must not be called for non-positive amounts');
+      },
+      deductBalance: async () => {
+        throw new Error('soroban.deductBalance() must not be called for non-positive amounts');
+      },
+    };
+  }
+
+  const rejectCases: Array<[string, string]> = [
+    ['0',           'amountUsdc must be greater than zero'],
+    ['0.0',         'amountUsdc must be greater than zero'],
+    ['0.0000000',   'amountUsdc must be greater than zero'],
+    ['-1',          'amountUsdc must be a positive decimal with at most 7 fractional digits'],
+    ['-0.0000001',  'amountUsdc must be a positive decimal with at most 7 fractional digits'],
+    ['-1.0000000',  'amountUsdc must be a positive decimal with at most 7 fractional digits'],
+    ['',            'amountUsdc must be a positive decimal with at most 7 fractional digits'],
+    ['   ',         'amountUsdc must be a positive decimal with at most 7 fractional digits'],
+    ['NaN',         'amountUsdc must be a positive decimal with at most 7 fractional digits'],
+  ];
+
+  for (const [amountUsdc, expectedError] of rejectCases) {
+    test(`rejects amountUsdc "${amountUsdc}" without touching the DB`, async () => {
+      const billingService = new BillingService(
+        poolThatMustNotConnect(),
+        sorobanThatMustNotBeCalled(),
+        { retryDelaysMs: [] }
+      );
+
+      const result = await billingService.deduct({ ...baseRequest, amountUsdc });
+
+      assert.equal(result.success, false);
+      assert.equal(result.alreadyProcessed, false);
+      assert.equal(result.usageEventId, '');
+      assert.ok(
+        result.error?.includes(expectedError),
+        `expected error to contain "${expectedError}", got "${result.error}"`
+      );
+    });
+  }
 });
 
 describe('BillingService.getByRequestId', () => {

--- a/src/services/billingService.test.ts
+++ b/src/services/billingService.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { MockSorobanBilling } from './billingService.js';
+
+describe('MockSorobanBilling.deductCredit — non-positive quantity rejection', () => {
+  test('rejects zero amount and leaves balance unchanged', async () => {
+    const billing = new MockSorobanBilling({ dev1: 100 });
+
+    const result = await billing.deductCredit('dev1', 0);
+
+    assert.equal(result.success, false);
+    assert.equal(billing.getBalance('dev1'), 100);
+  });
+
+  test('rejects negative amount and leaves balance unchanged', async () => {
+    const billing = new MockSorobanBilling({ dev1: 100 });
+
+    const result = await billing.deductCredit('dev1', -10);
+
+    assert.equal(result.success, false);
+    assert.equal(billing.getBalance('dev1'), 100);
+  });
+
+  test('negative amount does not increase balance (was a data-integrity bug)', async () => {
+    const billing = new MockSorobanBilling({ dev1: 50 });
+
+    await billing.deductCredit('dev1', -20);
+
+    // Balance must not have grown — a negative deduction is not a top-up
+    assert.equal(billing.getBalance('dev1'), 50);
+  });
+
+  test('returns current balance in the rejection result', async () => {
+    const billing = new MockSorobanBilling({ dev1: 75 });
+
+    const zeroResult = await billing.deductCredit('dev1', 0);
+    assert.equal(zeroResult.success, false);
+    assert.equal(zeroResult.balance, 75);
+
+    const negResult = await billing.deductCredit('dev1', -5);
+    assert.equal(negResult.success, false);
+    assert.equal(negResult.balance, 75);
+  });
+
+  test('rejects zero for a developer with zero balance', async () => {
+    const billing = new MockSorobanBilling({ dev1: 0 });
+
+    const result = await billing.deductCredit('dev1', 0);
+
+    assert.equal(result.success, false);
+    assert.equal(billing.getBalance('dev1'), 0);
+  });
+
+  test('rejects zero for an unknown developer (balance defaults to 0)', async () => {
+    const billing = new MockSorobanBilling();
+
+    const result = await billing.deductCredit('unknown', 0);
+
+    assert.equal(result.success, false);
+    assert.equal(result.balance, 0);
+  });
+
+  test('rejects negative fractional amount', async () => {
+    const billing = new MockSorobanBilling({ dev1: 100 });
+
+    const result = await billing.deductCredit('dev1', -0.001);
+
+    assert.equal(result.success, false);
+    assert.equal(billing.getBalance('dev1'), 100);
+  });
+});
+
+describe('MockSorobanBilling.deductCredit — valid positive amounts', () => {
+  test('succeeds and reduces balance when funds are sufficient', async () => {
+    const billing = new MockSorobanBilling({ dev1: 100 });
+
+    const result = await billing.deductCredit('dev1', 30);
+
+    assert.equal(result.success, true);
+    assert.equal(result.balance, 70);
+    assert.equal(billing.getBalance('dev1'), 70);
+  });
+
+  test('fails gracefully when funds are insufficient', async () => {
+    const billing = new MockSorobanBilling({ dev1: 5 });
+
+    const result = await billing.deductCredit('dev1', 10);
+
+    assert.equal(result.success, false);
+    assert.equal(result.balance, 5);
+    assert.equal(billing.getBalance('dev1'), 5);
+  });
+
+  test('allows deduction to exact zero balance', async () => {
+    const billing = new MockSorobanBilling({ dev1: 10 });
+
+    const result = await billing.deductCredit('dev1', 10);
+
+    assert.equal(result.success, true);
+    assert.equal(result.balance, 0);
+  });
+
+  test('subsequent rejection after valid deduction reports updated balance', async () => {
+    const billing = new MockSorobanBilling({ dev1: 50 });
+
+    await billing.deductCredit('dev1', 50); // drains to 0
+    const result = await billing.deductCredit('dev1', 0);
+
+    assert.equal(result.success, false);
+    assert.equal(result.balance, 0);
+  });
+});
+
+describe('MockSorobanBilling.checkBalance', () => {
+  test('returns 0 for unknown developers', async () => {
+    const billing = new MockSorobanBilling();
+    assert.equal(await billing.checkBalance('nobody'), 0);
+  });
+
+  test('reflects balance after successful deduction', async () => {
+    const billing = new MockSorobanBilling({ dev1: 80 });
+
+    await billing.deductCredit('dev1', 30);
+
+    assert.equal(await billing.checkBalance('dev1'), 50);
+  });
+
+  test('is unchanged after a rejected deduction', async () => {
+    const billing = new MockSorobanBilling({ dev1: 80 });
+
+    await billing.deductCredit('dev1', -10);
+    await billing.deductCredit('dev1', 0);
+
+    assert.equal(await billing.checkBalance('dev1'), 80);
+  });
+});

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -12,6 +12,10 @@ export class MockSorobanBilling implements BillingService {
   }
 
   async deductCredit(developerId: string, amount: number): Promise<BillingResult> {
+    if (amount <= 0) {
+      return { success: false, balance: this.balances.get(developerId) ?? 0 };
+    }
+
     const current = this.balances.get(developerId) ?? 0;
 
     if (current < amount) {


### PR DESCRIPTION
closes #219 

- Fix MockSorobanBilling.deductCredit to reject amount <= 0; previously a zero amount succeeded silently and a negative amount increased the developer balance (data-integrity bug)
- Extend billingInternals tests: cover all zero decimal forms (0.0, 0.0000000) and negative/malformed inputs (-0, -0.0, empty string, whitespace, NaN, Infinity)
- Add BillingService.deduct rejection tests: verify that zero/negative amountUsdc strings are caught by parseUsdcToContractUnits before any DB connection is opened or Soroban call is made
- Add billingService.test.ts covering MockSorobanBilling: zero and negative amounts rejected, balance unchanged after rejection, negative amount does not increase balance, valid positive deductions continue to work, checkBalance reflects state correctly

38 tests pass across 2 suites (billing.test.ts, billingService.test.ts)