### PR TITLE
chore(backend): implement retry/backoff for transient horizon/soroban errors

### DIFF
--- a/src/lib/__tests__/retry.test.ts
+++ b/src/lib/__tests__/retry.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { withRetry, isTransientNetworkError, TransientError, RETRIABLE_HTTP_STATUSES } from '../retry.js';
+
+describe('RETRIABLE_HTTP_STATUSES', () => {
+  test('includes 429, 500, 502, 503, 504', () => {
+    expect(RETRIABLE_HTTP_STATUSES.has(429)).toBe(true);
+    expect(RETRIABLE_HTTP_STATUSES.has(500)).toBe(true);
+    expect(RETRIABLE_HTTP_STATUSES.has(502)).toBe(true);
+    expect(RETRIABLE_HTTP_STATUSES.has(503)).toBe(true);
+    expect(RETRIABLE_HTTP_STATUSES.has(504)).toBe(true);
+  });
+
+  test('excludes 400, 401, 403, 404', () => {
+    expect(RETRIABLE_HTTP_STATUSES.has(400)).toBe(false);
+    expect(RETRIABLE_HTTP_STATUSES.has(401)).toBe(false);
+    expect(RETRIABLE_HTTP_STATUSES.has(403)).toBe(false);
+    expect(RETRIABLE_HTTP_STATUSES.has(404)).toBe(false);
+  });
+});
+
+describe('isTransientNetworkError', () => {
+  test('returns true for TransientError', () => {
+    assert.equal(isTransientNetworkError(new TransientError('HTTP 503')), true);
+  });
+
+  test('returns false for AbortError (self-imposed timeout)', () => {
+    const abort = new DOMException('The operation was aborted', 'AbortError');
+    assert.equal(isTransientNetworkError(abort), false);
+  });
+
+  test('returns true for TypeError with econnrefused', () => {
+    assert.equal(isTransientNetworkError(new TypeError('connect ECONNREFUSED 127.0.0.1:8080')), true);
+  });
+
+  test('returns true for TypeError with fetch failed', () => {
+    assert.equal(isTransientNetworkError(new TypeError('fetch failed')), true);
+  });
+
+  test('returns true for TypeError with socket hang up', () => {
+    assert.equal(isTransientNetworkError(new TypeError('socket hang up')), true);
+  });
+
+  test('returns false for generic Error', () => {
+    assert.equal(isTransientNetworkError(new Error('something broke')), false);
+  });
+
+  test('returns false for non-Error values', () => {
+    assert.equal(isTransientNetworkError('network error'), false);
+    assert.equal(isTransientNetworkError(null), false);
+    assert.equal(isTransientNetworkError(undefined), false);
+  });
+});
+
+describe('withRetry', () => {
+  test('returns the result immediately on success', async () => {
+    const result = await withRetry(() => Promise.resolve(42));
+    assert.equal(result, 42);
+  });
+
+  test('retries on TransientError and returns result on second attempt', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new TransientError('HTTP 503'))
+      .mockResolvedValueOnce('ok');
+
+    const result = await withRetry(fn, { maxAttempts: 2, baseDelayMs: 0, jitter: false });
+    assert.equal(result, 'ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries on transient TypeError and returns result on second attempt', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce('recovered');
+
+    const result = await withRetry(fn, { maxAttempts: 2, baseDelayMs: 0, jitter: false });
+    assert.equal(result, 'recovered');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('does NOT retry on non-transient Error', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('bad input'));
+
+    await assert.rejects(
+      withRetry(fn, { maxAttempts: 4, baseDelayMs: 0, jitter: false }),
+      /bad input/
+    );
+    // Throws immediately — no retries
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT retry on AbortError', async () => {
+    const abort = new DOMException('aborted', 'AbortError');
+    const fn = jest.fn().mockRejectedValue(abort);
+
+    await assert.rejects(
+      withRetry(fn, { maxAttempts: 4, baseDelayMs: 0, jitter: false }),
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('exhausts all attempts and throws the last error', async () => {
+    const err = new TransientError('still down');
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await assert.rejects(
+      withRetry(fn, { maxAttempts: 3, baseDelayMs: 0, jitter: false }),
+      (thrown) => thrown === err
+    );
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test('respects custom shouldRetry predicate', async () => {
+    const sentinel = new Error('retryable-custom');
+    const fn = jest.fn()
+      .mockRejectedValueOnce(sentinel)
+      .mockResolvedValueOnce('custom-ok');
+
+    const result = await withRetry(fn, {
+      maxAttempts: 2,
+      baseDelayMs: 0,
+      jitter: false,
+      shouldRetry: (e) => e === sentinel,
+    });
+    assert.equal(result, 'custom-ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('applies exponential backoff between retries', async () => {
+    jest.useFakeTimers();
+
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new TransientError('a'))
+      .mockRejectedValueOnce(new TransientError('b'))
+      .mockResolvedValueOnce('done');
+
+    const promise = withRetry(fn, { maxAttempts: 3, baseDelayMs: 100, jitter: false });
+
+    // Advance through first delay (100ms) then second (200ms)
+    await jest.advanceTimersByTimeAsync(100);
+    await jest.advanceTimersByTimeAsync(200);
+
+    const result = await promise;
+    assert.equal(result, 'done');
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    jest.useRealTimers();
+  });
+});

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,0 +1,70 @@
+/** HTTP status codes that indicate a transient server-side condition worth retrying. */
+export const RETRIABLE_HTTP_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+const TRANSIENT_MESSAGE_FRAGMENTS = [
+  'econnrefused',
+  'econnreset',
+  'etimedout',
+  'enotfound',
+  'fetch failed',
+  'failed to fetch',
+  'socket hang up',
+  'und_err_connect_timeout',
+  'und_err_socket',
+];
+
+/** Signals a retriable HTTP-level failure from within a retry scope. */
+export class TransientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransientError';
+  }
+}
+
+/**
+ * Returns true for errors representing a transient network condition.
+ * AbortError (self-imposed request timeout) is NOT retriable — the server
+ * was already unresponsive; retrying immediately makes things worse.
+ */
+export function isTransientNetworkError(error: unknown): boolean {
+  if (error instanceof TransientError) return true;
+  if (error instanceof DOMException && error.name === 'AbortError') return false;
+  if (error instanceof TypeError) {
+    const msg = error.message.toLowerCase();
+    return TRANSIENT_MESSAGE_FRAGMENTS.some((f) => msg.includes(f));
+  }
+  return false;
+}
+
+export interface RetryOptions {
+  /** Total attempts including the first. Default: 4 (3 retries). */
+  maxAttempts?: number;
+  /** Initial delay in ms; doubles each retry. Default: 500. */
+  baseDelayMs?: number;
+  /** Upper bound on computed delay before jitter. Default: 10_000. */
+  maxDelayMs?: number;
+  /** Apply ±20% jitter to prevent thundering herd. Default: true. */
+  jitter?: boolean;
+  /** Override the transient-error predicate. Default: isTransientNetworkError. */
+  shouldRetry?: (error: unknown) => boolean;
+}
+
+export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 4;
+  const baseDelayMs = options.baseDelayMs ?? 500;
+  const maxDelayMs = options.maxDelayMs ?? 10_000;
+  const jitter = options.jitter ?? true;
+  const shouldRetry = options.shouldRetry ?? isTransientNetworkError;
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= maxAttempts - 1 || !shouldRetry(error)) throw error;
+      const exponential = baseDelayMs * 2 ** attempt;
+      const capped = Math.min(exponential, maxDelayMs);
+      const factor = jitter ? 0.8 + Math.random() * 0.4 : 1;
+      await new Promise<void>((resolve) => setTimeout(resolve, Math.round(capped * factor)));
+    }
+  }
+}

--- a/src/services/sorobanSettlement.test.ts
+++ b/src/services/sorobanSettlement.test.ts
@@ -138,6 +138,7 @@ describe('SorobanRpcSettlementClient', () => {
       rpcUrl: 'http://soroban-rpc.internal',
       contractId: 'contract_abc',
       fetchImpl,
+      maxRetries: 0,
     });
 
     const result = await client.distribute('G_DEVELOPER_ACCOUNT', 3);
@@ -148,9 +149,9 @@ describe('SorobanRpcSettlementClient', () => {
     });
   });
 
-  test('retries transient request failures when retry delays are configured', async () => {
+  test('retries on transient network TypeError and succeeds', async () => {
     const fetchImpl = jest.fn()
-      .mockRejectedValueOnce(new Error('temporary outage'))
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
       .mockResolvedValue({
         ok: true,
         status: 200,
@@ -161,7 +162,8 @@ describe('SorobanRpcSettlementClient', () => {
       rpcUrl: 'http://soroban-rpc.internal',
       contractId: 'contract_abc',
       fetchImpl: fetchImpl as unknown as typeof fetch,
-      retryDelaysMs: [0],
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
     });
 
     const result = await client.distribute('G_DEVELOPER_ACCOUNT', 7);
@@ -169,5 +171,132 @@ describe('SorobanRpcSettlementClient', () => {
     assert.equal(result.success, true);
     assert.equal(result.txHash, '0xretried');
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries on HTTP 503 and succeeds on second attempt', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { transactionHash: '0xafter503' } }),
+      });
+
+    const client = createSorobanRpcSettlementClient({
+      rpcUrl: 'http://soroban-rpc.internal',
+      contractId: 'contract_abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+    });
+
+    const result = await client.distribute('G_DEVELOPER_ACCOUNT', 2);
+
+    assert.equal(result.success, true);
+    assert.equal(result.txHash, '0xafter503');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries on HTTP 429 and succeeds on second attempt', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { transactionHash: '0xafter429' } }),
+      });
+
+    const client = createSorobanRpcSettlementClient({
+      rpcUrl: 'http://soroban-rpc.internal',
+      contractId: 'contract_abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+    });
+
+    const result = await client.distribute('G_DEVELOPER_ACCOUNT', 2);
+
+    assert.equal(result.success, true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not retry HTTP 400 client errors', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 400 });
+
+    const client = createSorobanRpcSettlementClient({
+      rpcUrl: 'http://soroban-rpc.internal',
+      contractId: 'contract_abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      maxRetries: 3,
+      retryBaseDelayMs: 0,
+    });
+
+    const result = await client.distribute('G_DEVELOPER_ACCOUNT', 2);
+
+    assert.equal(result.success, false);
+    assert.match(result.error ?? '', /HTTP 400/);
+    // 400 is not in RETRIABLE_HTTP_STATUSES — single attempt only
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not retry on AbortError (self-imposed timeout)', async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(
+      Object.assign(new DOMException('The operation was aborted', 'AbortError'))
+    );
+
+    const client = createSorobanRpcSettlementClient({
+      rpcUrl: 'http://soroban-rpc.internal',
+      contractId: 'contract_abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      maxRetries: 3,
+      retryBaseDelayMs: 0,
+    });
+
+    const result = await client.distribute('G_DEVELOPER_ACCOUNT', 2);
+
+    assert.equal(result.success, false);
+    // AbortError must never trigger retries
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('exhausts retries and returns failure after all 5xx attempts fail', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+    const client = createSorobanRpcSettlementClient({
+      rpcUrl: 'http://soroban-rpc.internal',
+      contractId: 'contract_abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      maxRetries: 2,
+      retryBaseDelayMs: 0,
+    });
+
+    const result = await client.distribute('G_DEVELOPER_ACCOUNT', 2);
+
+    assert.equal(result.success, false);
+    // 3 total attempts (1 initial + 2 retries)
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  test('does not retry simulation body errors — they are deterministic', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ result: { error: { message: 'insufficient balance' } } }),
+    });
+
+    const client = createSorobanRpcSettlementClient({
+      rpcUrl: 'http://soroban-rpc.internal',
+      contractId: 'contract_abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      maxRetries: 3,
+      retryBaseDelayMs: 0,
+    });
+
+    const result = await client.distribute('G_DEVELOPER_ACCOUNT', 2);
+
+    assert.equal(result.success, false);
+    assert.match(result.error ?? '', /insufficient balance/);
+    // Simulation errors are returned by the server (200 OK) — no retry
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/sorobanSettlement.ts
+++ b/src/services/sorobanSettlement.ts
@@ -1,4 +1,11 @@
 import { config, type StellarNetwork } from '../config/index.js';
+import {
+  withRetry,
+  TransientError,
+  RETRIABLE_HTTP_STATUSES,
+  isTransientNetworkError,
+  type RetryOptions,
+} from '../lib/retry.js';
 
 export interface PayoutResult {
   success: boolean;
@@ -34,7 +41,10 @@ export interface SorobanRpcSettlementClientOptions {
   network?: StellarNetwork;
   fetchImpl?: typeof fetch;
   requestTimeoutMs?: number;
-  retryDelaysMs?: number[];
+  /** Maximum number of retries after the first attempt. Default: 3. */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff. Default: 500. */
+  retryBaseDelayMs?: number;
   requestIdFactory?: () => string;
   sourceAccount?: string;
   networkPassphrase?: string;
@@ -47,6 +57,8 @@ export interface SorobanSettlementClient {
 
 const USDC_STROOPS_MULTIPLIER = 10_000_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_BASE_DELAY_MS = 500;
 
 interface ResolvedSorobanRpcSettlementClientOptions
   extends Omit<SorobanRpcSettlementClientOptions, 'rpcUrl' | 'contractId' | 'networkPassphrase'> {
@@ -202,13 +214,22 @@ export class SorobanRpcSettlementClient implements SorobanSettlementClient {
       },
     };
 
+    const retryOptions: RetryOptions = {
+      maxAttempts: (this.options.maxRetries ?? DEFAULT_MAX_RETRIES) + 1,
+      baseDelayMs: this.options.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS,
+      shouldRetry: isTransientNetworkError,
+    };
+
     try {
-      const response = await this.executeWithRetries(async () => {
+      const response = await withRetry(async () => {
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
+        const timeout = setTimeout(
+          () => controller.abort(),
+          this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+        );
 
         try {
-          return await this.fetchImpl(this.resolvedOptions.rpcUrl, {
+          const res = await this.fetchImpl(this.resolvedOptions.rpcUrl, {
             method: 'POST',
             headers: {
               'content-type': 'application/json',
@@ -216,10 +237,18 @@ export class SorobanRpcSettlementClient implements SorobanSettlementClient {
             body: JSON.stringify(requestBody),
             signal: controller.signal,
           });
+
+          // Throw inside the retry scope so transient HTTP errors are retried.
+          // Non-retriable 4xx responses fall through and are handled below.
+          if (RETRIABLE_HTTP_STATUSES.has(res.status)) {
+            throw new TransientError(`Soroban RPC transient error: HTTP ${res.status}`);
+          }
+
+          return res;
         } finally {
           clearTimeout(timeout);
         }
-      });
+      }, retryOptions);
 
       if (!response.ok) {
         return {
@@ -252,26 +281,6 @@ export class SorobanRpcSettlementClient implements SorobanSettlementClient {
         error: `Soroban RPC request failed: ${normalizeSorobanError(error, 'Request failed')}`,
       };
     }
-  }
-
-  private async executeWithRetries<T>(request: () => Promise<T>): Promise<T> {
-    const retryDelays = this.options.retryDelaysMs ?? [];
-
-    let lastError: unknown;
-    for (let attempt = 0; attempt <= retryDelays.length; attempt++) {
-      try {
-        return await request();
-      } catch (error) {
-        lastError = error;
-        if (attempt === retryDelays.length) {
-          break;
-        }
-
-        await new Promise((resolve) => setTimeout(resolve, retryDelays[attempt]));
-      }
-    }
-
-    throw lastError;
   }
 
   private getSimulationError(payload: Record<string, unknown>): unknown {

--- a/src/services/transactionBuilder.test.ts
+++ b/src/services/transactionBuilder.test.ts
@@ -274,7 +274,8 @@ describe('TransactionBuilderService', () => {
   });
 
   test('maps Horizon transport failures to NetworkError', async () => {
-    const service = new TransactionBuilderService();
+    // mockRejectedValue (not Once) so all retry attempts fail
+    const service = new TransactionBuilderService({ maxRetries: 0 });
     mockLoadAccount.mockRejectedValueOnce(new Error('connect ETIMEDOUT'));
 
     await assert.rejects(
@@ -286,6 +287,38 @@ describe('TransactionBuilderService', () => {
       }),
       NetworkError
     );
+  });
+
+  test('retries transient Horizon errors and succeeds on second attempt', async () => {
+    const service = new TransactionBuilderService({ maxRetries: 1, retryBaseDelayMs: 0 });
+    mockLoadAccount
+      .mockRejectedValueOnce(new Error('connect ETIMEDOUT'))
+      .mockResolvedValueOnce({ accountId: 'GSOURCEACCOUNT123', sequence: '1' });
+
+    const result = await service.buildDepositTransaction({
+      userPublicKey: 'GUSERPUBLICKEY123',
+      vaultContractId: 'CVAULTTEST',
+      amountUsdc: '1.0000000',
+    });
+
+    assert.equal(result.network, 'testnet');
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not retry Horizon 404 account-not-found errors', async () => {
+    const service = new TransactionBuilderService({ maxRetries: 3, retryBaseDelayMs: 0 });
+    mockLoadAccount.mockRejectedValue(new Error('404 Resource Missing'));
+
+    await assert.rejects(
+      service.buildDepositTransaction({
+        userPublicKey: 'GUSERPUBLICKEY123',
+        vaultContractId: 'CVAULTTEST',
+        amountUsdc: '1.0000000',
+      }),
+      SourceAccountNotFoundError
+    );
+    // 404 is permanent — single attempt only
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
   });
 
   test('maps transaction builder failures to TransactionBuildError', async () => {

--- a/src/services/transactionBuilder.ts
+++ b/src/services/transactionBuilder.ts
@@ -7,6 +7,7 @@ import {
   nativeToScVal,
 } from '@stellar/stellar-sdk';
 import { config } from '../config/index.js';
+import { withRetry } from '../lib/retry.js';
 
 export type StellarNetwork = 'testnet' | 'mainnet';
 
@@ -107,6 +108,23 @@ export interface TransactionBuilderServiceOptions {
   createServer?: (horizonUrl: string) => HorizonAccountLoader;
   baseFee?: string | number;
   timeoutSeconds?: number;
+  /** Maximum number of retries for transient Horizon errors. Default: 3. */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff. Default: 500. */
+  retryBaseDelayMs?: number;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_BASE_DELAY_MS = 500;
+
+/**
+ * Returns true for errors that represent a transient Horizon failure worth retrying.
+ * 404 / account-not-found is a permanent state — retrying won't help.
+ */
+function isHorizonTransientError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') return false;
+  const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return !msg.includes('404') && !msg.includes('not found') && !msg.includes('resource missing');
 }
 
 export class TransactionBuilderService {
@@ -153,7 +171,14 @@ export class TransactionBuilderService {
     let sourceAccount: unknown;
 
     try {
-      sourceAccount = await server.loadAccount(sourceKey);
+      sourceAccount = await withRetry(
+        () => server.loadAccount(sourceKey),
+        {
+          maxAttempts: (this.options.maxRetries ?? DEFAULT_MAX_RETRIES) + 1,
+          baseDelayMs: this.options.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS,
+          shouldRetry: isHorizonTransientError,
+        }
+      );
     } catch (error) {
       throw this.mapLoadAccountError(sourceKey, error);
     }


### PR DESCRIPTION
Implemented chore(backend): implement retry/backoff for transient horizon/soroban errors

Closes: #235 