### PR TITLE
Reject malformed pagination query params

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -549,6 +549,25 @@ const buildApiRepo = () => {
   return new InMemoryApiRepository([activeApi], endpoints);
 };
 
+test('GET /api/apis rejects malformed pagination query parameters', async () => {
+  const app = createApp({ apiRepository: buildApiRepo() });
+
+  const invalidLimit = await request(app).get('/api/apis?limit=abc');
+  assert.equal(invalidLimit.status, 400);
+  assert.match(invalidLimit.body.message, /limit/);
+
+  const negativeOffset = await request(app).get('/api/apis?offset=-5');
+  assert.equal(negativeOffset.status, 400);
+  assert.match(negativeOffset.body.message, /offset/);
+});
+
+test('GET /api/apis still clamps valid over-max limits', async () => {
+  const app = createApp({ apiRepository: buildApiRepo() });
+
+  const response = await request(app).get('/api/apis?limit=500');
+  assert.equal(response.status, 200);
+});
+
 test('GET /api/apis/:id returns 400 for non-integer id', async () => {
   const app = createApp({ apiRepository: buildApiRepo() });
 

--- a/src/lib/__tests__/pagination.test.ts
+++ b/src/lib/__tests__/pagination.test.ts
@@ -1,6 +1,20 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { parsePagination, paginatedResponse } from '../pagination.js';
+import { parsePagination, PaginationParseError, paginatedResponse } from '../pagination.js';
+
+function assertPaginationError(
+  query: Parameters<typeof parsePagination>[0],
+  field: 'limit' | 'offset' | 'page',
+) {
+  assert.throws(
+    () => parsePagination(query),
+    (error: unknown) =>
+      error instanceof PaginationParseError &&
+      error.field === field &&
+      error.statusCode === 400 &&
+      error.message.includes(field),
+  );
+}
 
 describe('parsePagination', () => {
   it('returns defaults when no query params given', () => {
@@ -15,17 +29,18 @@ describe('parsePagination', () => {
     assert.deepEqual(parsePagination({ limit: '500' }), { limit: 100, offset: 0 });
   });
 
-  it('clamps limit to min 1', () => {
-    assert.deepEqual(parsePagination({ limit: '0' }), { limit: 1, offset: 0 });
-    assert.deepEqual(parsePagination({ limit: '-5' }), { limit: 1, offset: 0 });
+  it('rejects zero and negative limits', () => {
+    assertPaginationError({ limit: '0' }, 'limit');
+    assertPaginationError({ limit: '-5' }, 'limit');
   });
 
-  it('clamps offset to min 0', () => {
-    assert.deepEqual(parsePagination({ offset: '-10' }), { limit: 20, offset: 0 });
+  it('rejects negative offsets', () => {
+    assertPaginationError({ offset: '-10' }, 'offset');
   });
 
-  it('handles non-numeric strings gracefully', () => {
-    assert.deepEqual(parsePagination({ limit: 'abc', offset: 'xyz' }), { limit: 20, offset: 0 });
+  it('rejects non-numeric strings with the offending field', () => {
+    assertPaginationError({ limit: 'abc' }, 'limit');
+    assertPaginationError({ offset: 'xyz' }, 'offset');
   });
 
   // --- Edge cases: undefined / empty ---
@@ -34,22 +49,24 @@ describe('parsePagination', () => {
     assert.deepEqual(parsePagination({ limit: undefined, offset: undefined }), { limit: 20, offset: 0 });
   });
 
-  it('returns defaults for empty strings', () => {
-    assert.deepEqual(parsePagination({ limit: '', offset: '' }), { limit: 20, offset: 0 });
+  it('rejects empty strings when provided', () => {
+    assertPaginationError({ limit: '' }, 'limit');
+    assertPaginationError({ offset: '' }, 'offset');
   });
 
-  it('returns defaults for whitespace-only strings', () => {
-    assert.deepEqual(parsePagination({ limit: '  ', offset: '  ' }), { limit: 20, offset: 0 });
+  it('rejects whitespace-only strings when provided', () => {
+    assertPaginationError({ limit: '  ' }, 'limit');
+    assertPaginationError({ offset: '  ' }, 'offset');
   });
 
   // --- Edge cases: floating-point values ---
 
-  it('truncates floating-point limit via parseInt', () => {
-    assert.deepEqual(parsePagination({ limit: '10.7' }), { limit: 10, offset: 0 });
+  it('rejects floating-point limits', () => {
+    assertPaginationError({ limit: '10.7' }, 'limit');
   });
 
-  it('truncates floating-point offset via parseInt', () => {
-    assert.deepEqual(parsePagination({ offset: '5.9' }), { limit: 20, offset: 5 });
+  it('rejects floating-point offsets', () => {
+    assertPaginationError({ offset: '5.9' }, 'offset');
   });
 
   // --- Edge cases: huge values (prevent unbounded queries) ---
@@ -82,12 +99,12 @@ describe('parsePagination', () => {
 
   // --- Edge cases: special strings ---
 
-  it('falls back to defaults for "Infinity"', () => {
-    assert.deepEqual(parsePagination({ limit: 'Infinity' }), { limit: 20, offset: 0 });
+  it('rejects "Infinity"', () => {
+    assertPaginationError({ limit: 'Infinity' }, 'limit');
   });
 
-  it('falls back to defaults for "NaN"', () => {
-    assert.deepEqual(parsePagination({ limit: 'NaN' }), { limit: 20, offset: 0 });
+  it('rejects "NaN"', () => {
+    assertPaginationError({ limit: 'NaN' }, 'limit');
   });
 
   it('handles leading/trailing whitespace in numeric strings', () => {
@@ -111,14 +128,14 @@ describe('parsePagination', () => {
     assert.deepEqual(parsePagination({ limit: '10', page: '2', offset: '50' }), { limit: 10, offset: 10 });
   });
 
-  it('handles invalid page values gracefully', () => {
-    assert.deepEqual(parsePagination({ page: 'abc' }), { limit: 20, offset: 0 });
-    assert.deepEqual(parsePagination({ page: '0' }), { limit: 20, offset: 0 });
-    assert.deepEqual(parsePagination({ page: '-5' }), { limit: 20, offset: 0 });
+  it('rejects invalid page values', () => {
+    assertPaginationError({ page: 'abc' }, 'page');
+    assertPaginationError({ page: '0' }, 'page');
+    assertPaginationError({ page: '-5' }, 'page');
   });
 
-  it('handles floating-point page values', () => {
-    assert.deepEqual(parsePagination({ page: '2.9' }), { limit: 20, offset: 20 });
+  it('rejects floating-point page values', () => {
+    assertPaginationError({ page: '2.9' }, 'page');
   });
 });
 

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,3 +1,5 @@
+import { BadRequestError } from '../errors/index.js';
+
 export interface PaginationParams {
   limit: number;
   offset: number;
@@ -17,25 +19,52 @@ export interface PaginatedResponse<T> {
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 
+type PaginationField = 'limit' | 'offset' | 'page';
+
+export class PaginationParseError extends BadRequestError {
+  constructor(public readonly field: PaginationField, message: string) {
+    super(message, 'INVALID_PAGINATION');
+    this.name = 'PaginationParseError';
+    Object.setPrototypeOf(this, PaginationParseError.prototype);
+  }
+}
+
+function parseIntegerParam(
+  field: PaginationField,
+  value: string | undefined,
+  min: number,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new PaginationParseError(field, `${field} must be an integer greater than or equal to ${min}`);
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed < min) {
+    throw new PaginationParseError(field, `${field} must be an integer greater than or equal to ${min}`);
+  }
+
+  return parsed;
+}
+
 export function parsePagination(query: {
   limit?: string;
   offset?: string;
   page?: string;
 }): PaginationParams {
-  const parsedLimit = parseInt(query.limit ?? '', 10);
-  const limit = Math.min(
-    MAX_LIMIT,
-    Math.max(1, Number.isNaN(parsedLimit) ? DEFAULT_LIMIT : parsedLimit),
-  );
+  const parsedLimit = parseIntegerParam('limit', query.limit, 1);
+  const limit = Math.min(MAX_LIMIT, parsedLimit ?? DEFAULT_LIMIT);
 
   let offset = 0;
-  if (query.page) {
-    const parsedPage = parseInt(query.page, 10);
-    const page = Math.max(1, Number.isNaN(parsedPage) ? 1 : parsedPage);
+  if (query.page !== undefined) {
+    const page = parseIntegerParam('page', query.page, 1) ?? 1;
     offset = (page - 1) * limit;
   } else {
-    const parsedOffset = parseInt(query.offset ?? '', 10);
-    offset = Math.max(0, Number.isNaN(parsedOffset) ? 0 : parsedOffset);
+    offset = parseIntegerParam('offset', query.offset, 0) ?? 0;
   }
 
   return { limit, offset };

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,7 +3,7 @@ import { adminAuth } from '../middleware/adminAuth.js';
 import { createAdminIpAllowlist } from '../middleware/ipAllowlist.js';
 import { findUsers } from '../repositories/userRepository.js';
 import { parsePagination, paginatedResponse } from '../lib/pagination.js';
-import { AppError } from '../errors/index.js';
+import { AppError, isAppError } from '../errors/index.js';
 import { logger } from '../logger.js';
 
 const router = Router();
@@ -21,6 +21,11 @@ router.get('/users', async (req, res, next) => {
 
     res.json(paginatedResponse(users, { total, limit, offset }));
   } catch (error) {
+    if (isAppError(error)) {
+      next(error);
+      return;
+    }
+
     logger.error('Failed to list users:', error);
     next(new AppError('Internal server error', 500));
   }

--- a/src/routes/apis.ts
+++ b/src/routes/apis.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import type { ApisResponse } from '../types/index.js';
+import { parsePagination } from '../lib/pagination.js';
 
 const router = Router();
 
-router.get('/', (_req, res) => {
+router.get('/', (req, res) => {
+  parsePagination(req.query as Record<string, string>);
   const response: ApisResponse = { apis: [] };
   res.json(response);
 });


### PR DESCRIPTION
Closes #321.

## Summary
- make `parsePagination` strict for provided `limit`, `offset`, and `page` values
- return field-specific 400 errors for malformed, negative, zero-limit/page, and non-integer pagination inputs
- preserve defaults for omitted params and max-limit clamping for valid large limits
- surface pagination validation through the public API list route and preserve AppError handling in admin users route

## Validation
- `node --import tsx --test src/lib/__tests__/pagination.test.ts`
- `npm test -- src/app.test.ts --runInBand --forceExit -t "GET /api/apis rejects malformed pagination|GET /api/apis still clamps"`
- `npm run build`
- `git diff --check`

Note: the full `src/app.test.ts` suite still has an unrelated existing week-boundary expectation failure in `GET /api/developers/analytics correctly handles week boundaries`; the targeted pagination regressions pass.