### PR TITLE
Feature/api error shape

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -266,8 +266,9 @@ test('GET /api/developers/analytics returns 401 when unauthenticated', async () 
   const app = createApp({ usageEventsRepository: seedRepository() });
   const response = await request(app).get('/api/developers/analytics');
   expect(response.status).toBe(401);
-  expect(typeof response.body.error).toBe('string');
+  expect(typeof response.body.message).toBe('string');
   expect(response.body.code).toBe('UNAUTHORIZED');
+  expect(response.body.requestId).toBeTruthy();
 });
 
 test('GET /api/developers/analytics validates query params', async () => {
@@ -290,7 +291,7 @@ test('GET /api/developers/analytics returns 400 when from > to', async () => {
     .get('/api/developers/analytics?from=2026-02-10&to=2026-02-01')
     .set('x-user-id', 'dev-1');
   expect(response.status).toBe(400);
-  expect(response.body.error).toMatch(/from must be before or equal to to/);
+  expect(response.body.message).toMatch(/from must be before or equal to to/);
 });
 
 test('GET /api/developers/analytics aggregates by month', async () => {
@@ -553,7 +554,7 @@ test('GET /api/apis/:id returns 400 for non-integer id', async () => {
 
   const resAlpha = await request(app).get('/api/apis/abc');
   assert.equal(resAlpha.status, 400);
-  assert.equal(typeof resAlpha.body.error, 'string');
+  assert.equal(typeof resAlpha.body.message, 'string');
 
   const resFloat = await request(app).get('/api/apis/1.5');
   assert.equal(resFloat.status, 400);
@@ -569,7 +570,7 @@ test('GET /api/apis/:id returns 404 when api not found', async () => {
   const app = createApp({ apiRepository: buildApiRepo() });
   const res = await request(app).get('/api/apis/999');
   assert.equal(res.status, 404);
-  assert.equal(typeof res.body.error, 'string');
+  assert.equal(typeof res.body.message, 'string');
 });
 
 test('GET /api/apis/:id returns full API details with endpoints', async () => {
@@ -698,7 +699,7 @@ test('POST /api/developers/apis returns 400 when name is missing', async () => {
     .set('x-user-id', 'dev-1')
     .send(body);
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /name/i);
+  assert.match(res.body.message, /name/i);
 });
 
 test('POST /api/developers/apis returns 400 when base_url is missing', async () => {
@@ -710,7 +711,7 @@ test('POST /api/developers/apis returns 400 when base_url is missing', async () 
     .set('x-user-id', 'dev-1')
     .send(body);
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /base_url/i);
+  assert.match(res.body.message, /base_url/i);
 });
 
 test('POST /api/developers/apis returns 400 when base_url is not a valid URL', async () => {
@@ -720,7 +721,7 @@ test('POST /api/developers/apis returns 400 when base_url is not a valid URL', a
     .set('x-user-id', 'dev-1')
     .send({ ...validApiBody, base_url: 'not-a-url' });
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /base_url/i);
+  assert.match(res.body.message, /base_url/i);
 });
 
 test('POST /api/developers/apis returns 400 when status is invalid', async () => {
@@ -730,7 +731,7 @@ test('POST /api/developers/apis returns 400 when status is invalid', async () =>
     .set('x-user-id', 'dev-1')
     .send({ ...validApiBody, status: 'published' });
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /status/i);
+  assert.match(res.body.message, /status/i);
 });
 
 test('POST /api/developers/apis returns 400 when endpoints is not an array', async () => {
@@ -740,7 +741,7 @@ test('POST /api/developers/apis returns 400 when endpoints is not an array', asy
     .set('x-user-id', 'dev-1')
     .send({ ...validApiBody, endpoints: 'bad' });
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /endpoints/i);
+  assert.match(res.body.message, /endpoints/i);
 });
 
 test('POST /api/developers/apis returns 400 when an endpoint path does not start with /', async () => {
@@ -753,7 +754,7 @@ test('POST /api/developers/apis returns 400 when an endpoint path does not start
       endpoints: [{ path: 'no-slash', method: 'GET', price_per_call_usdc: '0.01' }],
     });
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /path/i);
+  assert.match(res.body.message, /path/i);
 });
 
 test('POST /api/developers/apis returns 400 when an endpoint method is invalid', async () => {
@@ -766,7 +767,7 @@ test('POST /api/developers/apis returns 400 when an endpoint method is invalid',
       endpoints: [{ path: '/data', method: 'FETCH', price_per_call_usdc: '0.01' }],
     });
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /method/i);
+  assert.match(res.body.message, /method/i);
 });
 
 test('POST /api/developers/apis returns 400 when price_per_call_usdc is invalid', async () => {
@@ -779,7 +780,7 @@ test('POST /api/developers/apis returns 400 when price_per_call_usdc is invalid'
       endpoints: [{ path: '/data', method: 'GET', price_per_call_usdc: 'free' }],
     });
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /price_per_call_usdc/i);
+  assert.match(res.body.message, /price_per_call_usdc/i);
 });
 
 test('POST /api/developers/apis returns 400 when price_per_call_usdc is negative', async () => {
@@ -792,7 +793,7 @@ test('POST /api/developers/apis returns 400 when price_per_call_usdc is negative
       endpoints: [{ path: '/data', method: 'GET', price_per_call_usdc: '-0.01' }],
     });
   assert.equal(res.status, 400);
-  assert.match(res.body.error, /price_per_call_usdc/i);
+  assert.match(res.body.message, /price_per_call_usdc/i);
 });
 
 test('POST /api/developers/apis returns 400 with DEVELOPER_NOT_FOUND when no developer profile', async () => {
@@ -959,9 +960,10 @@ describe('Global middleware behavior', () => {
     const res = await request(app).get('/api/developers/analytics');
     
     assert.equal(res.status, 401);
-    assert.ok(res.body.error);
-    assert.equal(typeof res.body.error, 'string');
+    assert.ok(res.body.message);
+    assert.equal(typeof res.body.message, 'string');
     assert.equal(res.body.code, 'UNAUTHORIZED');
+    assert.ok(res.body.requestId);
   });
 
   test('JSON body parser is configured', async () => {
@@ -1007,8 +1009,8 @@ describe('Route precedence and ordering', () => {
       .set('x-user-id', 'dev-1');
 
     assert.equal(res.status, 400);
-    assert.ok(res.body.error);
-    assert.equal(typeof res.body.error, 'string');
+    assert.ok(res.body.message);
+    assert.equal(typeof res.body.message, 'string');
   });
 });
 
@@ -1040,7 +1042,7 @@ describe('body size limits (REQUEST_BODY_LIMIT)', () => {
 
     assert.equal(res.status, 413);
     assert.ok(res.headers['content-type']?.includes('application/json'));
-    assert.equal(res.body.error, 'Request body too large');
+    assert.equal(res.body.message, 'Request body too large');
   });
 
   test('accepts JSON bodies within the configured limit', async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,7 +35,13 @@ import { TransactionBuilderService } from './services/transactionBuilder.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { requestLogger } from './middleware/logging.js';
 import { metricsMiddleware, metricsEndpoint } from './metrics.js';
-import { BadRequestError } from './errors/index.js';
+import {
+  BadRequestError,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+  UnauthorizedError,
+} from './errors/index.js';
 import { apiKeyRepository } from './repositories/apiKeyRepository.js';
 
 interface AppDependencies {
@@ -296,19 +302,19 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
    *   ]
    * }
    */
-  app.get('/api/apis/:id', async (req, res) => {
+  app.get('/api/apis/:id', async (req, res, next) => {
     const rawId = req.params.id;
     const id = Number(rawId);
 
     if (!Number.isInteger(id) || id <= 0) {
-      res.status(400).json({ error: 'id must be a positive integer' });
+      next(new BadRequestError('id must be a positive integer'));
       return;
     }
 
     const apiRepo = await getApiRepo();
     const api = await apiRepo.findById(id);
     if (!api) {
-      res.status(404).json({ error: 'API not found or not active' });
+      next(new NotFoundError('API not found or not active'));
       return;
     }
 
@@ -332,10 +338,10 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     });
   });
 
-  app.get('/api/usage', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>) => {
+  app.get('/api/usage', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {
   const user = res.locals.authenticatedUser;
   if (!user) {
-    res.status(401).json({ error: 'Unauthorized' });
+    next(new UnauthorizedError());
     return;
   }
 
@@ -362,7 +368,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
   }
   
   if (queryFrom > queryTo) {
-    res.status(400).json({ error: 'from must be before or equal to to' });
+    next(new BadRequestError('from must be before or equal to to'));
     return;
   }
 
@@ -416,20 +422,20 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     res.json(response);
   } catch (error) {
     console.error('Error fetching user usage:', error);
-    res.status(500).json({ error: 'Internal server error' });
+    next(new InternalServerError());
   }
 });
 
-  app.get('/api/developers/apis', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>) => {
+  app.get('/api/developers/apis', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {
     const user = res.locals.authenticatedUser;
     if (!user) {
-      res.status(401).json({ error: 'Unauthorized' });
+      next(new UnauthorizedError());
       return;
     }
 
     const developer = await developerRepository.findByUserId(user.id);
     if (!developer) {
-      res.status(404).json({ error: 'Developer profile not found' });
+      next(new NotFoundError('Developer profile not found'));
       return;
     }
 
@@ -437,9 +443,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     let statusFilter: ApiStatus | undefined;
     if (statusParam) {
       if (!apiStatusEnum.includes(statusParam as ApiStatus)) {
-        res
-          .status(400)
-          .json({ error: `status must be one of: ${apiStatusEnum.join(', ')}` });
+        next(new BadRequestError(`status must be one of: ${apiStatusEnum.join(', ')}`));
         return;
       }
       statusFilter = statusParam as ApiStatus;
@@ -503,27 +507,27 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
    *   ]
    * }
    */
-  app.get('/api/developers/analytics', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>) => {
+  app.get('/api/developers/analytics', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {
     const user = res.locals.authenticatedUser;
     if (!user) {
-      res.status(401).json({ error: 'Unauthorized' });
+      next(new UnauthorizedError());
       return;
     }
 
     const groupBy = req.query.groupBy ?? 'day';
     if (typeof groupBy !== 'string' || !isValidGroupBy(groupBy)) {
-      res.status(400).json({ error: 'groupBy must be one of: day, week, month' });
+      next(new BadRequestError('groupBy must be one of: day, week, month'));
       return;
     }
 
     const from = parseDate(req.query.from);
     const to = parseDate(req.query.to);
     if (!from || !to) {
-      res.status(400).json({ error: 'from and to are required ISO date values' });
+      next(new BadRequestError('from and to are required ISO date values'));
       return;
     }
     if (from > to) {
-      res.status(400).json({ error: 'from must be before or equal to to' });
+      next(new BadRequestError('from must be before or equal to to'));
       return;
     }
 
@@ -531,7 +535,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     if (apiId) {
       const ownsApi = await usageEventsRepository.developerOwnsApi(user.id, apiId);
       if (!ownsApi) {
-        res.status(403).json({ error: 'Forbidden: API does not belong to authenticated developer' });
+        next(new ForbiddenError('Forbidden: API does not belong to authenticated developer'));
         return;
       }
     }
@@ -559,10 +563,10 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
   });
 
   // Revoke API key endpoint
-  app.delete('/api/keys/:id', requireAuth, (req, res: express.Response<unknown, AuthenticatedLocals>) => {
+  app.delete('/api/keys/:id', requireAuth, (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {
     const user = res.locals.authenticatedUser;
     if (!user) {
-      res.status(401).json({ error: 'Unauthorized' });
+      next(new UnauthorizedError());
       return;
     }
 
@@ -570,7 +574,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     const result = apiKeyRepository.revoke(id, user.id);
 
     if (result === 'forbidden') {
-      res.status(403).json({ error: 'Forbidden' });
+      next(new ForbiddenError());
       return;
     }
 
@@ -629,7 +633,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     try {
       const user = res.locals.authenticatedUser;
       if (!user) {
-        next(new BadRequestError('Unauthorized'));
+        next(new UnauthorizedError());
         return;
       }
 

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -59,6 +59,34 @@ export class TooManyRequestsError extends AppError {
   }
 }
 
+export class ConflictError extends AppError {
+  constructor(message: string = 'Conflict', code?: string) {
+    super(message, 409, code ?? 'CONFLICT');
+    this.name = 'ConflictError';
+  }
+}
+
+export class InternalServerError extends AppError {
+  constructor(message: string = 'Internal server error', code?: string) {
+    super(message, 500, code ?? 'INTERNAL_SERVER_ERROR');
+    this.name = 'InternalServerError';
+  }
+}
+
+export class BadGatewayError extends AppError {
+  constructor(message: string = 'Bad Gateway', code?: string) {
+    super(message, 502, code ?? 'BAD_GATEWAY');
+    this.name = 'BadGatewayError';
+  }
+}
+
+export class ServiceUnavailableError extends AppError {
+  constructor(message: string = 'Service unavailable', code?: string) {
+    super(message, 503, code ?? 'SERVICE_UNAVAILABLE');
+    this.name = 'ServiceUnavailableError';
+  }
+}
+
 export class GatewayTimeoutError extends AppError {
   constructor(message: string = 'Gateway Timeout', code?: string) {
     super(message, 504, code ?? 'GATEWAY_TIMEOUT');

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import client from 'prom-client';
 import { performance } from 'node:perf_hooks';
+import { UnauthorizedError } from './errors/index.js';
 
 // Initialize the Prometheus Registry and collect default Node.js metrics (CPU, RAM, Event Loop)
 const register = new client.Registry();
@@ -217,14 +218,18 @@ export const metricsMiddleware = (req: Request, res: Response, next: NextFunctio
  * Security note: the endpoint is auth-gated in production to prevent
  * internal operational data from leaking to unauthenticated callers.
  */
-export const metricsEndpoint = async (req: Request, res: Response): Promise<void> => {
+export const metricsEndpoint = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
   const isProduction = process.env.NODE_ENV === 'production';
   const expectedKey = process.env.METRICS_API_KEY;
 
   if (isProduction && expectedKey) {
     const authHeader = req.headers.authorization;
     if (authHeader !== `Bearer ${expectedKey}`) {
-      res.status(401).json({ error: 'Unauthorized' });
+      next(new UnauthorizedError());
       return;
     }
   }

--- a/src/middleware/adminAuth.test.ts
+++ b/src/middleware/adminAuth.test.ts
@@ -13,10 +13,10 @@ function makeReq(headers: Record<string, string> = {}): Request {
 }
 
 function makeRes() {
-  const res = { status: jest.fn(), json: jest.fn() };
+  const res = { status: jest.fn(), json: jest.fn(), locals: {} as Record<string, unknown> };
   res.status.mockReturnValue(res);
   res.json.mockReturnValue(res);
-  return res as unknown as Response & { status: jest.Mock; json: jest.Mock };
+  return res as unknown as Response & { status: jest.Mock; json: jest.Mock; locals: Record<string, unknown> };
 }
 
 describe('adminAuth middleware — unit', () => {
@@ -46,24 +46,25 @@ describe('adminAuth middleware — unit', () => {
     it('returns 401 when the key does not match', () => {
       const res = makeRes();
       adminAuth(makeReq({ 'x-admin-api-key': 'wrong-key' }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized: admin access required' });
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({
+        statusCode: 401,
+        message: 'Unauthorized: admin access required',
+        code: 'UNAUTHORIZED',
+      }));
+      expect(res.status).not.toHaveBeenCalled();
     });
 
     it('returns 401 when ADMIN_API_KEY env var is unset and a key header is provided', () => {
       delete process.env.ADMIN_API_KEY;
       const res = makeRes();
       adminAuth(makeReq({ 'x-admin-api-key': 'any-key' }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
 
     it('skips the API key branch and falls through to 401 when header is an empty string', () => {
       const res = makeRes();
       adminAuth(makeReq({ 'x-admin-api-key': '' }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
   });
 
@@ -82,39 +83,34 @@ describe('adminAuth middleware — unit', () => {
       const token = jwt.sign({ role: 'developer', sub: 'user-1' }, TEST_JWT_SECRET, { expiresIn: '1h' });
       const res = makeRes();
       adminAuth(makeReq({ authorization: `Bearer ${token}` }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
 
     it('returns 401 when the JWT has no role claim', () => {
       const token = jwt.sign({ sub: 'user-1' }, TEST_JWT_SECRET, { expiresIn: '1h' });
       const res = makeRes();
       adminAuth(makeReq({ authorization: `Bearer ${token}` }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
 
     it('returns 401 for an expired JWT', () => {
       const token = jwt.sign({ role: 'admin', sub: 'admin-1' }, TEST_JWT_SECRET, { expiresIn: '-1s' });
       const res = makeRes();
       adminAuth(makeReq({ authorization: `Bearer ${token}` }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
 
     it('returns 401 when the JWT is signed with the wrong secret', () => {
       const token = jwt.sign({ role: 'admin', sub: 'admin-1' }, 'wrong-secret', { expiresIn: '1h' });
       const res = makeRes();
       adminAuth(makeReq({ authorization: `Bearer ${token}` }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
 
     it('returns 401 when the Bearer value is not a valid JWT', () => {
       const res = makeRes();
       adminAuth(makeReq({ authorization: 'Bearer not-a-real-jwt' }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
 
     it('returns 401 for the alg:none attack (unsigned token claiming admin role)', () => {
@@ -125,25 +121,26 @@ describe('adminAuth middleware — unit', () => {
       const token = `${header}.${body}.`;
       const res = makeRes();
       adminAuth(makeReq({ authorization: `Bearer ${token}` }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
 
     it('returns 401 when the Authorization header does not use the Bearer scheme', () => {
       const token = jwt.sign({ role: 'admin', sub: 'admin-1' }, TEST_JWT_SECRET, { expiresIn: '1h' });
       const res = makeRes();
       adminAuth(makeReq({ authorization: `Token ${token}` }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
 
     it('returns 500 when JWT_SECRET is not configured', () => {
       delete process.env.JWT_SECRET;
       const res = makeRes();
       adminAuth(makeReq({ authorization: 'Bearer some-token' }), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'JWT_SECRET not configured' });
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({
+        statusCode: 500,
+        message: 'JWT_SECRET not configured',
+        code: 'INTERNAL_SERVER_ERROR',
+      }));
+      expect(res.status).not.toHaveBeenCalled();
     });
   });
 
@@ -153,9 +150,10 @@ describe('adminAuth middleware — unit', () => {
     it('returns 401 when no credentials are provided', () => {
       const res = makeRes();
       adminAuth(makeReq({}), res, next);
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized: admin access required' });
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({
+        statusCode: 401,
+        message: 'Unauthorized: admin access required',
+      }));
     });
   });
 
@@ -180,8 +178,7 @@ describe('adminAuth middleware — unit', () => {
         res,
         next,
       );
-      expect(next).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
     });
   });
 });

--- a/src/middleware/adminAuth.ts
+++ b/src/middleware/adminAuth.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { InternalServerError, UnauthorizedError } from '../errors/index.js';
 
 interface AdminJwtPayload {
   role: string;
@@ -22,7 +23,7 @@ export function adminAuth(req: Request, res: Response, next: NextFunction): void
     const secret = process.env.JWT_SECRET;
 
     if (!secret) {
-      res.status(500).json({ error: 'JWT_SECRET not configured' });
+      next(new InternalServerError('JWT_SECRET not configured'));
       return;
     }
 
@@ -38,5 +39,5 @@ export function adminAuth(req: Request, res: Response, next: NextFunction): void
     }
   }
 
-  res.status(401).json({ error: 'Unauthorized: admin access required' });
+  next(new UnauthorizedError('Unauthorized: admin access required'));
 }

--- a/src/middleware/errorHandler.test.ts
+++ b/src/middleware/errorHandler.test.ts
@@ -53,8 +53,8 @@ describe('Error Handler', () => {
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.json).toHaveBeenCalledWith({
-      error: 'Test bad request',
       code: 'BAD_REQUEST',
+      message: 'Test bad request',
       requestId: 'test-request-id'
     });
 
@@ -76,7 +76,8 @@ describe('Error Handler', () => {
 
     expect(mockRes.status).toHaveBeenCalledWith(500);
     expect(mockRes.json).toHaveBeenCalledWith({
-      error: 'Generic error',
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Generic error',
       requestId: 'test-request-id'
     });
 
@@ -98,7 +99,8 @@ describe('Error Handler', () => {
 
     expect(mockRes.status).toHaveBeenCalledWith(500);
     expect(mockRes.json).toHaveBeenCalledWith({
-      error: 'Internal server error',
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Internal server error',
       requestId: 'test-request-id'
     });
   });
@@ -116,8 +118,8 @@ describe('Error Handler', () => {
     );
 
     expect(mockRes.json).toHaveBeenCalledWith({
-      error: 'Unauthorized',
       code: 'UNAUTHORIZED',
+      message: 'Unauthorized',
       requestId: 'unknown'
     });
   });
@@ -149,13 +151,12 @@ describe('Error Handler', () => {
 
     expect(mockRes.status).toHaveBeenCalledWith(422);
     expect(mockRes.json).toHaveBeenCalledWith({
-      error: 'Custom error',
+      message: 'Custom error',
       code: 'CUSTOM_CODE',
       requestId: 'test-request-id'
     });
   });
 
-<<<<<<< HEAD
   it('should include validation details for validation errors', () => {
     const error = new ValidationError([
       {
@@ -165,14 +166,22 @@ describe('Error Handler', () => {
       },
     ]);
 
-    errorHandler(
-=======
+    errorHandler(error, mockReq as Request, mockRes as Response<ErrorResponseBody>, mockNext);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Request validation failed',
+      code: 'VALIDATION_ERROR',
+      details: expect.any(Array)
+    }));
+  });
+
   it('should map ForbiddenError to 403', () => {
     const error = new ForbiddenError('Test forbidden');
     errorHandler(error, mockReq as Request, mockRes as Response<ErrorResponseBody>, mockNext);
     expect(mockRes.status).toHaveBeenCalledWith(403);
     expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
-      error: 'Test forbidden',
+      message: 'Test forbidden',
       code: 'FORBIDDEN'
     }));
   });
@@ -182,7 +191,7 @@ describe('Error Handler', () => {
     errorHandler(error, mockReq as Request, mockRes as Response<ErrorResponseBody>, mockNext);
     expect(mockRes.status).toHaveBeenCalledWith(404);
     expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
-      error: 'Test not found',
+      message: 'Test not found',
       code: 'NOT_FOUND'
     }));
   });
@@ -192,7 +201,7 @@ describe('Error Handler', () => {
     errorHandler(error, mockReq as Request, mockRes as Response<ErrorResponseBody>, mockNext);
     expect(mockRes.status).toHaveBeenCalledWith(402);
     expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
-      error: 'Test payment required',
+      message: 'Test payment required',
       code: 'PAYMENT_REQUIRED'
     }));
   });
@@ -202,7 +211,7 @@ describe('Error Handler', () => {
     errorHandler(error, mockReq as Request, mockRes as Response<ErrorResponseBody>, mockNext);
     expect(mockRes.status).toHaveBeenCalledWith(429);
     expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
-      error: 'Test too many requests',
+      message: 'Test too many requests',
       code: 'TOO_MANY_REQUESTS'
     }));
   });
@@ -249,7 +258,8 @@ describe('Error Handler - Production Environment', () => {
 
     expect(mockRes.status).toHaveBeenCalledWith(500);
     expect(mockRes.json).toHaveBeenCalledWith({
-      error: 'Internal server error',
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Internal server error',
       requestId: 'prod-request-id'
     });
   });
@@ -258,7 +268,6 @@ describe('Error Handler - Production Environment', () => {
     const error = new BadRequestError('User-facing validation error');
     
     productionErrorHandler(
->>>>>>> upstream/main
       error,
       mockReq as Request,
       mockRes as Response<ErrorResponseBody>,
@@ -267,22 +276,9 @@ describe('Error Handler - Production Environment', () => {
 
     expect(mockRes.status).toHaveBeenCalledWith(400);
     expect(mockRes.json).toHaveBeenCalledWith({
-<<<<<<< HEAD
-      error: 'Request validation failed',
-      code: 'VALIDATION_ERROR',
-      requestId: 'test-request-id',
-      details: [
-        {
-          field: 'body.endpoints[0].path',
-          message: 'Invalid input: expected string, received undefined',
-          code: 'INVALID_TYPE',
-        },
-      ],
-=======
-      error: 'User-facing validation error',
+      message: 'User-facing validation error',
       code: 'BAD_REQUEST',
       requestId: 'prod-request-id'
->>>>>>> upstream/main
     });
   });
 });

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -7,20 +7,57 @@ import { ValidationError } from './validate.js';
 const isProduction = process.env.NODE_ENV === 'production';
 
 /**
- * Standard JSON body for error responses: { error: string, code?: string, requestId: string }
+ * Standard JSON body for error responses: { code, message, requestId }
  */
 export interface ErrorResponseBody {
-  error: string;
-  code?: string;
+  message: string;
+  code: string;
   requestId: string;
   details?: ValidationErrorDetail[];
+}
+
+function deriveErrorCode(statusCode: number): string {
+  switch (statusCode) {
+    case 400:
+      return 'BAD_REQUEST';
+    case 401:
+      return 'UNAUTHORIZED';
+    case 402:
+      return 'PAYMENT_REQUIRED';
+    case 403:
+      return 'FORBIDDEN';
+    case 404:
+      return 'NOT_FOUND';
+    case 408:
+      return 'REQUEST_TIMEOUT';
+    case 409:
+      return 'CONFLICT';
+    case 413:
+      return 'REQUEST_BODY_TOO_LARGE';
+    case 415:
+      return 'UNSUPPORTED_MEDIA_TYPE';
+    case 422:
+      return 'UNPROCESSABLE_ENTITY';
+    case 429:
+      return 'TOO_MANY_REQUESTS';
+    case 500:
+      return 'INTERNAL_SERVER_ERROR';
+    case 502:
+      return 'BAD_GATEWAY';
+    case 503:
+      return 'SERVICE_UNAVAILABLE';
+    case 504:
+      return 'GATEWAY_TIMEOUT';
+    default:
+      return statusCode >= 500 ? 'INTERNAL_SERVER_ERROR' : 'BAD_REQUEST';
+  }
 }
 
 /**
  * Global error-handling middleware (4-arg form).
  * - Catches errors thrown in routes/services
  * - Maps known AppError subclasses to HTTP status codes
- * - Returns consistent JSON: { error, code?, requestId }
+ * - Returns consistent JSON: { code, message, requestId }
  * - Never sends stack traces to the client in production
  * - Logs full error server-side
  */
@@ -44,19 +81,18 @@ export function errorHandler(
         ? err.message
         : 'Internal server error';
 
-  const code = isAppError(err) ? err.code : undefined;
-  const requestId = (req as any).id || 'unknown';
+  const code = isAppError(err) ? (err.code ?? deriveErrorCode(statusCode)) : deriveErrorCode(statusCode);
+  const requestId = req.id || 'unknown';
 
   // Security: In production, mask the message for unexpected (non-AppError) errors
-  let finalMessage = message;
+  let finalMessage = rawMessage;
   const isKnownError = isAppError(err) || statusCode < 500;
   
   if (isProduction && !isKnownError) {
     finalMessage = 'Internal server error';
   }
 
-  const body: ErrorResponseBody = { error: finalMessage, requestId };
-  if (code) body.code = code;
+  const body: ErrorResponseBody = { code, message: finalMessage, requestId };
   if (err instanceof ValidationError) body.details = err.details;
 
   if (!res.headersSent) {
@@ -67,7 +103,7 @@ export function errorHandler(
   const logData = {
     requestId,
     statusCode,
-    message,
+    message: rawMessage,
     ...(isProduction ? {} : { err }),
   };
 

--- a/src/middleware/gatewayApiKeyAuth.test.ts
+++ b/src/middleware/gatewayApiKeyAuth.test.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import request from 'supertest';
 import { createHash } from 'node:crypto';
+import { errorHandler } from './errorHandler.js';
 import {
   API_KEY_PREFIX_LENGTH,
   createGatewayApiKeyAuthMiddleware,
@@ -70,6 +71,7 @@ describe('gatewayApiKeyAuth middleware', () => {
       },
     );
 
+    app.use(errorHandler);
     return app;
   }
 
@@ -132,7 +134,9 @@ describe('gatewayApiKeyAuth middleware', () => {
     const res = await request(app).get('/gateway/api_1');
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: missing API key');
+    expect(res.body.message).toBe('Unauthorized: missing API key');
+    expect(res.body.code).toBe('UNAUTHORIZED');
+    expect(res.body.requestId).toBeTruthy();
   });
 
   it('returns 401 when the Authorization header is malformed', async () => {
@@ -143,7 +147,7 @@ describe('gatewayApiKeyAuth middleware', () => {
       .set('Authorization', 'Basic abc123');
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: malformed Authorization header');
+    expect(res.body.message).toBe('Unauthorized: malformed Authorization header');
   });
 
   it('returns 401 when the prefix lookup misses', async () => {
@@ -154,7 +158,7 @@ describe('gatewayApiKeyAuth middleware', () => {
       .set('x-api-key', 'ck_live_unknown_key');
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: API key not found');
+    expect(res.body.message).toBe('Unauthorized: API key not found');
   });
 
   it('returns 401 when the hash does not match the prefix candidate', async () => {
@@ -175,7 +179,7 @@ describe('gatewayApiKeyAuth middleware', () => {
       .set('x-api-key', validApiKey);
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: invalid API key');
+    expect(res.body.message).toBe('Unauthorized: invalid API key');
   });
 
   it('returns 401 when the key has been revoked', async () => {
@@ -196,7 +200,8 @@ describe('gatewayApiKeyAuth middleware', () => {
       .set('x-api-key', validApiKey);
 
     expect(res.status).toBe(403);
-    expect(res.body.error).toBe('Unauthorized: API key has been revoked');
+    expect(res.body.message).toBe('Unauthorized: API key has been revoked');
+    expect(res.body.code).toBe('FORBIDDEN');
   });
 
   it('returns 401 when the key is for a different API', async () => {
@@ -217,7 +222,7 @@ describe('gatewayApiKeyAuth middleware', () => {
       .set('x-api-key', validApiKey);
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: API key does not grant access to this API');
+    expect(res.body.message).toBe('Unauthorized: API key does not grant access to this API');
   });
 
   it('returns 404 when the target API cannot be resolved', async () => {
@@ -230,6 +235,7 @@ describe('gatewayApiKeyAuth middleware', () => {
       .set('x-api-key', validApiKey);
 
     expect(res.status).toBe(404);
-    expect(res.body.error).toBe('Not Found: unknown API');
+    expect(res.body.message).toBe('Not Found: unknown API');
+    expect(res.body.code).toBe('NOT_FOUND');
   });
 });

--- a/src/middleware/gatewayApiKeyAuth.ts
+++ b/src/middleware/gatewayApiKeyAuth.ts
@@ -1,5 +1,6 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
-import type { Request, RequestHandler, Response } from 'express';
+import type { NextFunction, Request, RequestHandler } from 'express';
+import { ForbiddenError, NotFoundError, UnauthorizedError } from '../errors/index.js';
 
 export const API_KEY_PREFIX_LENGTH = 16;
 
@@ -42,8 +43,8 @@ export interface GatewayApiKeyAuthOptions<
   getApiKeyCandidates(prefix: string, req: Request): Promise<GatewayAuthCandidate<TUser, TVault>[]>;
   resolveApiContext(req: Request): Promise<GatewayResolvedContext<TApi, TEndpoint> | null> | GatewayResolvedContext<TApi, TEndpoint> | null;
   getApiId(api: TApi): string;
-  onUnauthorized?: (res: Response, message: string) => void;
-  onNotFound?: (res: Response, message: string) => void;
+  onUnauthorized?: (next: NextFunction, message: string) => void;
+  onNotFound?: (next: NextFunction, message: string) => void;
 }
 
 export interface ExtractedApiKey {
@@ -113,16 +114,16 @@ function matchesStoredHash(apiKey: string, storedHash: string): boolean {
   return candidates.some((candidate) => timingSafeStringEqual(candidate, storedHash));
 }
 
-function unauthorized(res: Response, message: string): void {
-  res.status(401).json({ error: message });
+function unauthorized(next: NextFunction, message: string): void {
+  next(new UnauthorizedError(message));
 }
 
-function notFound(res: Response, message: string): void {
-  res.status(404).json({ error: message });
+function notFound(next: NextFunction, message: string): void {
+  next(new NotFoundError(message));
 }
 
-function forbidden(res: Response, message: string): void {
-  res.status(403).json({ error: message });
+function forbidden(next: NextFunction, message: string): void {
+  next(new ForbiddenError(message));
 }
 
 export function extractApiKey(req: Request): ExtractedApiKey {
@@ -169,20 +170,20 @@ export function createGatewayApiKeyAuthMiddleware<
   return async (req, res, next) => {
     const extracted = extractApiKey(req);
     if (!extracted.apiKey) {
-      handleUnauthorized(res, extracted.error ?? 'Unauthorized: missing API key');
+      handleUnauthorized(next, extracted.error ?? 'Unauthorized: missing API key');
       return;
     }
 
     const resolvedContext = await options.resolveApiContext(req);
     if (!resolvedContext) {
-      handleNotFound(res, 'Not Found: unknown API');
+      handleNotFound(next, 'Not Found: unknown API');
       return;
     }
 
     const prefix = extracted.apiKey.slice(0, API_KEY_PREFIX_LENGTH);
     const candidates = await options.getApiKeyCandidates(prefix, req);
     if (candidates.length === 0) {
-      handleUnauthorized(res, 'Unauthorized: API key not found');
+      handleUnauthorized(next, 'Unauthorized: API key not found');
       return;
     }
 
@@ -195,22 +196,22 @@ export function createGatewayApiKeyAuthMiddleware<
     }
 
     if (!matchedCandidate) {
-      handleUnauthorized(res, 'Unauthorized: invalid API key');
+      handleUnauthorized(next, 'Unauthorized: invalid API key');
       return;
     }
 
     if (matchedCandidate.apiKeyRecord.revoked) {
-      handleForbidden(res, 'Unauthorized: API key has been revoked');
+      handleForbidden(next, 'Unauthorized: API key has been revoked');
       return;
     }
 
     if (!matchedCandidate.user || matchedCandidate.vault === undefined) {
-      handleUnauthorized(res, 'Unauthorized: API key context is incomplete');
+      handleUnauthorized(next, 'Unauthorized: API key context is incomplete');
       return;
     }
 
     if (String(matchedCandidate.apiKeyRecord.apiId) !== options.getApiId(resolvedContext.api)) {
-      handleUnauthorized(res, 'Unauthorized: API key does not grant access to this API');
+      handleUnauthorized(next, 'Unauthorized: API key does not grant access to this API');
       return;
     }
 

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -184,17 +184,11 @@ export class ValidationError extends BadRequestError {
  * @returns Express middleware function
  */
 export function validateWithDetails(schemas: ValidationSchemas) {
-  return (req: Request, res: Response, next: NextFunction): void => {
+  return (req: Request, _res: Response, next: NextFunction): void => {
     const errors = collectValidationErrors(schemas, req);
 
     if (errors.length > 0) {
-      const responseBody: ValidationErrorResponse = {
-        error: 'Request validation failed',
-        code: 'VALIDATION_ERROR',
-        details: errors
-      };
-      
-      res.status(400).json(responseBody);
+      next(new ValidationError(errors));
       return;
     }
 

--- a/src/repositories/usageEventsRepository.ts
+++ b/src/repositories/usageEventsRepository.ts
@@ -75,8 +75,6 @@ export class InMemoryUsageEventsRepository implements UsageEventsRepository {
       filtered = filtered.slice(query.offset);
     }
     if (typeof query.limit === 'number' && query.limit > 0) {
-    // Apply limit if specified (0 means return nothing, consistent with PgUsageEventsRepository)
-    if (query.limit !== undefined) {
       filtered = filtered.slice(0, query.limit);
     }
 

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -1,8 +1,14 @@
 import { Router } from 'express';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import type { Pool } from 'pg';
 
-import { BadRequestError } from '../errors/index.js';
+import {
+  BadRequestError,
+  InternalServerError,
+  NotFoundError,
+  PaymentRequiredError,
+  UnauthorizedError,
+} from '../errors/index.js';
 import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
 import { BillingService } from '../services/billing.js';
 import { createSorobanRpcBillingClient } from '../services/sorobanBilling.js';
@@ -29,12 +35,12 @@ router.post(
   async (
     req: Request,
     res: Response<unknown, AuthenticatedLocals>,
-    next
+    next: NextFunction
   ) => {
     try {
       const user = res.locals.authenticatedUser;
       if (!user) {
-        res.status(401).json({ error: 'Unauthorized' });
+        next(new UnauthorizedError());
         return;
       }
 
@@ -88,7 +94,7 @@ router.post(
 
       const pool = req.app.locals.dbPool as Pool | undefined;
       if (!pool) {
-        res.status(500).json({ error: 'Database not available' });
+        next(new InternalServerError('Database not available', 'DATABASE_NOT_AVAILABLE'));
         return;
       }
 
@@ -107,12 +113,12 @@ router.post(
 
       if (!result.success) {
         const message = result.error ?? 'Billing deduction failed';
-        const statusCode = message.toLowerCase().includes('insufficient balance') ? 402 : 500;
+        if (message.toLowerCase().includes('insufficient balance')) {
+          next(new PaymentRequiredError('Billing deduction failed', 'BILLING_DEDUCTION_FAILED'));
+          return;
+        }
 
-        res.status(statusCode).json({
-          error: 'Billing deduction failed',
-          details: message,
-        });
+        next(new InternalServerError('Billing deduction failed', 'BILLING_DEDUCTION_FAILED'));
         return;
       }
 
@@ -134,12 +140,12 @@ router.get(
   async (
     req: Request,
     res: Response<unknown, AuthenticatedLocals>,
-    next
+    next: NextFunction
   ) => {
     try {
       const user = res.locals.authenticatedUser;
       if (!user) {
-        res.status(401).json({ error: 'Unauthorized' });
+        next(new UnauthorizedError());
         return;
       }
 
@@ -151,7 +157,7 @@ router.get(
 
       const pool = req.app.locals.dbPool as Pool | undefined;
       if (!pool) {
-        res.status(500).json({ error: 'Database not available' });
+        next(new InternalServerError('Database not available', 'DATABASE_NOT_AVAILABLE'));
         return;
       }
 
@@ -159,10 +165,7 @@ router.get(
       const result = await billingService.getByRequestId(requestId.trim());
 
       if (!result) {
-        res.status(404).json({
-          error: 'Billing request not found',
-          requestId: requestId.trim(),
-        });
+        next(new NotFoundError('Billing request not found', 'BILLING_REQUEST_NOT_FOUND'));
         return;
       }
 

--- a/src/routes/gatewayRoutes.test.ts
+++ b/src/routes/gatewayRoutes.test.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { createGatewayRouter } from "./gatewayRoutes.js";
 import { createRateLimiter } from "../services/rateLimiter.js";
 import { errorHandler } from "../middleware/errorHandler.js";
+import { requestIdMiddleware } from "../middleware/requestId.js";
 
 describe("gateway route - rate limiting", () => {
   beforeEach(() => {
@@ -35,7 +36,9 @@ describe("gateway route - rate limiting", () => {
 
     const app = express();
     // The gateway router supplies its own body parser; no outer express.json() needed
+    app.use(requestIdMiddleware);
     app.use("/gateway", createGatewayRouter(deps));
+    app.use(errorHandler);
 
     const res = await request(app)
       .get(`/gateway/${apiId}`)
@@ -44,8 +47,8 @@ describe("gateway route - rate limiting", () => {
     expect(res.status).toBe(429);
     // Retry-After header is in seconds, rounded up
     expect(res.headers["retry-after"]).toBe(String(Math.ceil(windowMs / 1000)));
-    expect(res.body).toHaveProperty("error", "Too Many Requests");
-    expect(res.body).toHaveProperty("retryAfterMs", windowMs);
+    expect(res.body).toHaveProperty("code", "TOO_MANY_REQUESTS");
+    expect(res.body).toHaveProperty("message", "Too Many Requests");
     expect(res.body).toHaveProperty("requestId");
   });
 });
@@ -68,6 +71,7 @@ describe("gateway route - body size limits", () => {
 
     const app = express();
     // No outer express.json() — the gateway router enforces its own limit
+    app.use(requestIdMiddleware);
     app.use("/gateway", createGatewayRouter(deps));
     app.use(errorHandler);
     return { app, apiKey, apiId };
@@ -91,6 +95,7 @@ describe("gateway route - body size limits", () => {
     } as any;
 
     const app = express();
+    app.use(requestIdMiddleware);
     app.use("/gateway", createGatewayRouter(deps));
     app.use(errorHandler);
 
@@ -150,6 +155,7 @@ describe("gateway route - body size limits", () => {
     } as any;
 
     const app = express();
+    app.use(requestIdMiddleware);
     app.use("/gateway", createGatewayRouter(deps));
     app.use(errorHandler);
 
@@ -186,6 +192,7 @@ describe("gateway route - body size limits", () => {
 
     expect(res.status).toBe(413);
     expect(res.headers["content-type"]).toMatch(/application\/json/);
-    expect(res.body).toHaveProperty("error", "Request body too large");
+    expect(res.body).toHaveProperty("code", "REQUEST_BODY_TOO_LARGE");
+    expect(res.body).toHaveProperty("message", "Request body too large");
   });
 });

--- a/src/routes/gatewayRoutes.ts
+++ b/src/routes/gatewayRoutes.ts
@@ -5,7 +5,14 @@ import { startUpstreamTimer, type UpstreamOutcome } from '../metrics.js';
 import { validate } from '../middleware/validate.js';
 import type { GatewayDeps } from '../types/gateway.js';
 import { buildHopByHopSet } from '../lib/hopByHop.js';
-import { GatewayTimeoutError } from '../errors/index.js';
+import {
+  BadGatewayError,
+  ForbiddenError,
+  GatewayTimeoutError,
+  PaymentRequiredError,
+  TooManyRequestsError,
+  UnauthorizedError,
+} from '../errors/index.js';
 
 const CREDIT_COST_PER_CALL = 1;
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -36,27 +43,18 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
         const requestId = randomUUID();
 
         if (!apiKeyHeader) {
-          res.status(401).json({
-            error: 'Unauthorized: missing x-api-key header',
-            requestId,
-          });
+          next(new UnauthorizedError('Unauthorized: missing x-api-key header'));
           return;
         }
 
         const keyRecord = apiKeys.get(apiKeyHeader);
         if (!keyRecord || keyRecord.apiId !== req.params.apiId) {
-          res.status(401).json({
-            error: 'Unauthorized: invalid API key',
-            requestId,
-          });
+          next(new UnauthorizedError('Unauthorized: invalid API key'));
           return;
         }
 
         if (keyRecord.revoked) {
-          res.status(403).json({
-            error: 'Forbidden: API key has been revoked',
-            requestId,
-          });
+          next(new ForbiddenError('Forbidden: API key has been revoked'));
           return;
         }
 
@@ -64,11 +62,7 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
         if (!rateResult.allowed) {
           const retryAfterSec = Math.ceil((rateResult.retryAfterMs ?? 1000) / 1000);
           res.set('Retry-After', String(retryAfterSec));
-          res.status(429).json({
-            error: 'Too Many Requests',
-            retryAfterMs: rateResult.retryAfterMs,
-            requestId,
-          });
+          next(new TooManyRequestsError('Too Many Requests'));
           return;
         }
 
@@ -77,16 +71,16 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
           CREDIT_COST_PER_CALL,
         );
         if (!billingResult.success) {
-          res.status(402).json({
-            error: 'Payment Required: insufficient balance',
-            balance: billingResult.balance,
-            requestId,
-          });
+          next(new PaymentRequiredError('Payment Required: insufficient balance'));
           return;
         }
 
         let upstreamStatus = 502;
-        let upstreamBody = JSON.stringify({ error: 'Bad Gateway: upstream unreachable', requestId });
+        let upstreamBody = JSON.stringify({
+          code: 'BAD_GATEWAY',
+          message: 'Bad Gateway: upstream unreachable',
+          requestId,
+        });
         let upstreamContentType = 'application/json; charset=utf-8';
         let outcome: UpstreamOutcome = 'error';
         // Safe upstream response headers to forward (populated on success)
@@ -128,6 +122,8 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
             timer.stop(504, outcome);
             throw new GatewayTimeoutError('Upstream service timed out');
           }
+
+          throw new BadGatewayError('Bad Gateway: upstream unreachable');
         } finally {
           if (outcome !== 'timeout') {
             timer.stop(upstreamStatus, outcome);

--- a/src/routes/proxyRoutes.ts
+++ b/src/routes/proxyRoutes.ts
@@ -5,7 +5,13 @@ import { resolveEndpointPrice } from '../data/apiRegistry.js';
 import { startUpstreamTimer, type UpstreamOutcome } from '../metrics.js';
 import { createMapBackedGatewayApiKeyAuthMiddleware } from '../middleware/gatewayApiKeyAuth.js';
 import { buildHopByHopSet, STATIC_HOP_BY_HOP } from '../lib/hopByHop.js';
-import { GatewayTimeoutError } from '../errors/index.js';
+import {
+  BadGatewayError,
+  GatewayTimeoutError,
+  InternalServerError,
+  PaymentRequiredError,
+  TooManyRequestsError,
+} from '../errors/index.js';
 
 /**
  * Headers that must never be forwarded to the upstream server.
@@ -88,7 +94,12 @@ export function createProxyRouter(deps: ProxyDeps): Router {
       const keyRecord = req.apiKeyRecord as { id: string; userId: string; apiId: string } | undefined;
 
       if (!apiEntry || !endpoint || !apiKeyHeader || !keyRecord) {
-        res.status(500).json({ error: 'Gateway authentication context missing', requestId });
+        next(
+          new InternalServerError(
+            'Gateway authentication context missing',
+            'GATEWAY_AUTH_CONTEXT_MISSING',
+          ),
+        );
         return;
       }
 
@@ -97,22 +108,14 @@ export function createProxyRouter(deps: ProxyDeps): Router {
       if (!rateResult.allowed) {
         const retryAfterSec = Math.ceil((rateResult.retryAfterMs ?? 1000) / 1000);
         res.set('Retry-After', String(retryAfterSec));
-        res.status(429).json({
-          error: 'Too Many Requests',
-          retryAfterMs: rateResult.retryAfterMs,
-          requestId,
-        });
+        next(new TooManyRequestsError('Too Many Requests'));
         return;
       }
 
       // 4. Pre-proxy balance check (ensure they have funds, deduct later)
       const currentBalance = await billing.checkBalance(keyRecord.userId);
       if (currentBalance <= 0) {
-        res.status(402).json({
-          error: 'Payment Required: insufficient balance',
-          balance: currentBalance,
-          requestId,
-        });
+        next(new PaymentRequiredError('Payment Required: insufficient balance'));
         return;
       }
 
@@ -199,8 +202,7 @@ export function createProxyRouter(deps: ProxyDeps): Router {
           throw new GatewayTimeoutError('Upstream service timed out');
         } else {
           upstreamStatus = 502;
-          res.set('x-request-id', requestId);
-          res.status(502).json({ error: 'Bad Gateway: upstream unreachable', requestId });
+          throw new BadGatewayError('Bad Gateway: upstream unreachable');
         }
 
         timer.stop(upstreamStatus, outcome);

--- a/src/webhooks/webhook.routes.ts
+++ b/src/webhooks/webhook.routes.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import express from 'express';
 import { validateWebhookUrl, WebhookValidationError } from './webhook.validator.js';
 import { WebhookStore } from './webhook.store.js';
@@ -7,6 +7,7 @@ import {
   captureRawBody,
   verifyWebhookSignature,
 } from './webhook.signature.js';
+import { AppError, BadRequestError, NotFoundError } from '../errors/index.js';
 
 const router = Router();
 
@@ -17,54 +18,64 @@ const VALID_EVENTS: WebhookEventType[] = [
 ];
 
 // POST /api/webhooks — Register a webhook
-router.post('/', express.json(), async (req: Request, res: Response) => {
-  const { developerId, url, events, secret } = req.body;
-
-  if (!developerId || !url || !Array.isArray(events) || events.length === 0) {
-    return res.status(400).json({
-      error: 'developerId, url, and a non-empty events array are required.',
-    });
-  }
-
-  const invalidEvents = events.filter(
-    (e: string) => !VALID_EVENTS.includes(e as WebhookEventType)
-  );
-  if (invalidEvents.length > 0) {
-    return res.status(400).json({
-      error: `Invalid event types: ${invalidEvents.join(', ')}. Valid: ${VALID_EVENTS.join(', ')}`,
-    });
-  }
-
+router.post('/', express.json(), async (req: Request, res: Response, next: NextFunction) => {
   try {
-    await validateWebhookUrl(url);
-  } catch (err: unknown) {
-    if (err instanceof WebhookValidationError) {
-      return res.status(400).json({ error: err.message });
+    const { developerId, url, events, secret } = req.body;
+
+    if (!developerId || !url || !Array.isArray(events) || events.length === 0) {
+      throw new BadRequestError(
+        'developerId, url, and a non-empty events array are required.',
+        'INVALID_WEBHOOK_REGISTRATION'
+      );
     }
-    return res.status(500).json({ error: 'URL validation failed.' });
+
+    const invalidEvents = events.filter(
+      (e: string) => !VALID_EVENTS.includes(e as WebhookEventType)
+    );
+    if (invalidEvents.length > 0) {
+      throw new BadRequestError(
+        `Invalid event types: ${invalidEvents.join(', ')}. Valid: ${VALID_EVENTS.join(', ')}`,
+        'INVALID_WEBHOOK_EVENT_TYPES'
+      );
+    }
+
+    try {
+      await validateWebhookUrl(url);
+    } catch (err: unknown) {
+      if (err instanceof WebhookValidationError) {
+        throw new BadRequestError(err.message, 'INVALID_WEBHOOK_URL');
+      }
+
+      throw new AppError('URL validation failed.', 500, 'WEBHOOK_URL_VALIDATION_FAILED');
+    }
+
+    WebhookStore.register({
+      developerId,
+      url,
+      events: events as WebhookEventType[],
+      secret: secret ?? undefined,
+      createdAt: new Date(),
+    });
+
+    res.status(201).json({
+      message: 'Webhook registered successfully.',
+      developerId,
+      url,
+      events,
+    });
+  } catch (error) {
+    next(error);
   }
-
-  WebhookStore.register({
-    developerId,
-    url,
-    events: events as WebhookEventType[],
-    secret: secret ?? undefined,
-    createdAt: new Date(),
-  });
-
-  return res.status(201).json({
-    message: 'Webhook registered successfully.',
-    developerId,
-    url,
-    events,
-  });
 });
 
 // GET /api/webhooks/:developerId — Get webhook config
 router.get('/:developerId', (req: Request, res: Response) => {
   const config = WebhookStore.get(req.params.developerId);
   if (!config) {
-    return res.status(404).json({ error: 'No webhook registered for this developer.' });
+    throw new NotFoundError(
+      'No webhook registered for this developer.',
+      'WEBHOOK_NOT_FOUND'
+    );
   }
   // Never expose the secret
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -97,7 +108,11 @@ router.post(
   (req: Request & { webhookSecret?: string }, res: Response, next) => {
     const config = WebhookStore.get(req.params.developerId);
     if (!config) {
-      return res.status(404).json({ error: 'No webhook registered for this developer.' });
+      next(new NotFoundError(
+        'No webhook registered for this developer.',
+        'WEBHOOK_NOT_FOUND'
+      ));
+      return;
     }
     req.webhookSecret = config.secret;
     next();

--- a/src/webhooks/webhook.signature.test.ts
+++ b/src/webhooks/webhook.signature.test.ts
@@ -46,15 +46,29 @@ function makeRes(): Response & { _status: number; _body: unknown } {
     _status: 200,
     _body: undefined as unknown,
     status(code: number) {
-      this._status = code;
-      return this;
+      res._status = code;
+      return res;
     },
     json(body: unknown) {
-      this._body = body;
-      return this;
+      res._body = body;
+      return res;
     },
   } as unknown as Response & { _status: number; _body: unknown };
   return res;
+}
+
+function collectNextError(
+  callback: (next: NextFunction) => void
+): { nextCalled: boolean; error: unknown } {
+  let nextCalled = false;
+  let capturedError: unknown;
+
+  callback((error?: unknown) => {
+    nextCalled = true;
+    capturedError = error;
+  });
+
+  return { nextCalled, error: capturedError };
 }
 
 // ---------------------------------------------------------------------------
@@ -147,10 +161,10 @@ test('verifyWebhookSignature rejects when signature header is missing', () => {
     rawBody: Buffer.from('{}'),
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'UnauthorizedError');
+  assert.equal((error as { code?: string }).code, 'MISSING_WEBHOOK_SIGNATURE_HEADERS');
 });
 
 test('verifyWebhookSignature rejects when timestamp header is missing', () => {
@@ -160,10 +174,10 @@ test('verifyWebhookSignature rejects when timestamp header is missing', () => {
     rawBody: Buffer.from('{}'),
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'UnauthorizedError');
+  assert.equal((error as { code?: string }).code, 'MISSING_WEBHOOK_SIGNATURE_HEADERS');
 });
 
 test('verifyWebhookSignature rejects a non-ISO timestamp', () => {
@@ -176,10 +190,10 @@ test('verifyWebhookSignature rejects a non-ISO timestamp', () => {
     rawBody: Buffer.from('{}'),
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'BadRequestError');
+  assert.equal((error as { code?: string }).code, 'INVALID_WEBHOOK_TIMESTAMP');
 });
 
 test('verifyWebhookSignature rejects a stale timestamp (too old)', () => {
@@ -193,10 +207,10 @@ test('verifyWebhookSignature rejects a stale timestamp (too old)', () => {
     rawBody: Buffer.from('{}'),
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'UnauthorizedError');
+  assert.equal((error as { code?: string }).code, 'WEBHOOK_TIMESTAMP_OUT_OF_WINDOW');
 });
 
 test('verifyWebhookSignature rejects a future timestamp outside tolerance', () => {
@@ -210,10 +224,10 @@ test('verifyWebhookSignature rejects a future timestamp outside tolerance', () =
     rawBody: Buffer.from('{}'),
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'UnauthorizedError');
+  assert.equal((error as { code?: string }).code, 'WEBHOOK_TIMESTAMP_OUT_OF_WINDOW');
 });
 
 test('verifyWebhookSignature rejects a malformed signature header (no prefix)', () => {
@@ -227,10 +241,10 @@ test('verifyWebhookSignature rejects a malformed signature header (no prefix)', 
     rawBody: Buffer.from('{}'),
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'BadRequestError');
+  assert.equal((error as { code?: string }).code, 'MALFORMED_WEBHOOK_SIGNATURE');
 });
 
 test('verifyWebhookSignature rejects a wrong prefix (md5=…)', () => {
@@ -244,10 +258,10 @@ test('verifyWebhookSignature rejects a wrong prefix (md5=…)', () => {
     rawBody: Buffer.from('{}'),
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'BadRequestError');
+  assert.equal((error as { code?: string }).code, 'MALFORMED_WEBHOOK_SIGNATURE');
 });
 
 // ---------------------------------------------------------------------------
@@ -268,10 +282,10 @@ test('verifyWebhookSignature rejects when HMAC does not match', () => {
     rawBody: body,
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'UnauthorizedError');
+  assert.equal((error as { code?: string }).code, 'INVALID_WEBHOOK_SIGNATURE');
 });
 
 test('verifyWebhookSignature rejects when body has been tampered with', () => {
@@ -289,10 +303,10 @@ test('verifyWebhookSignature rejects when body has been tampered with', () => {
     rawBody: tamperedBody,
   });
   const res = makeRes();
-  let nextCalled = false;
-  verifyWebhookSignature(req, res, () => { nextCalled = true; });
-  assert.equal(nextCalled, false);
-  assert.equal(res._status, 401);
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'UnauthorizedError');
+  assert.equal((error as { code?: string }).code, 'INVALID_WEBHOOK_SIGNATURE');
 });
 
 // ---------------------------------------------------------------------------

--- a/src/webhooks/webhook.signature.ts
+++ b/src/webhooks/webhook.signature.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import type { Request, Response, NextFunction } from 'express';
+import { BadRequestError, UnauthorizedError } from '../errors/index.js';
 
 export const SIGNATURE_HEADER = 'x-callora-signature-256';
 export const TIMESTAMP_HEADER = 'x-callora-timestamp';
@@ -59,7 +60,7 @@ export function safeCompare(a: string, b: string): boolean {
  */
 export function verifyWebhookSignature(
   req: Request & { webhookSecret?: string; rawBody?: Buffer },
-  res: Response,
+  _res: Response,
   next: NextFunction
 ): void {
   const secret = req.webhookSecret;
@@ -73,30 +74,38 @@ export function verifyWebhookSignature(
   const tsHeader = req.headers[TIMESTAMP_HEADER] as string | undefined;
 
   if (!sigHeader || !tsHeader) {
-    res.status(401).json({
-      error: `Missing required headers: ${SIGNATURE_HEADER}, ${TIMESTAMP_HEADER}.`,
-    });
+    next(new UnauthorizedError(
+      `Missing required headers: ${SIGNATURE_HEADER}, ${TIMESTAMP_HEADER}.`,
+      'MISSING_WEBHOOK_SIGNATURE_HEADERS'
+    ));
     return;
   }
 
   // Validate timestamp format and staleness
   const deliveryTime = Date.parse(tsHeader);
   if (Number.isNaN(deliveryTime)) {
-    res.status(401).json({ error: 'Invalid timestamp format in x-callora-timestamp.' });
+    next(new BadRequestError(
+      'Invalid timestamp format in x-callora-timestamp.',
+      'INVALID_WEBHOOK_TIMESTAMP'
+    ));
     return;
   }
 
   if (Math.abs(Date.now() - deliveryTime) > SIGNATURE_TOLERANCE_MS) {
-    res.status(401).json({ error: 'Webhook timestamp is too old or too far in the future.' });
+    next(new UnauthorizedError(
+      'Webhook timestamp is too old or too far in the future.',
+      'WEBHOOK_TIMESTAMP_OUT_OF_WINDOW'
+    ));
     return;
   }
 
   // Extract hex digest from "sha256=<hex>"
   const parts = sigHeader.split('=');
   if (parts.length !== 2 || parts[0] !== 'sha256' || !parts[1]) {
-    res.status(401).json({
-      error: `Malformed ${SIGNATURE_HEADER} header. Expected format: sha256=<hex>.`,
-    });
+    next(new BadRequestError(
+      `Malformed ${SIGNATURE_HEADER} header. Expected format: sha256=<hex>.`,
+      'MALFORMED_WEBHOOK_SIGNATURE'
+    ));
     return;
   }
   const receivedHex = parts[1];
@@ -105,7 +114,10 @@ export function verifyWebhookSignature(
   const expectedHex = computeSignature(secret, tsHeader, rawBody);
 
   if (!safeCompare(expectedHex, receivedHex)) {
-    res.status(401).json({ error: 'Webhook signature verification failed.' });
+    next(new UnauthorizedError(
+      'Webhook signature verification failed.',
+      'INVALID_WEBHOOK_SIGNATURE'
+    ));
     return;
   }
 

--- a/tests/integration/adminAuth.test.ts
+++ b/tests/integration/adminAuth.test.ts
@@ -105,7 +105,8 @@ describe('adminAuth middleware on /api/admin routes', () => {
     const res = await request(app).get('/api/admin/users');
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: admin access required');
+    expect(res.body.message).toBe('Unauthorized: admin access required');
+    expect(res.body.code).toBe('UNAUTHORIZED');
   });
 
   it('rejects requests with a non-matching admin API key', async () => {
@@ -116,7 +117,7 @@ describe('adminAuth middleware on /api/admin routes', () => {
       .set('x-admin-api-key', 'wrong-key');
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: admin access required');
+    expect(res.body.message).toBe('Unauthorized: admin access required');
   });
 
   it('rejects JWT callers that are not admins', async () => {
@@ -128,7 +129,7 @@ describe('adminAuth middleware on /api/admin routes', () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: admin access required');
+    expect(res.body.message).toBe('Unauthorized: admin access required');
   });
 
   it('rejects expired JWT tokens', async () => {
@@ -140,7 +141,7 @@ describe('adminAuth middleware on /api/admin routes', () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: admin access required');
+    expect(res.body.message).toBe('Unauthorized: admin access required');
   });
 
   it('rejects JWT tokens signed with the wrong secret', async () => {
@@ -152,7 +153,7 @@ describe('adminAuth middleware on /api/admin routes', () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: admin access required');
+    expect(res.body.message).toBe('Unauthorized: admin access required');
   });
 
   it('rejects a malformed Bearer token (not a valid JWT)', async () => {
@@ -163,7 +164,7 @@ describe('adminAuth middleware on /api/admin routes', () => {
       .set('Authorization', 'Bearer not-a-real-jwt');
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Unauthorized: admin access required');
+    expect(res.body.message).toBe('Unauthorized: admin access required');
   });
 
   it('accepts valid admin API key credentials and logs audit event', async () => {
@@ -213,7 +214,8 @@ describe('adminAuth middleware on /api/admin routes', () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toBe('JWT_SECRET not configured');
+    expect(res.body.message).toBe('JWT_SECRET not configured');
+    expect(res.body.code).toBe('INTERNAL_SERVER_ERROR');
   });
 
   it('prefers valid API key path even when Bearer token is invalid', async () => {

--- a/tests/integration/billing-http.test.ts
+++ b/tests/integration/billing-http.test.ts
@@ -198,7 +198,8 @@ describe('Billing HTTP Endpoints - Integration Tests', () => {
           });
 
         assert.equal(response1.status, 400);
-        assert.ok(response1.body.error?.includes('requestId is required'));
+        assert.ok(response1.body.message?.includes('requestId is required'));
+        assert.equal(response1.body.code, 'BAD_REQUEST');
 
         // Test invalid amount
         const response2 = await request(app)
@@ -213,7 +214,7 @@ describe('Billing HTTP Endpoints - Integration Tests', () => {
           });
 
         assert.equal(response2.status, 400);
-        assert.ok(response2.body.error?.includes('amountUsdc must be a positive number'));
+        assert.ok(response2.body.message?.includes('amountUsdc must be a positive number'));
 
         // Test empty apiId
         const response3 = await request(app)
@@ -228,7 +229,7 @@ describe('Billing HTTP Endpoints - Integration Tests', () => {
           });
 
         assert.equal(response3.status, 400);
-        assert.ok(response3.body.error?.includes('apiId is required'));
+        assert.ok(response3.body.message?.includes('apiId is required'));
       } finally {
         await testDb.end();
       }
@@ -269,7 +270,8 @@ describe('Billing HTTP Endpoints - Integration Tests', () => {
           .send(requestBody);
 
         assert.equal(response1.status, 401);
-        assert.equal(response1.body.error, 'Unauthorized');
+        assert.equal(response1.body.message, 'Unauthorized');
+        assert.equal(response1.body.code, 'UNAUTHORIZED');
 
         // Invalid token
         const response2 = await request(app)
@@ -278,7 +280,8 @@ describe('Billing HTTP Endpoints - Integration Tests', () => {
           .send(requestBody);
 
         assert.equal(response2.status, 401);
-        assert.equal(response2.body.error, 'Unauthorized');
+        assert.equal(response2.body.message, 'Invalid token');
+        assert.equal(response2.body.code, 'INVALID_TOKEN');
       } finally {
         await testDb.end();
       }
@@ -428,8 +431,9 @@ describe('Billing HTTP Endpoints - Integration Tests', () => {
           .set(createAuthHeaders(token));
 
         assert.equal(response.status, 404);
-        assert.equal(response.body.error, 'Billing request not found');
-        assert.equal(response.body.requestId, 'req_nonexistent');
+        assert.equal(response.body.message, 'Billing request not found');
+        assert.equal(response.body.code, 'BILLING_REQUEST_NOT_FOUND');
+        assert.ok(response.body.requestId);
       } finally {
         await testDb.end();
       }
@@ -462,7 +466,7 @@ describe('Billing HTTP Endpoints - Integration Tests', () => {
           .send();
 
         assert.equal(response.status, 401);
-        assert.equal(response.body.error, 'Unauthorized');
+        assert.equal(response.body.message, 'Unauthorized');
       } finally {
         await testDb.end();
       }
@@ -634,7 +638,7 @@ describe('Billing HTTP Endpoints - Integration Tests', () => {
             });
 
           assert.equal(response.status, 400, `Expected 400 for amount: ${amount}`);
-          assert.ok(response.body.error?.includes('amountUsdc'), `Error should mention amountUsdc for: ${amount}`);
+          assert.ok(response.body.message?.includes('amountUsdc'), `Error should mention amountUsdc for: ${amount}`);
         }
       } finally {
         await testDb.end();

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -7,6 +7,8 @@ import { WebhookStore } from '../../src/webhooks/webhook.store.js';
 import { validateWebhookUrl, WebhookValidationError } from '../../src/webhooks/webhook.validator.js';
 import { dispatchWebhook } from '../../src/webhooks/webhook.dispatcher.js';
 import { WebhookEventType } from '../../src/webhooks/webhook.types.js';
+import { requestIdMiddleware } from '../../src/middleware/requestId.js';
+import { errorHandler } from '../../src/middleware/errorHandler.js';
 
 // Mock the logger to avoid console output in tests
 // Must use `var` so the variable is hoisted with the jest.mock() call (same as mockDnsLookup below)
@@ -34,8 +36,10 @@ jest.mock('dns/promises', () => ({
 
 function buildWebhookApp() {
   const app = express();
+  app.use(requestIdMiddleware);
   app.use(express.json());
   app.use('/api/webhooks', webhookRoutes);
+  app.use(errorHandler);
   return app;
 }
 
@@ -78,7 +82,9 @@ describe('Webhook Routes Security Tests', () => {
           .send(testCase.payload)
           .expect(400);
 
-        expect(response.body.error).toBe(testCase.expectedError);
+        expect(response.body.message).toBe(testCase.expectedError);
+        expect(response.body.code).toBe('INVALID_WEBHOOK_REGISTRATION');
+        expect(response.body.requestId).toBeDefined();
       }
     });
 
@@ -91,7 +97,8 @@ describe('Webhook Routes Security Tests', () => {
         })
         .expect(400);
 
-      expect(response.body.error).toContain('Invalid event types: invalid_event');
+      expect(response.body.message).toContain('Invalid event types: invalid_event');
+      expect(response.body.code).toBe('INVALID_WEBHOOK_EVENT_TYPES');
     });
 
     it('should reject URLs that resolve to private IP ranges in production', async () => {
@@ -108,7 +115,8 @@ describe('Webhook Routes Security Tests', () => {
         })
         .expect(400);
 
-      expect(response.body.error).toContain('private/internal IP address');
+      expect(response.body.message).toContain('private/internal IP address');
+      expect(response.body.code).toBe('INVALID_WEBHOOK_URL');
     });
 
     it('should reject non-HTTPS URLs in production', async () => {
@@ -122,7 +130,8 @@ describe('Webhook Routes Security Tests', () => {
         })
         .expect(400);
 
-      expect(response.body.error).toContain('must use HTTPS in production');
+      expect(response.body.message).toContain('must use HTTPS in production');
+      expect(response.body.code).toBe('INVALID_WEBHOOK_URL');
     });
 
     it('should reject non-standard ports in production', async () => {
@@ -136,7 +145,8 @@ describe('Webhook Routes Security Tests', () => {
         })
         .expect(400);
 
-      expect(response.body.error).toContain('Only ports 80 and 443 are allowed');
+      expect(response.body.message).toContain('Only ports 80 and 443 are allowed');
+      expect(response.body.code).toBe('INVALID_WEBHOOK_URL');
     });
 
     it('should reject URLs that cannot be resolved', async () => {
@@ -147,7 +157,8 @@ describe('Webhook Routes Security Tests', () => {
         .send(validPayload)
         .expect(400);
 
-      expect(response.body.error).toContain('Could not resolve webhook hostname');
+      expect(response.body.message).toContain('Could not resolve webhook hostname');
+      expect(response.body.code).toBe('INVALID_WEBHOOK_URL');
     });
 
     it('should allow valid webhook registration', async () => {
@@ -202,7 +213,8 @@ describe('Webhook Routes Security Tests', () => {
         .get('/api/webhooks/non-existent')
         .expect(404);
 
-      expect(response.body.error).toBe('No webhook registered for this developer.');
+      expect(response.body.message).toBe('No webhook registered for this developer.');
+      expect(response.body.code).toBe('WEBHOOK_NOT_FOUND');
     });
   });
 
@@ -228,6 +240,7 @@ describe('Webhook Routes Security Tests', () => {
       const getResponse = await request(app)
         .get('/api/webhooks/dev-123')
         .expect(404);
+      expect(getResponse.body.code).toBe('WEBHOOK_NOT_FOUND');
     });
 
     it('should handle deletion of non-existent webhook gracefully', async () => {


### PR DESCRIPTION
Closes #212 

Changes made:
- Standardize API error responses to { code, message, requestId } format
- Replace ad hoc { error: ... } responses with typed errors via global handler
- Add reusable error classes for common HTTP cases
- Update tests to validate new error response structure
- Fix syntax issue in in-memory usage repository during verification
- Ran lint, test and typecheck and my changes passes. The errors were already existing erros