### PR TITLE
Add typed event emitter contracts

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,8 +4,7 @@ module.exports = {
   testEnvironment: "node",
   setupFiles: ["<rootDir>/jest.env-setup.cjs"],
   testMatch: ["**/?(*.)+(spec|test).ts"],
-  // Exclude tests that use Node.js native test runner
-  testPathIgnorePatterns: ["/node_modules/", "event.emitter.test.ts"],
+  testPathIgnorePatterns: ["/node_modules/"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: {
     "^(.*/)?generated/prisma/client(\\.js)?$":

--- a/src/events/README.md
+++ b/src/events/README.md
@@ -15,9 +15,15 @@ The `event.emitter.ts` module provides a centralized event system for the Callor
 
 ### Event Types
 
-1. `new_api_call`: Triggered when API calls are made
-2. `settlement_completed`: Triggered when settlements are processed
-3. `low_balance_alert`: Triggered when balance falls below threshold
+The emitter API is typed through `CalloraEventMap`; event names and payloads are checked at compile time.
+
+| Event | Payload |
+| --- | --- |
+| `new_api_call` | `NewApiCallData`: `apiId`, `endpoint`, `method`, `statusCode`, `latencyMs`, `creditsUsed` |
+| `settlement_completed` | `SettlementCompletedData`: `settlementId`, `amount`, `asset`, `txHash`, `settledAt` |
+| `low_balance_alert` | `LowBalanceAlertData`: `currentBalance`, `thresholdBalance`, `asset` |
+
+The first argument for every event is `developerId: string`; the second argument is the event-specific payload.
 
 ## Threading and Async Behavior
 
@@ -27,18 +33,31 @@ The event emitter operates on Node.js's single-threaded event loop with the foll
 
 #### Event Emission (Synchronous)
 ```typescript
-// Event emission is SYNCHRONOUS and NON-BLOCKING
+// Event emission is SYNCHRONOUS and NON-BLOCKING.
 calloraEvents.emit('new_api_call', developerId, data);
 // Returns immediately, does not wait for processing
 ```
 
 #### Event Processing (Asynchronous)
 ```typescript
-// Event listeners are ASYNCHRONOUS
+// Event listeners may start asynchronous work.
 calloraEvents.on('new_api_call', async (developerId, data) => {
     await handleEvent('new_api_call', developerId, data);
     // Processing happens in the background
 });
+```
+
+### Unsubscribe Semantics
+
+`on()` returns an unsubscribe function. The unsubscribe removes only the listener that created it and is safe to call more than once.
+
+```typescript
+const unsubscribe = calloraEvents.on('low_balance_alert', (developerId, data) => {
+    // handle alert
+});
+
+unsubscribe();
+unsubscribe(); // no-op
 ```
 
 ### Concurrency Model

--- a/src/events/event.emitter.test.ts
+++ b/src/events/event.emitter.test.ts
@@ -6,7 +6,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { calloraEvents } from './event.emitter.js';
+import { calloraEvents, CalloraEventEmitter } from './event.emitter.js';
 import { WebhookStore } from '../webhooks/webhook.store.js';
 import type { 
     WebhookConfig, 
@@ -41,6 +41,58 @@ describe('Event Emitter - Memory Leak Safety', () => {
         assert.equal(calloraEvents.listenerCount('new_api_call'), 1, 'Should have 1 new_api_call listener');
         assert.equal(calloraEvents.listenerCount('settlement_completed'), 1, 'Should have 1 settlement_completed listener');
         assert.equal(calloraEvents.listenerCount('low_balance_alert'), 1, 'Should have 1 low_balance_alert listener');
+    });
+
+    test('unsubscribe removes only the target listener and is idempotent', () => {
+        const emitter = new CalloraEventEmitter();
+        let firstCalls = 0;
+        let secondCalls = 0;
+
+        const firstListener = () => {
+            firstCalls += 1;
+        };
+        const secondListener = () => {
+            secondCalls += 1;
+        };
+
+        const unsubscribeFirst = emitter.on('new_api_call', firstListener);
+        emitter.on('new_api_call', secondListener);
+
+        assert.equal(emitter.listenerCount('new_api_call'), 2);
+
+        unsubscribeFirst();
+        unsubscribeFirst();
+
+        assert.equal(emitter.listenerCount('new_api_call'), 1);
+
+        emitter.emit('new_api_call', 'dev_unsubscribe', {
+            apiId: 'api_unsubscribe',
+            endpoint: '/test',
+            method: 'GET',
+            statusCode: 200,
+            latencyMs: 10,
+            creditsUsed: 1,
+        });
+
+        assert.equal(firstCalls, 0);
+        assert.equal(secondCalls, 1);
+    });
+
+    test('event names and payloads are statically typed', () => {
+        if (false) {
+            // @ts-expect-error unknown event names are rejected by the typed API
+            calloraEvents.emit('unknown_event', 'dev_type_test', {});
+
+            // @ts-expect-error payload must match the event contract
+            calloraEvents.emit('new_api_call', 'dev_type_test', { invalid: 'data' });
+
+            // @ts-expect-error listener payload must match the selected event
+            calloraEvents.on('low_balance_alert', (_developerId, data: NewApiCallData) => {
+                return data.apiId;
+            });
+        }
+
+        assert.ok(true);
     });
 
     test('event emission does not accumulate listeners', async () => {
@@ -303,28 +355,32 @@ describe('Event Emitter - Async Behavior and Node.js Event Loop', () => {
 });
 
 describe('Event Emitter - Error Handling and Edge Cases', () => {
+    const untypedEvents = calloraEvents as unknown as {
+        emit(event: string, ...args: unknown[]): boolean;
+    };
+
     test('handles malformed event data gracefully', () => {
         const developerId = 'dev_malformed_test';
         
         // Emit with various malformed data
         assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', developerId, null);
+            untypedEvents.emit('new_api_call', developerId, null);
         });
 
         assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', developerId, undefined);
+            untypedEvents.emit('new_api_call', developerId, undefined);
         });
 
         assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', developerId, { invalid: 'data' });
+            untypedEvents.emit('new_api_call', developerId, { invalid: 'data' });
         });
 
         assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', null, {});
+            untypedEvents.emit('new_api_call', null, {});
         });
 
         assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', undefined, {});
+            untypedEvents.emit('new_api_call', undefined, {});
         });
     });
 
@@ -334,15 +390,15 @@ describe('Event Emitter - Error Handling and Edge Cases', () => {
 
         // Emit unknown event types
         assert.doesNotThrow(() => {
-            calloraEvents.emit('unknown_event', developerId, data);
+            untypedEvents.emit('unknown_event', developerId, data);
         });
 
         assert.doesNotThrow(() => {
-            calloraEvents.emit('', developerId, data);
+            untypedEvents.emit('', developerId, data);
         });
 
         assert.doesNotThrow(() => {
-            calloraEvents.emit('another_unknown_event', developerId, data);
+            untypedEvents.emit('another_unknown_event', developerId, data);
         });
     });
 

--- a/src/events/event.emitter.ts
+++ b/src/events/event.emitter.ts
@@ -9,7 +9,59 @@ import {
 import { WebhookStore } from '../webhooks/webhook.store.js';
 import { dispatchToAll } from '../webhooks/webhook.dispatcher.js';
 
-export const calloraEvents = new EventEmitter();
+export interface CalloraEventMap {
+    new_api_call: [developerId: string, data: NewApiCallData];
+    settlement_completed: [developerId: string, data: SettlementCompletedData];
+    low_balance_alert: [developerId: string, data: LowBalanceAlertData];
+}
+
+export type CalloraEventName = keyof CalloraEventMap;
+export type CalloraEventListener<TEvent extends CalloraEventName> = (
+    ...args: CalloraEventMap[TEvent]
+) => void;
+export type CalloraEventUnsubscribe = () => void;
+
+export class CalloraEventEmitter {
+    private readonly emitter = new EventEmitter();
+
+    on<TEvent extends CalloraEventName>(
+        event: TEvent,
+        listener: CalloraEventListener<TEvent>
+    ): CalloraEventUnsubscribe {
+        this.emitter.on(event, listener as (...args: unknown[]) => void);
+
+        let active = true;
+        return () => {
+            if (!active) {
+                return;
+            }
+
+            active = false;
+            this.off(event, listener);
+        };
+    }
+
+    off<TEvent extends CalloraEventName>(
+        event: TEvent,
+        listener: CalloraEventListener<TEvent>
+    ): this {
+        this.emitter.off(event, listener as (...args: unknown[]) => void);
+        return this;
+    }
+
+    emit<TEvent extends CalloraEventName>(
+        event: TEvent,
+        ...args: CalloraEventMap[TEvent]
+    ): boolean {
+        return this.emitter.emit(event, ...args);
+    }
+
+    listenerCount<TEvent extends CalloraEventName>(event: TEvent): number {
+        return this.emitter.listenerCount(event);
+    }
+}
+
+export const calloraEvents = new CalloraEventEmitter();
 
 async function handleEvent(
     event: WebhookEventType,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,3 +32,10 @@ export interface UsageResponse {
   calls: number;
   period: string;
 }
+
+export type {
+  CalloraEventListener,
+  CalloraEventMap,
+  CalloraEventName,
+  CalloraEventUnsubscribe,
+} from '../events/event.emitter.js';


### PR DESCRIPTION
## Summary
- replace the raw event emitter export with a typed `CalloraEventEmitter` wrapper
- add typed event-name/payload contracts and export them from `src/types`
- make `on()` return an idempotent unsubscribe function that removes only the target listener
- document event payloads and unsubscribe semantics
- remove the stale Jest ignore so `src/events/event.emitter.test.ts` can run

Closes #335.

## Validation
- `npm test -- src/events/event.emitter.test.ts --runInBand --forceExit`
- `npm run build`
- `git diff --check`

Note: local dependency installation used `npm install --ignore-scripts` because `better-sqlite3@9.2.2` does not compile under the local Node 24 toolchain. This test target does not require the native sqlite binding.

## Stellar Wave
This implements the public Stellar Wave issue requirements for typed event contracts, unsubscribe safety, documentation, and test coverage.