### PR TITLE
Add shared network query validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ STELLAR_TRANSACTION_TIMEOUT=300
 
 Notes:
 - Do not point a testnet deployment at mainnet URLs or contract IDs (or vice versa).
+- Stellar-aware API routes that accept a `network` query parameter only allow `testnet` or `mainnet`.
+- `GET /api/vault/balance` defaults `network` to `testnet` when the query parameter is omitted.
 - Deposit transaction building uses the configured network Horizon URL and validates vault contract ID when configured.
 - Deposit transaction building defaults to a `100` stroop fee and a `300` second timeout unless overridden.
 - Soroban settlement client uses the configured network RPC URL and settlement contract ID.

--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,7 @@ import { VaultController } from './controllers/vaultController.js';
 import { TransactionBuilderService } from './services/transactionBuilder.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { requestLogger } from './middleware/logging.js';
+import { validate } from './middleware/validate.js';
 import { metricsMiddleware, metricsEndpoint } from './metrics.js';
 import {
   BadRequestError,
@@ -43,6 +44,7 @@ import {
   UnauthorizedError,
 } from './errors/index.js';
 import { apiKeyRepository } from './repositories/apiKeyRepository.js';
+import { optionalNetworkQuerySchema } from './validators/networkValidator.js';
 
 interface AppDependencies {
   usageEventsRepository?: UsageEventsRepository;
@@ -557,10 +559,22 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     depositController.prepareDeposit(req, res);
   });
 
-  // Vault balance endpoint
-  app.get('/api/vault/balance', requireAuth, (req, res: express.Response<unknown, AuthenticatedLocals>) => {
-    vaultController.getBalance(req, res);
-  });
+  /**
+   * GET /api/vault/balance
+   *
+   * Returns the authenticated user's vault balance.
+   *
+   * Query params:
+   *   network - Optional Stellar network: "testnet" or "mainnet". Defaults to "testnet".
+   */
+  app.get(
+    '/api/vault/balance',
+    requireAuth,
+    validate({ query: optionalNetworkQuerySchema }),
+    (req, res: express.Response<unknown, AuthenticatedLocals>) => {
+      vaultController.getBalance(req, res);
+    }
+  );
 
   // Revoke API key endpoint
   app.delete('/api/keys/:id', requireAuth, (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {

--- a/src/controllers/vaultController.test.ts
+++ b/src/controllers/vaultController.test.ts
@@ -4,6 +4,15 @@ import { VaultController } from './vaultController.js';
 import { InMemoryVaultRepository } from '../repositories/vaultRepository.js';
 import { errorHandler } from '../middleware/errorHandler.js';
 
+// Keep app-router integration coverage independent from the native sqlite binding.
+jest.mock('better-sqlite3', () => {
+  return class MockDatabase {
+    prepare() { return { get: () => null }; }
+    exec() { }
+    close() { }
+  };
+});
+
 function createTestApp(vaultRepository: InMemoryVaultRepository, useJwtAuth = false) {
   const app = express();
   app.use(express.json());
@@ -38,9 +47,9 @@ function createTestApp(vaultRepository: InMemoryVaultRepository, useJwtAuth = fa
       res.status(401).json({ error: 'Authentication required' });
     });
   } else {
-    // Mock requireAuth to accept essentially any user via x-user-id header
+    // Mock requireAuth's x-user-id behavior for controller-level tests.
     app.use((req, res, next) => {
-      const userId = req.headers['x-user-id'] as string;
+      const userId = (req.headers['x-user-id'] as string | undefined)?.trim();
       if (userId) {
         res.locals.authenticatedUser = {
           id: userId,
@@ -317,7 +326,7 @@ describe('VaultController - getBalance', () => {
       repository.findByUserId = originalFindByUserId;
     });
 
-    it('handles malformed user IDs gracefully', async () => {
+    it('rejects whitespace-only user IDs', async () => {
       const repository = new InMemoryVaultRepository();
       const app = createTestApp(repository);
 
@@ -325,7 +334,7 @@ describe('VaultController - getBalance', () => {
         .get('/api/vault/balance')
         .set('x-user-id', '   '); // whitespace only
 
-      expect(response.status).toBe(404); // Will be treated as authenticated but vault not found
+      expect(response.status).toBe(401);
     });
   });
 
@@ -442,6 +451,32 @@ describe('VaultController - getBalance', () => {
       expect(response.status).toBe(404);
       expect(response.body).toHaveProperty('error');
       expect(typeof response.body.error).toBe('string');
+    });
+
+    it('rejects invalid network values through app-level validation middleware', async () => {
+      const { createApp } = await import('../app.js');
+      const repository = new InMemoryVaultRepository();
+      await repository.create('integration-user', 'contract-integration', 'testnet');
+
+      const app = createApp({ vaultRepository: repository });
+
+      const response = await request(app)
+        .get('/api/vault/balance?network=invalid')
+        .set('x-user-id', 'integration-user');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        code: 'VALIDATION_ERROR',
+        message: 'Request validation failed',
+      });
+      expect(response.body.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            field: 'query.network',
+            message: 'network must be either "testnet" or "mainnet"',
+          }),
+        ])
+      );
     });
   });
 

--- a/src/validators/networkValidator.ts
+++ b/src/validators/networkValidator.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const networkSchema = z.enum(['testnet', 'mainnet'], {
+  error: 'network must be either "testnet" or "mainnet"',
+});
+
+export const optionalNetworkQuerySchema = z.object({
+  network: networkSchema.optional(),
+});
+
+export type StellarNetwork = z.infer<typeof networkSchema>;


### PR DESCRIPTION
## Summary
- add a reusable Zod network schema for `testnet`/`mainnet`
- validate `GET /api/vault/balance` query params through the shared `validate` middleware
- document the accepted `network` values/default and extend vault controller coverage

Closes #336.

## Validation
- `npm test -- src/controllers/vaultController.test.ts --runInBand --forceExit`
- `npm run build`
- `git diff --check`

Note: local dependency installation required `npm install --ignore-scripts` because `better-sqlite3@9.2.2` has no Node 24 prebuild and fails to compile under the local Node 24 toolchain. The app-router tests mock `better-sqlite3`, matching the existing pattern in `src/app.test.ts`.

## Stellar Wave
This implements the public Stellar Wave issue requirements for consistent `network` query validation and documentation.