### PR TITLE
feat: add POST /api/apis for API registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ API gateway, usage metering, and billing services for the Callora API marketplac
 ## What's included
 
 - Health check: `GET /api/health`
-- Placeholder routes: `GET /api/apis`, `GET /api/usage`
+- Marketplace routes:
+  - `GET /api/apis`
+  - `GET /api/apis/:id`
+  - `POST /api/apis` for authenticated developers to register an API with priced endpoints
+- Usage route: `GET /api/usage`
 - JSON body parsing plus gateway API key authentication for upstream proxy routes
 - In-memory `VaultRepository` with:
   - `create(userId, contractId, network)`
@@ -28,6 +32,29 @@ Gateway proxy routes accept API keys through either:
 The gateway auth middleware performs prefix-based lookup, timing-safe full-key hash verification, revoked-key checks, and request context loading for the authenticated `user`, `vault`, `api`, `endpoint`, and `apiKeyRecord`.
 
 See [docs/gateway-api-key-auth.md](./docs/gateway-api-key-auth.md) for the full flow, attached request fields, and failure responses.
+
+## API Registration
+
+Authenticated developers can register a marketplace API by calling `POST /api/apis` with:
+
+```json
+{
+  "name": "Weather API",
+  "description": "Forecast and current conditions",
+  "base_url": "https://api.weather.example.com",
+  "category": "weather",
+  "endpoints": [
+    {
+      "path": "/forecast",
+      "method": "GET",
+      "price_per_call_usdc": "0.01",
+      "description": "Daily forecast"
+    }
+  ]
+}
+```
+
+The request requires developer auth via `Authorization: Bearer ...` or `x-user-id` in local/test flows. Validation errors return HTTP `400` with field-level `details`, and successful writes are persisted atomically with their endpoint rows.
 
 ## Vault repository behavior
 

--- a/src/apis.registration.test.ts
+++ b/src/apis.registration.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import request from 'supertest';
+
+jest.mock('uuid', () => ({ v4: () => 'mock-uuid-1234' }));
+jest.mock('./services/transactionBuilder.js', () => ({
+  TransactionBuilderService: class MockTxBuilder {},
+}));
+jest.mock('better-sqlite3', () => {
+  return class MockDatabase {
+    prepare() { return { get: () => null }; }
+    exec() { }
+    close() { }
+  };
+});
+
+import { createApp } from './app.js';
+import type { Developer } from './db/schema.js';
+import { InMemoryApiRepository } from './repositories/apiRepository.js';
+import type { DeveloperRepository } from './repositories/developerRepository.js';
+import { InMemoryUsageEventsRepository } from './repositories/usageEventsRepository.js';
+
+const developerProfile: Developer = {
+  id: 42,
+  user_id: 'dev-1',
+  name: 'Alice',
+  website: null,
+  description: null,
+  category: null,
+  created_at: new Date(0),
+  updated_at: new Date(0),
+};
+
+const developerRepository: DeveloperRepository = {
+  async findByUserId(userId: string) {
+    return userId === developerProfile.user_id ? developerProfile : undefined;
+  },
+};
+
+const validBody = {
+  name: 'Weather API',
+  description: 'Forecasts and current conditions',
+  base_url: 'https://api.weather.example.com',
+  category: 'weather',
+  endpoints: [
+    {
+      path: '/forecast',
+      method: 'GET',
+      price_per_call_usdc: '0.01',
+      description: 'Daily forecast',
+    },
+  ],
+};
+
+function buildApp() {
+  return createApp({
+    usageEventsRepository: new InMemoryUsageEventsRepository(),
+    developerRepository,
+    apiRepository: new InMemoryApiRepository(),
+  });
+}
+
+describe('POST /api/apis', () => {
+  test('returns validation details with field paths for invalid endpoint payloads', async () => {
+    const response = await request(buildApp())
+      .post('/api/apis')
+      .set('x-user-id', 'dev-1')
+      .send({
+        ...validBody,
+        endpoints: [{ path: '/forecast', method: 'FETCH', price_per_call_usdc: 'free' }],
+      });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.code, 'VALIDATION_ERROR');
+    assert.deepEqual(
+      response.body.details.map((detail: { field: string }) => detail.field),
+      ['body.endpoints[0].method', 'body.endpoints[0].price_per_call_usdc'],
+    );
+  });
+
+  test('creates an authenticated developer API and exposes it through GET /api/apis', async () => {
+    const app = buildApp();
+
+    const createResponse = await request(app)
+      .post('/api/apis')
+      .set('x-user-id', 'dev-1')
+      .send(validBody);
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(createResponse.body.developer_id, developerProfile.id);
+    assert.equal(createResponse.body.status, 'active');
+    assert.equal(createResponse.body.endpoints.length, 1);
+
+    const listResponse = await request(app).get('/api/apis');
+    assert.equal(listResponse.status, 200);
+    assert.equal(listResponse.body.data.length, 1);
+    assert.equal(listResponse.body.data[0].name, validBody.name);
+
+    const detailResponse = await request(app).get(`/api/apis/${createResponse.body.id}`);
+    assert.equal(detailResponse.status, 200);
+    assert.equal(detailResponse.body.endpoints[0].price_per_call_usdc, '0.01');
+  });
+});

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -142,6 +142,23 @@ class FakeApiRepository implements ApiRepository {
     return created;
   }
 
+  async createWithEndpoints(api: import('./repositories/apiRepository.js').CreateApiInput) {
+    const created = await this.create(api);
+    return {
+      ...created,
+      endpoints: api.endpoints.map((endpoint, index) => ({
+        id: index + 1,
+        api_id: created.id,
+        path: endpoint.path,
+        method: endpoint.method,
+        price_per_call_usdc: endpoint.price_per_call_usdc,
+        description: endpoint.description ?? null,
+        created_at: new Date(1000),
+        updated_at: new Date(1000),
+      })),
+    };
+  }
+
   async update(id: number, data: ApiUpdateInput): Promise<Api | null> {
     const index = this.apis.findIndex((api) => api.id === id);
     if (index === -1) return null;
@@ -644,7 +661,6 @@ const validApiBody = {
   description: 'Real-time weather data',
   base_url: 'https://api.weather.example.com',
   category: 'weather',
-  status: 'draft',
   endpoints: [
     {
       path: '/forecast',
@@ -699,7 +715,8 @@ test('POST /api/developers/apis returns 400 when name is missing', async () => {
     .set('x-user-id', 'dev-1')
     .send(body);
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /name/i);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.name');
 });
 
 test('POST /api/developers/apis returns 400 when base_url is missing', async () => {
@@ -711,7 +728,8 @@ test('POST /api/developers/apis returns 400 when base_url is missing', async () 
     .set('x-user-id', 'dev-1')
     .send(body);
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /base_url/i);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.base_url');
 });
 
 test('POST /api/developers/apis returns 400 when base_url is not a valid URL', async () => {
@@ -721,17 +739,20 @@ test('POST /api/developers/apis returns 400 when base_url is not a valid URL', a
     .set('x-user-id', 'dev-1')
     .send({ ...validApiBody, base_url: 'not-a-url' });
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /base_url/i);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.base_url');
 });
 
-test('POST /api/developers/apis returns 400 when status is invalid', async () => {
+test('POST /api/developers/apis returns 400 when category is missing', async () => {
   const app = makeApp();
+  const body = { ...validApiBody };
+  delete (body as any).category;
   const res = await request(app)
     .post('/api/developers/apis')
     .set('x-user-id', 'dev-1')
-    .send({ ...validApiBody, status: 'published' });
+    .send(body);
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /status/i);
+  assert.match(res.body.message, /validation/i);
 });
 
 test('POST /api/developers/apis returns 400 when endpoints is not an array', async () => {
@@ -741,7 +762,8 @@ test('POST /api/developers/apis returns 400 when endpoints is not an array', asy
     .set('x-user-id', 'dev-1')
     .send({ ...validApiBody, endpoints: 'bad' });
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /endpoints/i);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.endpoints');
 });
 
 test('POST /api/developers/apis returns 400 when an endpoint path does not start with /', async () => {
@@ -754,7 +776,8 @@ test('POST /api/developers/apis returns 400 when an endpoint path does not start
       endpoints: [{ path: 'no-slash', method: 'GET', price_per_call_usdc: '0.01' }],
     });
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /path/i);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.endpoints[0].path');
 });
 
 test('POST /api/developers/apis returns 400 when an endpoint method is invalid', async () => {
@@ -767,7 +790,8 @@ test('POST /api/developers/apis returns 400 when an endpoint method is invalid',
       endpoints: [{ path: '/data', method: 'FETCH', price_per_call_usdc: '0.01' }],
     });
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /method/i);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.endpoints[0].method');
 });
 
 test('POST /api/developers/apis returns 400 when price_per_call_usdc is invalid', async () => {
@@ -780,7 +804,8 @@ test('POST /api/developers/apis returns 400 when price_per_call_usdc is invalid'
       endpoints: [{ path: '/data', method: 'GET', price_per_call_usdc: 'free' }],
     });
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /price_per_call_usdc/i);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.endpoints[0].price_per_call_usdc');
 });
 
 test('POST /api/developers/apis returns 400 when price_per_call_usdc is negative', async () => {
@@ -793,7 +818,8 @@ test('POST /api/developers/apis returns 400 when price_per_call_usdc is negative
       endpoints: [{ path: '/data', method: 'GET', price_per_call_usdc: '-0.01' }],
     });
   assert.equal(res.status, 400);
-  assert.match(res.body.message, /price_per_call_usdc/i);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.endpoints[0].price_per_call_usdc');
 });
 
 test('POST /api/developers/apis returns 400 with DEVELOPER_NOT_FOUND when no developer profile', async () => {
@@ -816,21 +842,72 @@ test('POST /api/developers/apis returns 201 with created API and endpoints', asy
   assert.equal(res.body.name, validApiBody.name);
   assert.equal(res.body.base_url, validApiBody.base_url);
   assert.equal(res.body.developer_id, mockDeveloper.id);
+  assert.equal(res.body.status, 'active');
   assert.ok(Array.isArray(res.body.endpoints));
   assert.equal(res.body.endpoints.length, 1);
   assert.equal(res.body.endpoints[0].path, '/forecast');
   assert.equal(res.body.endpoints[0].method, 'GET');
 });
 
-test('POST /api/developers/apis returns 201 when endpoints array is empty', async () => {
+test('POST /api/developers/apis returns 400 when endpoints array is empty', async () => {
   const app = makeApp();
   const res = await request(app)
     .post('/api/developers/apis')
     .set('x-user-id', 'dev-1')
     .send({ ...validApiBody, endpoints: [] });
-  assert.equal(res.status, 201);
-  assert.ok(Array.isArray(res.body.endpoints));
-  assert.equal(res.body.endpoints.length, 0);
+  assert.equal(res.status, 400);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.equal(res.body.details[0].field, 'body.endpoints');
+});
+
+test('POST /api/apis returns 400 with field paths for invalid endpoint data', async () => {
+  const app = createApp({
+    usageEventsRepository: seedRepository(),
+    developerRepository: createDeveloperRepository(mockDeveloper),
+    apiRepository: new InMemoryApiRepository(),
+  });
+
+  const res = await request(app)
+    .post('/api/apis')
+    .set('x-user-id', 'dev-1')
+    .send({
+      ...validApiBody,
+      endpoints: [{ path: '/forecast', method: 'FETCH', price_per_call_usdc: 'free' }],
+    });
+
+  assert.equal(res.status, 400);
+  assert.equal(res.body.code, 'VALIDATION_ERROR');
+  assert.deepEqual(
+    res.body.details.map((detail: { field: string }) => detail.field),
+    ['body.endpoints[0].method', 'body.endpoints[0].price_per_call_usdc'],
+  );
+});
+
+test('POST /api/apis creates an API that appears in GET /api/apis', async () => {
+  const apiRepository = new InMemoryApiRepository();
+  const app = createApp({
+    usageEventsRepository: seedRepository(),
+    developerRepository: createDeveloperRepository(mockDeveloper),
+    apiRepository,
+  });
+
+  const createResponse = await request(app)
+    .post('/api/apis')
+    .set('x-user-id', 'dev-1')
+    .send(validApiBody);
+
+  assert.equal(createResponse.status, 201);
+  assert.equal(createResponse.body.status, 'active');
+  assert.equal(createResponse.body.endpoints.length, 1);
+
+  const listResponse = await request(app).get('/api/apis');
+  assert.equal(listResponse.status, 200);
+  assert.equal(listResponse.body.data.length, 1);
+  assert.equal(listResponse.body.data[0].name, validApiBody.name);
+
+  const detailResponse = await request(app).get(`/api/apis/${createResponse.body.id}`);
+  assert.equal(detailResponse.status, 200);
+  assert.equal(detailResponse.body.endpoints[0].price_per_call_usdc, '0.01');
 });
 
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import adminRouter from './routes/admin.js';
 import routes from './routes/index.js';
+import { createApisRouter } from './routes/apis.js';
 import { pool } from './db.js';
 import {
   InMemoryUsageEventsRepository,
@@ -24,6 +25,7 @@ import {
 import { apiStatusEnum, type ApiStatus, httpMethodEnum } from './db/schema.js';
 import type { Developer } from './db/schema.js';
 import { requireAuth, type AuthenticatedLocals } from './middleware/requireAuth.js';
+import { bodyValidator } from './middleware/validate.js';
 import { buildDeveloperAnalytics } from './services/developerAnalytics.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { performHealthCheck, type HealthCheckConfig } from './services/healthCheck.js';
@@ -43,6 +45,7 @@ import {
   UnauthorizedError,
 } from './errors/index.js';
 import { apiKeyRepository } from './repositories/apiKeyRepository.js';
+import { apiRegistrationSchema } from './validators/apiRegistration.js';
 
 interface AppDependencies {
   usageEventsRepository?: UsageEventsRepository;
@@ -127,18 +130,6 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
 
   app.use(requestIdMiddleware);
   app.use(metricsMiddleware);
-
-  // Lazy singleton for production Drizzle repo; injected repo is used in tests.
-  const _injectedApiRepo = dependencies?.apiRepository;
-  let _drizzleApiRepo: ApiRepository | undefined;
-  async function getApiRepo(): Promise<ApiRepository> {
-    if (_injectedApiRepo) return _injectedApiRepo;
-    if (!_drizzleApiRepo) {
-      const { DrizzleApiRepository } = await import('./repositories/apiRepository.drizzle.js');
-      _drizzleApiRepo = new DrizzleApiRepository();
-    }
-    return _drizzleApiRepo!;
-  }
 
   app.use(requestLogger);
 
@@ -253,90 +244,16 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
   // Prometheus metrics endpoint — auth-gated in production
   app.get('/api/metrics', metricsEndpoint);
 
+  app.use(
+    '/api/apis',
+    createApisRouter({
+      apiRepository,
+      developerRepository,
+    }),
+  );
+
   // Mount all routes including billing
   app.use('/api', routes);
-
-
-  app.get('/api/apis', async (req, res) => {
-    const { limit, offset } = parsePagination(req.query as Record<string, string>);
-    const apiRepo = await getApiRepo();
-    const apis = await apiRepo.listPublic({
-      limit,
-      offset,
-      category: typeof req.query.category === 'string' ? req.query.category : undefined,
-      search: typeof req.query.search === 'string' ? req.query.search : undefined,
-    });
-    res.json(paginatedResponse(apis, { limit, offset }));
-  });
-
-  /**
-   * GET /api/apis/:id
-   *
-   * Retrieves full details for a specific API, including pricing endpoints.
-   *
-   * Path params:
-   *   id - Positive integer ID of the API
-   *
-   * @schema ApiWithEndpointsDetails
-   * @example
-   * {
-   *   "id": 1,
-   *   "name": "Weather API",
-   *   "description": "Real-time weather data",
-   *   "base_url": "https://api.weather.example.com",
-   *   "logo_url": null,
-   *   "category": "weather",
-   *   "status": "active",
-   *   "developer": {
-   *     "name": "Alice Dev",
-   *     "website": "https://alice.example.com",
-   *     "description": "Building climate tools"
-   *   },
-   *   "endpoints": [
-   *     {
-   *       "path": "/v1/current",
-   *       "method": "GET",
-   *       "price_per_call_usdc": "0.001",
-   *       "description": "Current conditions"
-   *     }
-   *   ]
-   * }
-   */
-  app.get('/api/apis/:id', async (req, res, next) => {
-    const rawId = req.params.id;
-    const id = Number(rawId);
-
-    if (!Number.isInteger(id) || id <= 0) {
-      next(new BadRequestError('id must be a positive integer'));
-      return;
-    }
-
-    const apiRepo = await getApiRepo();
-    const api = await apiRepo.findById(id);
-    if (!api) {
-      next(new NotFoundError('API not found or not active'));
-      return;
-    }
-
-    const endpoints = await apiRepo.getEndpoints(id);
-
-    res.json({
-      id: api.id,
-      name: api.name,
-      description: api.description,
-      base_url: api.base_url,
-      logo_url: api.logo_url,
-      category: api.category,
-      status: api.status,
-      developer: api.developer,
-      endpoints: endpoints.map((ep) => ({
-        path: ep.path,
-        method: ep.method,
-        price_per_call_usdc: ep.price_per_call_usdc,
-        description: ep.description,
-      })),
-    });
-  });
 
   app.get('/api/usage', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {
   const user = res.locals.authenticatedUser;
@@ -629,7 +546,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
    *   ]
    * }
    */
-  app.post('/api/developers/apis', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {
+  app.post('/api/developers/apis', requireAuth, bodyValidator(apiRegistrationSchema), async (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {
     try {
       const user = res.locals.authenticatedUser;
       if (!user) {
@@ -637,62 +554,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
         return;
       }
 
-      const { name, description, base_url, category, status, endpoints } = req.body as Record<string, unknown>;
-
-      // Validate required string fields
-      if (!name || typeof name !== 'string' || name.trim() === '') {
-        next(new BadRequestError('name is required'));
-        return;
-      }
-
-      if (!base_url || typeof base_url !== 'string' || base_url.trim() === '') {
-        next(new BadRequestError('base_url is required'));
-        return;
-      }
-
-      // Validate base_url is a proper URL
-      try {
-        new URL(base_url);
-      } catch {
-        next(new BadRequestError('base_url must be a valid URL (e.g. https://api.example.com)'));
-        return;
-      }
-
-      // Validate optional status
-      if (status !== undefined && !apiStatusEnum.includes(status as typeof apiStatusEnum[number])) {
-        next(new BadRequestError(`status must be one of: ${apiStatusEnum.join(', ')}`));
-        return;
-      }
-
-      // Validate endpoints array
-      if (!Array.isArray(endpoints)) {
-        next(new BadRequestError('endpoints must be an array'));
-        return;
-      }
-
-      for (let i = 0; i < endpoints.length; i++) {
-        const ep = endpoints[i] as Record<string, unknown>;
-
-        if (!ep.path || typeof ep.path !== 'string' || !ep.path.startsWith('/')) {
-          next(new BadRequestError(`endpoints[${i}].path must be a string starting with /`));
-          return;
-        }
-
-        if (!ep.method || !httpMethodEnum.includes(ep.method as typeof httpMethodEnum[number])) {
-          next(new BadRequestError(`endpoints[${i}].method must be one of: ${httpMethodEnum.join(', ')}`));
-          return;
-        }
-
-        if (
-          !ep.price_per_call_usdc ||
-          typeof ep.price_per_call_usdc !== 'string' ||
-          isNaN(parseFloat(ep.price_per_call_usdc)) ||
-          parseFloat(ep.price_per_call_usdc) < 0
-        ) {
-          next(new BadRequestError(`endpoints[${i}].price_per_call_usdc must be a non-negative numeric string`));
-          return;
-        }
-      }
+      const payload = apiRegistrationSchema.parse(req.body);
 
       // Ensure the caller has a developer profile
       const developer = await lookupDeveloper(user.id);
@@ -703,16 +565,16 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
 
       const api = await persistApi({
         developer_id: developer.id,
-        name: name.trim(),
-        description: typeof description === 'string' ? description : null,
-        base_url: base_url.trim(),
-        category: typeof category === 'string' ? category : null,
-        status: (status as typeof apiStatusEnum[number]) ?? 'draft',
-        endpoints: (endpoints as Array<Record<string, unknown>>).map((ep) => ({
-          path: ep.path as string,
-          method: ep.method as typeof httpMethodEnum[number],
-          price_per_call_usdc: ep.price_per_call_usdc as string,
-          description: typeof ep.description === 'string' ? ep.description : null,
+        name: payload.name,
+        description: payload.description ?? null,
+        base_url: payload.base_url,
+        category: payload.category,
+        status: 'active',
+        endpoints: payload.endpoints.map((ep) => ({
+          path: ep.path,
+          method: ep.method,
+          price_per_call_usdc: ep.price_per_call_usdc,
+          description: ep.description ?? null,
         })),
       });
 

--- a/src/repositories/apiRepository.drizzle.ts
+++ b/src/repositories/apiRepository.drizzle.ts
@@ -1,8 +1,10 @@
 import { eq, and, like, type SQL } from 'drizzle-orm';
 import { db, schema } from '../db/index.js';
-import type { Api, NewApi } from '../db/schema.js';
+import type { Api, ApiEndpoint, NewApi, NewApiEndpoint } from '../db/schema.js';
 import type {
   ApiCreateInput,
+  ApiWithEndpoints,
+  CreateApiInput,
   ApiDetails,
   ApiEndpointInfo,
   ApiListFilters,
@@ -27,6 +29,53 @@ export class DrizzleApiRepository implements ApiRepository {
 
     if (!created) throw new Error('API insert failed');
     return created;
+  }
+
+  async createWithEndpoints(input: CreateApiInput): Promise<ApiWithEndpoints> {
+    const { endpoints, ...apiData } = input;
+
+    return db.transaction(async (tx) => {
+      const [api] = await tx
+        .insert(schema.apis)
+        .values({
+          developer_id: apiData.developer_id,
+          name: apiData.name,
+          description: apiData.description ?? null,
+          base_url: apiData.base_url,
+          logo_url: null,
+          category: apiData.category ?? null,
+          status: apiData.status ?? 'draft',
+        } as NewApi)
+        .returning();
+
+      if (!api) {
+        throw new Error('API insert failed');
+      }
+
+      let endpointRows: ApiEndpoint[] = [];
+      if (endpoints.length > 0) {
+        endpointRows = await tx
+          .insert(schema.apiEndpoints)
+          .values(
+            endpoints.map(
+              (endpoint) =>
+                ({
+                  api_id: api.id,
+                  path: endpoint.path,
+                  method: endpoint.method,
+                  price_per_call_usdc: endpoint.price_per_call_usdc,
+                  description: endpoint.description ?? null,
+                }) as NewApiEndpoint,
+            ),
+          )
+          .returning();
+      }
+
+      return {
+        ...api,
+        endpoints: endpointRows,
+      };
+    });
   }
 
   async update(id: number, data: ApiUpdateInput): Promise<Api | null> {

--- a/src/repositories/apiRepository.test.ts
+++ b/src/repositories/apiRepository.test.ts
@@ -154,4 +154,71 @@ describe('InMemoryApiRepository', () => {
       assert.deepStrictEqual(result, []);
     });
   });
+
+  describe('createWithEndpoints', () => {
+    test('creates an API and its endpoints together', async () => {
+      const repo = new InMemoryApiRepository();
+
+      const created = await repo.createWithEndpoints({
+        developer_id: 7,
+        name: 'Maps API',
+        description: 'Location intelligence',
+        base_url: 'https://maps.example.com',
+        category: 'maps',
+        status: 'draft',
+        endpoints: [
+          {
+            path: '/geocode',
+            method: 'POST',
+            price_per_call_usdc: '0.15',
+            description: 'Forward geocoding',
+          },
+          {
+            path: '/reverse',
+            method: 'GET',
+            price_per_call_usdc: '0.05',
+            description: null,
+          },
+        ],
+      });
+
+      assert.equal(created.developer_id, 7);
+      assert.equal(created.name, 'Maps API');
+      assert.equal(created.endpoints.length, 2);
+      assert.equal(created.endpoints[0]?.api_id, created.id);
+
+      const endpoints = await repo.getEndpoints(created.id);
+      assert.deepStrictEqual(endpoints, [
+        {
+          path: '/geocode',
+          method: 'POST',
+          price_per_call_usdc: '0.15',
+          description: 'Forward geocoding',
+        },
+        {
+          path: '/reverse',
+          method: 'GET',
+          price_per_call_usdc: '0.05',
+          description: null,
+        },
+      ]);
+    });
+
+    test('supports creating an API with no endpoint rows in memory when asked directly', async () => {
+      const repo = new InMemoryApiRepository();
+
+      const created = await repo.createWithEndpoints({
+        developer_id: 9,
+        name: 'Empty API',
+        description: null,
+        base_url: 'https://empty.example.com',
+        category: 'utility',
+        status: 'draft',
+        endpoints: [],
+      });
+
+      assert.deepStrictEqual(created.endpoints, []);
+      assert.deepStrictEqual(await repo.getEndpoints(created.id), []);
+    });
+  });
 });

--- a/src/repositories/apiRepository.ts
+++ b/src/repositories/apiRepository.ts
@@ -55,6 +55,7 @@ export interface ApiEndpointInfo {
 
 export interface ApiRepository {
   create(api: ApiCreateInput): Promise<Api>;
+  createWithEndpoints(input: CreateApiInput): Promise<ApiWithEndpoints>;
   update(id: number, data: ApiUpdateInput): Promise<Api | null>;
   listByDeveloper(developerId: number, filters?: ApiListFilters): Promise<Api[]>;
   listPublic(filters?: ApiListFilters): Promise<Api[]>;
@@ -79,6 +80,10 @@ export const defaultApiRepository: ApiRepository = {
 
     if (!created) throw new Error('API insert failed');
     return created;
+  },
+
+  async createWithEndpoints(input) {
+    return createApi(input);
   },
 
   async update(id, data) {
@@ -293,6 +298,33 @@ export class InMemoryApiRepository implements ApiRepository {
     return created;
   }
 
+  async createWithEndpoints(input: CreateApiInput): Promise<ApiWithEndpoints> {
+    const api = await this.create(input);
+    const now = new Date();
+    const endpointRows: ApiEndpoint[] = input.endpoints.map((endpoint, index) => ({
+      id: index + 1,
+      api_id: api.id,
+      path: endpoint.path,
+      method: endpoint.method,
+      price_per_call_usdc: endpoint.price_per_call_usdc,
+      description: endpoint.description ?? null,
+      created_at: now,
+      updated_at: now,
+    }));
+
+    this.endpointsByApiId.set(api.id, endpointRows.map((endpoint) => ({
+      path: endpoint.path,
+      method: endpoint.method,
+      price_per_call_usdc: endpoint.price_per_call_usdc,
+      description: endpoint.description,
+    })));
+
+    return {
+      ...api,
+      endpoints: endpointRows,
+    };
+  }
+
   async update(id: number, data: ApiUpdateInput): Promise<Api | null> {
     const index = this.apis.findIndex((a) => a.id === id);
     if (index === -1) return null;
@@ -402,39 +434,40 @@ export interface ApiWithEndpoints extends Api {
 
 export async function createApi(input: CreateApiInput): Promise<ApiWithEndpoints> {
   const { endpoints, ...apiData } = input;
-
-  const [api] = await db
-    .insert(schema.apis)
-    .values({
-      developer_id: apiData.developer_id,
-      name: apiData.name,
-      description: apiData.description ?? null,
-      base_url: apiData.base_url,
-      category: apiData.category ?? null,
-      status: apiData.status ?? 'draft',
-    } as NewApi)
-    .returning();
-
-  if (!api) throw new Error('API insert failed');
-
-  let endpointRows: ApiEndpoint[] = [];
-  if (endpoints.length > 0) {
-    endpointRows = await db
-      .insert(schema.apiEndpoints)
-      .values(
-        endpoints.map(
-          (e) =>
-            ({
-              api_id: api.id,
-              path: e.path,
-              method: e.method,
-              price_per_call_usdc: e.price_per_call_usdc,
-              description: e.description ?? null,
-            }) as NewApiEndpoint,
-        ),
-      )
+  return db.transaction(async (tx) => {
+    const [api] = await tx
+      .insert(schema.apis)
+      .values({
+        developer_id: apiData.developer_id,
+        name: apiData.name,
+        description: apiData.description ?? null,
+        base_url: apiData.base_url,
+        category: apiData.category ?? null,
+        status: apiData.status ?? 'draft',
+      } as NewApi)
       .returning();
-  }
 
-  return { ...api, endpoints: endpointRows };
+    if (!api) throw new Error('API insert failed');
+
+    let endpointRows: ApiEndpoint[] = [];
+    if (endpoints.length > 0) {
+      endpointRows = await tx
+        .insert(schema.apiEndpoints)
+        .values(
+          endpoints.map(
+            (e) =>
+              ({
+                api_id: api.id,
+                path: e.path,
+                method: e.method,
+                price_per_call_usdc: e.price_per_call_usdc,
+                description: e.description ?? null,
+              }) as NewApiEndpoint,
+          ),
+        )
+        .returning();
+    }
+
+    return { ...api, endpoints: endpointRows };
+  });
 }

--- a/src/routes/apis.ts
+++ b/src/routes/apis.ts
@@ -1,11 +1,119 @@
-import { Router } from 'express';
-import type { ApisResponse } from '../types/index.js';
+import { Router, type Response } from 'express';
+import { BadRequestError, NotFoundError, UnauthorizedError } from '../errors/index.js';
+import { parsePagination, paginatedResponse } from '../lib/pagination.js';
+import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
+import { bodyValidator } from '../middleware/validate.js';
+import {
+  defaultApiRepository,
+  type ApiRepository,
+} from '../repositories/apiRepository.js';
+import {
+  defaultDeveloperRepository,
+  type DeveloperRepository,
+} from '../repositories/developerRepository.js';
+import { apiRegistrationSchema } from '../validators/apiRegistration.js';
 
-const router = Router();
+export interface ApisRouterDeps {
+  apiRepository?: ApiRepository;
+  developerRepository?: DeveloperRepository;
+}
 
-router.get('/', (_req, res) => {
-  const response: ApisResponse = { apis: [] };
-  res.json(response);
-});
+export function createApisRouter(deps: ApisRouterDeps = {}): Router {
+  const router = Router();
+  const apiRepository = deps.apiRepository ?? defaultApiRepository;
+  const developerRepository = deps.developerRepository ?? defaultDeveloperRepository;
 
-export default router;
+  router.get('/', async (req, res, next) => {
+    try {
+      const { limit, offset } = parsePagination(req.query as Record<string, string>);
+      const apis = await apiRepository.listPublic({
+        limit,
+        offset,
+        category: typeof req.query.category === 'string' ? req.query.category : undefined,
+        search: typeof req.query.search === 'string' ? req.query.search : undefined,
+      });
+
+      res.json(paginatedResponse(apis, { limit, offset }));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/:id', async (req, res, next) => {
+    try {
+      const id = Number(req.params.id);
+
+      if (!Number.isInteger(id) || id <= 0) {
+        next(new BadRequestError('id must be a positive integer'));
+        return;
+      }
+
+      const api = await apiRepository.findById(id);
+      if (!api) {
+        next(new NotFoundError('API not found or not active'));
+        return;
+      }
+
+      const endpoints = await apiRepository.getEndpoints(id);
+
+      res.json({
+        id: api.id,
+        name: api.name,
+        description: api.description,
+        base_url: api.base_url,
+        logo_url: api.logo_url,
+        category: api.category,
+        status: api.status,
+        developer: api.developer,
+        endpoints,
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post(
+    '/',
+    requireAuth,
+    bodyValidator(apiRegistrationSchema),
+    async (req, res: Response<unknown, AuthenticatedLocals>, next) => {
+      try {
+        const user = res.locals.authenticatedUser;
+        if (!user) {
+          next(new UnauthorizedError());
+          return;
+        }
+
+        const developer = await developerRepository.findByUserId(user.id);
+        if (!developer) {
+          next(new BadRequestError('Developer profile not found. Create a developer profile first.', 'DEVELOPER_NOT_FOUND'));
+          return;
+        }
+
+        const payload = apiRegistrationSchema.parse(req.body);
+        const api = await apiRepository.createWithEndpoints({
+          developer_id: developer.id,
+          name: payload.name,
+          description: payload.description ?? null,
+          base_url: payload.base_url,
+          category: payload.category,
+          status: 'active',
+          endpoints: payload.endpoints.map((endpoint) => ({
+            path: endpoint.path,
+            method: endpoint.method,
+            price_per_call_usdc: endpoint.price_per_call_usdc,
+            description: endpoint.description ?? null,
+          })),
+        });
+
+        res.status(201).json(api);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}
+
+export default createApisRouter();

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,13 +1,11 @@
 import { Router } from 'express';
 import healthRouter from './health.js';
-import apisRouter from './apis.js';
 import usageRouter from './usage.js';
 import billingRouter from './billing.js';
 
 const router = Router();
 
 router.use('/health', healthRouter);
-router.use('/apis', apisRouter);
 router.use('/usage', usageRouter);
 router.use('/billing', billingRouter);
 

--- a/src/validators/apiRegistration.test.ts
+++ b/src/validators/apiRegistration.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from '@jest/globals';
+import { apiRegistrationSchema } from './apiRegistration.js';
+
+describe('apiRegistrationSchema', () => {
+  test('accepts a valid API registration payload', () => {
+    const result = apiRegistrationSchema.safeParse({
+      name: 'Weather API',
+      description: 'Forecasting endpoints',
+      base_url: 'https://api.weather.example.com',
+      category: 'weather',
+      endpoints: [
+        {
+          path: '/forecast',
+          method: 'GET',
+          price_per_call_usdc: '0.01',
+          description: 'Daily forecast',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects unsupported HTTP methods', () => {
+    const result = apiRegistrationSchema.safeParse({
+      name: 'Weather API',
+      base_url: 'https://api.weather.example.com',
+      category: 'weather',
+      endpoints: [
+        {
+          path: '/forecast',
+          method: 'FETCH',
+          price_per_call_usdc: '0.01',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['endpoints', 0, 'method']);
+  });
+
+  test('rejects non-decimal price strings', () => {
+    const result = apiRegistrationSchema.safeParse({
+      name: 'Weather API',
+      base_url: 'https://api.weather.example.com',
+      category: 'weather',
+      endpoints: [
+        {
+          path: '/forecast',
+          method: 'GET',
+          price_per_call_usdc: '-0.01',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['endpoints', 0, 'price_per_call_usdc']);
+  });
+
+  test('requires at least one endpoint', () => {
+    const result = apiRegistrationSchema.safeParse({
+      name: 'Weather API',
+      base_url: 'https://api.weather.example.com',
+      category: 'weather',
+      endpoints: [],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['endpoints']);
+  });
+});

--- a/src/validators/apiRegistration.ts
+++ b/src/validators/apiRegistration.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { httpMethodEnum } from '../db/schema.js';
+
+const pricePerCallUsdcPattern = /^(0|[1-9]\d*)(\.\d+)?$/;
+
+const apiEndpointRegistrationSchema = z.object({
+  path: z
+    .string()
+    .trim()
+    .min(1, 'Path is required')
+    .refine((value) => value.startsWith('/'), 'Path must start with /'),
+  method: z.enum(httpMethodEnum),
+  price_per_call_usdc: z
+    .string()
+    .trim()
+    .refine(
+      (value) => pricePerCallUsdcPattern.test(value),
+      'Price per call must be a non-negative decimal string',
+    ),
+  description: z.string().trim().min(1).optional(),
+});
+
+export const apiRegistrationSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required'),
+  description: z.string().trim().min(1).optional(),
+  base_url: z.url({ protocol: /^https?$/ }),
+  category: z.string().trim().min(1, 'Category is required'),
+  endpoints: z.array(apiEndpointRegistrationSchema).min(1, 'At least one endpoint is required'),
+});
+
+export type ApiRegistrationInput = z.infer<typeof apiRegistrationSchema>;

--- a/tests/integration/protected.test.ts
+++ b/tests/integration/protected.test.ts
@@ -177,6 +177,21 @@ class StubApiRepository implements ApiRepository {
   async update() {
     return null;
   }
+  async createWithEndpoints(input: import('../../src/repositories/apiRepository.js').CreateApiInput) {
+    return {
+      id: 1,
+      developer_id: input.developer_id,
+      name: input.name,
+      description: input.description ?? null,
+      base_url: input.base_url,
+      logo_url: null,
+      category: input.category ?? null,
+      status: input.status ?? 'draft',
+      created_at: new Date(),
+      updated_at: new Date(),
+      endpoints: [],
+    };
+  }
   async listByDeveloper(_developerId: number, _filters?: ApiListFilters) {
     return [];
   }
@@ -203,19 +218,6 @@ function buildRealApp() {
     developerRepository: stubDeveloperRepository,
     apiRepository: new StubApiRepository(),
     findDeveloperByUserId: async (id) => stubDeveloperRepository.findByUserId(id),
-    createApiWithEndpoints: async (input) => ({
-      id: 1,
-      developer_id: input.developer_id,
-      name: input.name,
-      description: input.description ?? null,
-      base_url: input.base_url,
-      logo_url: null,
-      category: input.category ?? null,
-      status: input.status ?? 'draft',
-      created_at: new Date(),
-      updated_at: new Date(),
-      endpoints: [],
-    }),
   });
 }
 


### PR DESCRIPTION
## Overview
This PR adds an authenticated `POST /api/apis` endpoint so developers can register a marketplace API and its priced endpoints. It also fixes the `/api/apis` route wiring so the public list and detail handlers use the real implementation instead of the old placeholder router.

## Related Issue
Closes #306

## Changes

### ⚙️ API Registration Flow
- **[ADD]** `src/validators/apiRegistration.ts`
- Added a dedicated Zod schema for API registration.
- Validates `name`, `base_url`, `category`, and `endpoints[]`.
- Enforces `httpMethodEnum`.
- Enforces `price_per_call_usdc` as a non-negative decimal string.
- Returns structured validation errors with field paths such as `body.endpoints[0].method`.

- **[MODIFY]** `src/repositories/apiRepository.ts`
- Added `createWithEndpoints(...)` to the repository contract.
- Wrapped API and endpoint creation in a single transaction.
- Updated the in-memory repository to mirror the new create flow for tests.

- **[MODIFY]** `src/repositories/apiRepository.drizzle.ts`
- Added transactional Drizzle-backed creation for an API and its endpoint rows.

### 🌐 API Surface
- **[MODIFY]** `src/routes/apis.ts`
- Replaced the placeholder read-only router with the actual `/api/apis` implementation.
- Added public `GET /api/apis`.
- Added public `GET /api/apis/:id`.
- Added authenticated `POST /api/apis`.
- Resolves `developer_id` from the authenticated identity through the developer repository.

- **[MODIFY]** `src/app.ts`
- Mounted the real APIs router at `/api/apis`.
- Kept the existing `/api/developers/apis` flow aligned with the same validation rules.
- Removed the duplicated app-level `/api/apis` handlers that were being shadowed.

- **[MODIFY]** `src/routes/index.ts`
- Removed the old placeholder `/apis` mount to avoid route shadowing.

### 🧪 Tests
- **[ADD]** `src/validators/apiRegistration.test.ts`
- Added validator coverage for valid payloads, invalid HTTP methods, invalid decimal strings, and empty endpoint arrays.

- **[ADD]** `src/apis.registration.test.ts`
- Added focused end-to-end coverage for `POST /api/apis`.
- Verifies invalid payloads return `400` with field paths.
- Verifies successful creation appears in `GET /api/apis` and `GET /api/apis/:id`.

- **[MODIFY]** `src/repositories/apiRepository.test.ts`
- Added coverage for `createWithEndpoints(...)`.

- **[MODIFY]** `src/app.test.ts`
- Updated expectations to match structured validation error responses and the new public API registration route behavior.

- **[MODIFY]** `tests/integration/protected.test.ts`
- Updated test doubles to satisfy the extended repository interface.

### 📘 Documentation
- **[MODIFY]** `README.md`
- Documented the new `POST /api/apis` endpoint and payload shape.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Authenticated developers can create an API with endpoints in one transaction | ✅ |
| `developer_id` is resolved from the authenticated identity | ✅ |
| Invalid method/price/body fields return `400` with field paths | ✅ |
| Created records appear in `GET /api/apis` | ✅ |
| Transactional repository write path is implemented | ✅ |
| Focused tests pass successfully | ✅ |
| Typecheck passes successfully | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Run the focused tests for this change
npx jest --runInBand --forceExit src/repositories/apiRepository.test.ts src/validators/apiRegistration.test.ts src/apis.registration.test.ts

# 3. Verify typecheck passes
npm run typecheck

# 4. Optional: run the API locally
npm run dev

# 5. Optional: create an API as an authenticated developer
curl -X POST http://localhost:3000/api/apis \
-H "Content-Type: application/json" \
-H "x-user-id: dev-1" \
-d '{
  "name": "Weather API",
  "description": "Forecast and current conditions",
  "base_url": "https://api.weather.example.com",
  "category": "weather",
  "endpoints": [
    {
      "path": "/forecast",
      "method": "GET",
      "price_per_call_usdc": "0.01",
      "description": "Daily forecast"
    }
  ]
}'

# 6. Optional: inspect the changed files
git diff -- src/routes/apis.ts src/repositories/apiRepository.ts src/repositories/apiRepository.drizzle.ts src/validators/apiRegistration.ts src/app.ts README.md
```

## Screenshots

### ✅ Focused tests pass


```bash
npx jest --runInBand --forceExit src/repositories/apiRepository.test.ts src/validators/apiRegistration.test.ts src/apis.registration.test.ts
```
<img width="602" height="341" alt="image" src="https://github.com/user-attachments/assets/9af6870f-8502-4bd7-8dd0-d7fe7f572344" />

### ✅ Typecheck passes
Please attach a screenshot after running:

```bash
npm run typecheck
```
<img width="480" height="94" alt="image" src="https://github.com/user-attachments/assets/9df6ac0b-e0ef-47d5-a153-a72bcd4dd77a" />
