### PR TITLE
chore(backend): ensure usage events are idempotent by requestId (serv…

### DIFF
--- a/src/repositories/usageEventsRepository.pg.ts
+++ b/src/repositories/usageEventsRepository.pg.ts
@@ -142,7 +142,7 @@ const appendDateFilters = (params: unknown[], clauses: string[], from?: Date, to
 };
 
 export class PgUsageEventsRepository implements UsageEventsPgRepository {
-  constructor(private readonly db: UsageEventsRepositoryQueryable) {}
+  constructor(private readonly db: UsageEventsRepositoryQueryable) { }
 
   async create(event: CreateUsageEventInput): Promise<BillingUsageEvent> {
     const userId = assertNonEmpty(event.userId, 'userId');
@@ -152,21 +152,32 @@ export class PgUsageEventsRepository implements UsageEventsPgRepository {
     const requestId = assertNonEmpty(event.requestId, 'requestId');
     const amount = assertAmount(event.amount).toString();
 
-    await this.db.query(
+    const result = await this.db.query<UsageEventRow>(
       `
-        INSERT INTO usage_events (
-          user_id,
-          api_id,
-          endpoint_id,
-          api_key_id,
-          amount_usdc,
-          request_id,
-          stellar_tx_hash,
-          created_at
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, NOW()))
-        ON CONFLICT (request_id) DO NOTHING
-      `,
+      INSERT INTO usage_events (
+        user_id,
+        api_id,
+        endpoint_id,
+        api_key_id,
+        amount_usdc,
+        request_id,
+        stellar_tx_hash,
+        created_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, NOW()))
+      ON CONFLICT (request_id)
+      DO UPDATE SET request_id = EXCLUDED.request_id
+      RETURNING
+        id,
+        user_id,
+        api_id,
+        endpoint_id,
+        api_key_id,
+        amount_usdc,
+        request_id,
+        stellar_tx_hash,
+        created_at
+    `,
       [
         userId,
         apiId,
@@ -179,30 +190,13 @@ export class PgUsageEventsRepository implements UsageEventsPgRepository {
       ],
     );
 
-    const existing = await this.db.query<UsageEventRow>(
-      `
-        SELECT
-          id,
-          user_id,
-          api_id,
-          endpoint_id,
-          api_key_id,
-          amount_usdc,
-          request_id,
-          stellar_tx_hash,
-          created_at
-        FROM usage_events
-        WHERE request_id = $1
-        LIMIT 1
-      `,
-      [requestId],
-    );
+    const row = result.rows[0];
 
-    if (!existing.rows[0]) {
-      throw new Error(`Usage event with requestId "${requestId}" could not be loaded after insert.`);
+    if (!row) {
+      throw new Error(`Failed to create or retrieve usage event for requestId "${requestId}".`);
     }
 
-    return mapUsageEventRow(existing.rows[0]);
+    return mapUsageEventRow(row);
   }
 
   async findByUserId(

--- a/src/repositories/usageEventsRepository.test.ts
+++ b/src/repositories/usageEventsRepository.test.ts
@@ -57,6 +57,88 @@ describe('InMemoryUsageEventsRepository – findByDeveloper', () => {
     assert.equal(results[0]?.id, 'e1');
   });
 
+  it('returns the same record when called multiple times with the same requestId', async () => {
+    const input = {
+      userId: 'user-1',
+      apiId: 'api-1',
+      endpointId: 'endpoint-1',
+      apiKeyId: 'key-1',
+      amount: 100n,
+      requestId: 'req-idempotent-1',
+    };
+
+    const first = await repo.create(input);
+    const second = await repo.create(input);
+
+    expect(second).toEqual(first);
+  });
+
+  it('does not create duplicate rows for the same requestId', async () => {
+    const input = {
+      userId: 'user-dup',
+      apiId: 'api-dup',
+      endpointId: 'endpoint-dup',
+      apiKeyId: 'key-dup',
+      amount: 50n,
+      requestId: 'req-idempotent-2',
+    };
+
+    await repo.create(input);
+    await repo.create(input);
+
+    const result = await db.query<{ count: string }>(
+      `SELECT COUNT(*)::text as count FROM usage_events WHERE request_id = $1`,
+      [input.requestId],
+    );
+
+    expect(Number(result.rows[0].count)).toBe(1);
+  });
+
+  it('returns the existing record even if subsequent payload differs for same requestId', async () => {
+    const requestId = 'req-idempotent-3';
+
+    const first = await repo.create({
+      userId: 'user-a',
+      apiId: 'api-a',
+      endpointId: 'endpoint-a',
+      apiKeyId: 'key-a',
+      amount: 10n,
+      requestId,
+    });
+
+    const second = await repo.create({
+      userId: 'user-b', // different
+      apiId: 'api-b',
+      endpointId: 'endpoint-b',
+      apiKeyId: 'key-b',
+      amount: 999n,
+      requestId,
+    });
+
+    // Should still return original row
+    expect(second.id).toBe(first.id);
+    expect(second.userId).toBe(first.userId);
+    expect(second.amount).toBe(first.amount);
+  });
+
+  it('creates a new usage event when requestId is unique', async () => {
+    const input = {
+      userId: 'user-new',
+      apiId: 'api-new',
+      endpointId: 'endpoint-new',
+      apiKeyId: 'key-new',
+      amount: 123n,
+      requestId: 'req-unique-1',
+    };
+
+    const result = await repo.create(input);
+
+    expect(result.id).toBeDefined();
+    expect(result.requestId).toBe(input.requestId);
+    expect(result.amount).toBe(123n);
+  });
+
+
   it('filters by optional apiId', async () => {
     const repo = new InMemoryUsageEventsRepository([
       makeEvent({ id: 'e1', apiId: 'api-weather' }),


### PR DESCRIPTION
Closes #226 

# Ensure Usage Events Are Idempotent by requestId (Server-Side)

## Summary

This PR enforces strict idempotency for usage event creation using `requestId`.

## Key Changes

- Replaced `ON CONFLICT DO NOTHING` with:
  ```sql
  ON CONFLICT (request_id) DO UPDATE ... RETURNING *