### PR TITLE
chore(backend): include requestid in all error logs from errorhandler

### DIFF
--- a/src/middleware/errorHandler.test.ts
+++ b/src/middleware/errorHandler.test.ts
@@ -1,6 +1,15 @@
 import { Request, Response, NextFunction } from 'express';
 import { errorHandler, ErrorResponseBody } from '../middleware/errorHandler.js';
 import { AppError, BadRequestError, UnauthorizedError } from '../errors/index.js';
+import { logger } from '../logger.js';
+
+jest.mock('../logger.js', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
 
 describe('Error Handler', () => {
   let mockReq: Partial<Request>;
@@ -39,6 +48,11 @@ describe('Error Handler', () => {
       code: 'BAD_REQUEST',
       requestId: 'test-request-id'
     });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[errorHandler]',
+      expect.objectContaining({ requestId: 'test-request-id', statusCode: 400 })
+    );
   });
 
   it('should handle generic Error with default values', () => {
@@ -56,6 +70,11 @@ describe('Error Handler', () => {
       error: 'Generic error',
       requestId: 'test-request-id'
     });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[errorHandler]',
+      expect.objectContaining({ requestId: 'test-request-id', statusCode: 500 })
+    );
   });
 
   it('should handle unknown error type', () => {

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -40,9 +40,16 @@ export function errorHandler(
   }
 
   // Log full error server-side (including stack in dev)
+  const logData = {
+    requestId,
+    statusCode,
+    message,
+    ...(isProduction ? {} : { err }),
+  };
+
   if (isProduction) {
-    logger.error('[errorHandler]', statusCode, message, err instanceof Error ? err.stack : String(err));
+    logger.error('[errorHandler]', logData, err instanceof Error ? err.stack : String(err));
   } else {
-    logger.error('[errorHandler]', err);
+    logger.error('[errorHandler]', logData);
   }
 }

--- a/src/middleware/logging.test.ts
+++ b/src/middleware/logging.test.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import type { Request, Response } from 'express';
 
@@ -28,19 +27,17 @@ describe('structured logger options', () => {
       30,
     );
 
-    assert.deepEqual(method.mock.calls[0], [
-      {
-        headers: {
-          authorization: REDACTED_LOG_VALUE,
-          'x-api-key': REDACTED_LOG_VALUE,
-        },
-        password: REDACTED_LOG_VALUE,
-        nested: {
-          token: REDACTED_LOG_VALUE,
-          ok: true,
-        },
+    expect(method).toHaveBeenCalledWith({
+      headers: {
+        authorization: REDACTED_LOG_VALUE,
+        'x-api-key': REDACTED_LOG_VALUE,
       },
-    ]);
+      password: REDACTED_LOG_VALUE,
+      nested: {
+        token: REDACTED_LOG_VALUE,
+        ok: true,
+      },
+    });
   });
 });
 
@@ -72,19 +69,49 @@ describe('requestLogger', () => {
       requestLogger(req, res, next);
       res.emit('finish');
 
-      assert.equal(next.mock.calls.length, 1);
-      assert.deepEqual(res.setHeader.mock.calls[0], ['x-request-id', 'req-safe-1']);
-      assert.equal(infoSpy.mock.calls.length, 1);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.setHeader).toHaveBeenCalledWith('x-request-id', 'req-safe-1');
+      expect(infoSpy).toHaveBeenCalledTimes(1);
 
       const [payload, message] = infoSpy.mock.calls[0] as [Record<string, unknown>, string];
-      assert.equal(message, 'request completed');
-      assert.equal(payload.requestId, 'req-safe-1');
-      assert.equal(payload.method, 'POST');
-      assert.equal(payload.path, '/api/vault/deposit/prepare');
-      assert.equal(payload.statusCode, 200);
-      assert.equal(typeof payload.durationMs, 'number');
-      assert.equal('headers' in payload, false);
-      assert.equal('body' in payload, false);
+      expect(message).toBe('request completed');
+      expect(payload.requestId).toBe('req-safe-1');
+      expect(payload.method).toBe('POST');
+      expect(payload.path).toBe('/api/vault/deposit/prepare');
+      expect(payload.statusCode).toBe(200);
+      expect(typeof payload.durationMs).toBe('number');
+      expect('headers' in payload).toBe(false);
+      expect('body' in payload).toBe(false);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('honors req.id set by upstream middleware', () => {
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    try {
+      const req = {
+        id: 'req-from-id-property',
+        headers: {},
+        method: 'GET',
+        path: '/test',
+      } as unknown as Request;
+
+      const res = new EventEmitter() as EventEmitter &
+        Response & {
+          statusCode: number;
+          setHeader: jest.Mock;
+        };
+      res.statusCode = 200;
+      res.setHeader = jest.fn();
+
+      requestLogger(req, res, jest.fn());
+      res.emit('finish');
+
+      const [payload] = infoSpy.mock.calls[0] as [Record<string, unknown>, string];
+      expect(payload.requestId).toBe('req-from-id-property');
+      expect(res.setHeader).toHaveBeenCalledWith('x-request-id', 'req-from-id-property');
     } finally {
       infoSpy.mockRestore();
     }
@@ -111,10 +138,10 @@ describe('requestLogger', () => {
       requestLogger(req, res, jest.fn());
       res.emit('finish');
 
-      assert.equal(errorSpy.mock.calls.length, 1);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
       const [payload, message] = errorSpy.mock.calls[0] as [Record<string, unknown>, string];
-      assert.equal(message, 'request completed');
-      assert.equal(payload.statusCode, 503);
+      expect(message).toBe('request completed');
+      expect(payload.statusCode).toBe(503);
     } finally {
       errorSpy.mockRestore();
     }

--- a/src/middleware/logging.ts
+++ b/src/middleware/logging.ts
@@ -39,9 +39,11 @@ export const logger = pino(structuredLoggerOptions);
 
 export function requestLogger(req: Request, res: Response, next: NextFunction): void {
   const requestId =
+    req.id ||
     (Array.isArray(req.headers['x-request-id'])
       ? req.headers['x-request-id'][0]
-      : req.headers['x-request-id']) ?? uuidv4();
+      : req.headers['x-request-id']) ||
+    uuidv4();
 
   res.setHeader('x-request-id', requestId);
 


### PR DESCRIPTION
## Description
Implement the inclusion of `requestId` in all error logs from the `errorHandler` middleware. This change ensures that all errors are traceable to the specific request that triggered them. Additionally, refactored `requestLogger` to consistently use the same `requestId` established by upstream middleware.

Closes #233

## Security and Data-Integrity Assumptions
- **Security**: The `requestId` is treated as a non-sensitive trace identifier. It is included in log payloads but does not contain user-specific or sensitive business data. Existing redaction logic in the logger remains active for other fields.
- **Data Integrity**: By unifying the `requestId` across `requestLogger` and `errorHandler`, we ensure that the audit trail is consistent and reliable for troubleshooting.

## Test Results
Ran unit tests for the affected middleware:
```
PASS src/middleware/logging.test.ts
PASS src/middleware/errorHandler.test.ts
PASS src/middleware/requestId.test.ts

Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
```
All tests passed successfully, including new test cases for `requestId` logging and persistence.