### PR TITLE
feat: add PostgreSQL-backed settlement and usage stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ See [docs/gateway-api-key-auth.md](./docs/gateway-api-key-auth.md) for the full 
 - Read methods support time-bounded lookups by `userId` or `apiId`, plus aggregate totals for user spend and API revenue.
 - Amounts are handled as smallest-unit `bigint` values in application code, even though the backing column is named `amount_usdc`.
 
+## Persistent developer revenue stores
+
+- The runtime now uses PostgreSQL-backed `SettlementStore` and `UsageStore` implementations so `/api/developers/revenue` survives process restarts.
+- Unsettled usage is persisted through `revenue_ledger`, and settlement batches are persisted through `settlements`.
+- The in-memory store factories are still available for unit tests and isolated local scenarios.
+- Apply `migrations/001_create_usage_events.sql`, `migrations/002_create_settlements.sql`, `migrations/003_create_revenue_ledger.sql`, and `migrations/005_add_persistent_store_columns.sql` before starting the API against PostgreSQL.
+
 ## Local setup
 
 1. **Prerequisites:** Node.js 18+

--- a/SETTLEMENT_STORE_DOCUMENTATION.md
+++ b/SETTLEMENT_STORE_DOCUMENTATION.md
@@ -162,5 +162,7 @@ The `InMemorySettlementStore` provides a solid foundation for development and te
 Key takeaways:
 - Current implementation is suitable for development/testing only
 - Production use requires database backing and concurrency controls
+- `PostgresSettlementStore` now provides that backing while preserving external settlement IDs through `settlements.external_id`
+- Persistent developer revenue also depends on `revenue_ledger` so unsettled usage continues to satisfy `total_earned = completed + pending + usage` after restarts
 - Security concerns must be addressed at the application layer
 - Test coverage provides confidence in current behavior guarantees

--- a/migrations/005_add_persistent_store_columns.sql
+++ b/migrations/005_add_persistent_store_columns.sql
@@ -1,0 +1,23 @@
+-- Migration: add columns needed by persistent settlement and usage stores
+
+ALTER TABLE settlements
+  ADD COLUMN IF NOT EXISTS external_id VARCHAR(255);
+
+UPDATE settlements
+SET external_id = CONCAT('stl_', id)
+WHERE external_id IS NULL;
+
+ALTER TABLE settlements
+  ALTER COLUMN external_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_settlements_external_id
+  ON settlements(external_id);
+
+ALTER TABLE usage_events
+  ADD COLUMN IF NOT EXISTS api_key VARCHAR(255);
+
+ALTER TABLE usage_events
+  ADD COLUMN IF NOT EXISTS status_code INTEGER NOT NULL DEFAULT 200;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_revenue_ledger_usage_event
+  ON revenue_ledger(usage_event_id);

--- a/src/__tests__/persistentStores.test.ts
+++ b/src/__tests__/persistentStores.test.ts
@@ -1,0 +1,222 @@
+import express from 'express';
+import request from 'supertest';
+import { DataType, newDb } from 'pg-mem';
+import { createDeveloperRouter } from '../routes/developerRoutes.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { createPostgresSettlementStore } from '../services/settlementStore.js';
+import { createPostgresUsageStore } from '../services/usageStore.js';
+
+function createPersistentStoreHarness() {
+  const db = newDb();
+
+  db.public.registerFunction({
+    name: 'now',
+    returns: DataType.timestamp,
+    implementation: () => new Date('2026-03-01T00:00:00.000Z'),
+  });
+
+  db.public.none(`
+    CREATE TABLE usage_events (
+      id BIGSERIAL PRIMARY KEY,
+      user_id VARCHAR(255) NOT NULL,
+      api_id VARCHAR(255) NOT NULL,
+      endpoint_id VARCHAR(255) NOT NULL,
+      api_key_id VARCHAR(255) NOT NULL,
+      api_key VARCHAR(255),
+      amount_usdc NUMERIC NOT NULL,
+      request_id VARCHAR(255) NOT NULL UNIQUE,
+      status_code INTEGER NOT NULL DEFAULT 200,
+      stellar_tx_hash VARCHAR(64),
+      created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE settlements (
+      id BIGSERIAL PRIMARY KEY,
+      external_id VARCHAR(255) NOT NULL UNIQUE,
+      developer_id VARCHAR(255) NOT NULL,
+      amount_usdc NUMERIC NOT NULL,
+      stellar_tx_hash VARCHAR(64),
+      status VARCHAR(20) NOT NULL CHECK (status IN ('pending', 'completed', 'failed')),
+      created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+      completed_at TIMESTAMP
+    );
+
+    CREATE TABLE revenue_ledger (
+      id BIGSERIAL PRIMARY KEY,
+      api_id VARCHAR(255) NOT NULL,
+      developer_id VARCHAR(255) NOT NULL,
+      amount_usdc NUMERIC NOT NULL,
+      usage_event_id BIGINT NOT NULL UNIQUE REFERENCES usage_events(id),
+      settlement_id BIGINT REFERENCES settlements(id),
+      created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+  `);
+
+  const { Pool } = db.adapters.createPg();
+  const pool = new Pool();
+
+  return {
+    pool,
+    settlementStore: createPostgresSettlementStore(pool),
+    usageStore: createPostgresUsageStore(pool),
+  };
+}
+
+test('PostgresSettlementStore preserves ordering and status updates', async () => {
+  const { pool, settlementStore } = createPersistentStoreHarness();
+
+  try {
+    await settlementStore.create({
+      id: 'stl_older',
+      developerId: 'dev_1',
+      amount: 10,
+      status: 'pending',
+      tx_hash: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+    await settlementStore.create({
+      id: 'stl_newer',
+      developerId: 'dev_1',
+      amount: 25,
+      status: 'pending',
+      tx_hash: null,
+      created_at: '2026-01-02T00:00:00.000Z',
+    });
+
+    await settlementStore.updateStatus('stl_newer', 'completed', 'stellar-tx-1');
+
+    const settlements = await settlementStore.getDeveloperSettlements('dev_1');
+
+    expect(settlements.map((settlement) => settlement.id)).toEqual(['stl_newer', 'stl_older']);
+    expect(settlements[0]).toMatchObject({
+      status: 'completed',
+      tx_hash: 'stellar-tx-1',
+      amount: 25,
+    });
+  } finally {
+    await pool.end();
+  }
+});
+
+test('PostgresUsageStore records idempotently and marks events as settled', async () => {
+  const { pool, settlementStore, usageStore } = createPersistentStoreHarness();
+
+  try {
+    const firstInsert = await usageStore.record({
+      id: 'ignored-in-pg-store',
+      requestId: 'req-1',
+      apiKey: 'key-1',
+      apiKeyId: 'key-1',
+      apiId: 'api-1',
+      endpointId: 'endpoint-1',
+      userId: 'dev_1',
+      amountUsdc: 4.25,
+      statusCode: 200,
+      timestamp: '2026-02-01T10:00:00.000Z',
+    });
+
+    const duplicateInsert = await usageStore.record({
+      id: 'another-ignored-id',
+      requestId: 'req-1',
+      apiKey: 'key-1',
+      apiKeyId: 'key-1',
+      apiId: 'api-1',
+      endpointId: 'endpoint-1',
+      userId: 'dev_1',
+      amountUsdc: 999,
+      statusCode: 500,
+      timestamp: '2026-02-02T10:00:00.000Z',
+    });
+
+    const events = await usageStore.getEvents('key-1');
+    expect(firstInsert).toBe(true);
+    expect(duplicateInsert).toBe(false);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      requestId: 'req-1',
+      amountUsdc: 4.25,
+      statusCode: 200,
+      apiKey: 'key-1',
+      settlementId: undefined,
+    });
+
+    await settlementStore.create({
+      id: 'stl_1',
+      developerId: 'dev_1',
+      amount: 4.25,
+      status: 'pending',
+      tx_hash: null,
+      created_at: '2026-02-03T10:00:00.000Z',
+    });
+
+    await usageStore.markAsSettled([events[0]!.id], 'stl_1');
+
+    const unsettled = await usageStore.getUnsettledEvents();
+    const settledEvents = await usageStore.getEvents('key-1');
+
+    expect(unsettled).toEqual([]);
+    expect(settledEvents[0]?.settlementId).toBe('stl_1');
+  } finally {
+    await pool.end();
+  }
+});
+
+test('persistent stores survive new instances and keep developer revenue available after restart', async () => {
+  const harness = createPersistentStoreHarness();
+
+  try {
+    await harness.settlementStore.create({
+      id: 'stl_completed',
+      developerId: 'dev_restart',
+      amount: 8,
+      status: 'completed',
+      tx_hash: 'stellar-complete',
+      created_at: '2026-02-01T00:00:00.000Z',
+    });
+    await harness.settlementStore.create({
+      id: 'stl_pending',
+      developerId: 'dev_restart',
+      amount: 5,
+      status: 'pending',
+      tx_hash: null,
+      created_at: '2026-02-02T00:00:00.000Z',
+    });
+    await harness.usageStore.record({
+      id: 'restart-event',
+      requestId: 'req-restart',
+      apiKey: 'key-restart',
+      apiKeyId: 'key-restart',
+      apiId: 'api-restart',
+      endpointId: 'endpoint-restart',
+      userId: 'dev_restart',
+      amountUsdc: 3,
+      statusCode: 200,
+      timestamp: '2026-02-03T00:00:00.000Z',
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api/developers', createDeveloperRouter({
+      settlementStore: createPostgresSettlementStore(harness.pool),
+      usageStore: createPostgresUsageStore(harness.pool),
+    }));
+    app.use(errorHandler);
+
+    const res = await request(app)
+      .get('/api/developers/revenue')
+      .set('x-user-id', 'dev_restart');
+
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toEqual({
+      total_earned: 16,
+      pending: 5,
+      available_to_withdraw: 3,
+    });
+    expect(res.body.settlements.map((settlement: { id: string }) => settlement.id)).toEqual([
+      'stl_pending',
+      'stl_completed',
+    ]);
+  } finally {
+    await harness.pool.end();
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,12 @@ import { createGatewayRouter } from './routes/gatewayRoutes.js';
 import { createProxyRouter } from './routes/proxyRoutes.js';
 import { createBillingService } from './services/billingService.js';
 import { createRateLimiter } from './services/rateLimiter.js';
-import { createUsageStore } from './services/usageStore.js';
-import { createSettlementStore } from './services/settlementStore.js';
+import { createPostgresUsageStore } from './services/usageStore.js';
+import { createPostgresSettlementStore } from './services/settlementStore.js';
 import { createApiRegistry } from './data/apiRegistry.js';
 import { ApiKey } from './types/gateway.js';
 import { config } from './config/index.js';
+import { pool } from './db.js';
 
 // Helper for Jest/CommonJS compat
 const isDirectExecution = process.argv[1] && (process.argv[1].endsWith('index.ts') || process.argv[1].endsWith('index.js'));
@@ -117,8 +118,8 @@ if (isDirectExecution) {
 
   const billing = createBillingService(MOCK_DEVELOPER_BALANCES);
   const rateLimiter = createRateLimiter(5, 60_000); // 5 reqs per minute
-  const usageStore = createUsageStore();
-  const settlementStore = createSettlementStore();
+  const usageStore = createPostgresUsageStore(pool);
+  const settlementStore = createPostgresSettlementStore(pool);
   const registry = createApiRegistry();
 
   const apiKeys = new Map<string, ApiKey>([

--- a/src/routes/developerRoutes.ts
+++ b/src/routes/developerRoutes.ts
@@ -73,7 +73,7 @@ export function createDeveloperRouter(deps: DeveloperRoutesDeps): Router {
   router.get('/revenue', 
     requireAuth, 
     validate({ query: revenueQuerySchema }), 
-    (req: Request, res: Response<unknown, AuthenticatedLocals>) => {
+    async (req: Request, res: Response<unknown, AuthenticatedLocals>) => {
       const user = res.locals.authenticatedUser;
       if (!user) {
         // Fallback for direct testing mock headers if they bypassed standard gateway structure but still need requireAuth defaults
@@ -91,7 +91,7 @@ export function createDeveloperRouter(deps: DeveloperRoutesDeps): Router {
       }
 
     // Fetch settlements
-    const allSettlements = settlementStore.getDeveloperSettlements(developerId);
+    const allSettlements = await settlementStore.getDeveloperSettlements(developerId);
     const settlements = allSettlements.slice(offset, offset + limit);
     const total = allSettlements.length;
 
@@ -105,7 +105,7 @@ export function createDeveloperRouter(deps: DeveloperRoutesDeps): Router {
       .reduce((sum, s) => sum + s.amount, 0);
 
     // Get unsettled usage to calculate total earned
-    const unsettledEvents = usageStore.getUnsettledEvents().filter((e) => e.userId === developerId);
+    const unsettledEvents = (await usageStore.getUnsettledEvents()).filter((e) => e.userId === developerId);
     const unsettledRevenue = unsettledEvents.reduce((sum, e) => sum + e.amountUsdc, 0);
 
     const totalEarned = completedTotal + unsettledRevenue + pendingTotal;

--- a/src/routes/gatewayRoutes.ts
+++ b/src/routes/gatewayRoutes.ts
@@ -130,7 +130,7 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
           }
         }
 
-        usageStore.record({
+        await usageStore.record({
           id: randomUUID(),
           requestId,
           apiKey: apiKeyHeader,

--- a/src/routes/proxyRoutes.ts
+++ b/src/routes/proxyRoutes.ts
@@ -211,25 +211,31 @@ export function createProxyRouter(deps: ProxyDeps): Router {
       // 8. Record usage & deduct billing (Non-blocking background task)
       if (config.recordableStatuses(upstreamStatus)) {
         setImmediate(() => {
-          const recorded = usageStore.record({
-            id: randomUUID(), // ID of the usage event itself
-            requestId,        // Idempotency key
-            apiKey: apiKeyHeader,
-            apiKeyId: keyRecord.id,
-            apiId: String(apiEntry.id),
-            endpointId: endpoint.endpointId,
-            userId: keyRecord.userId,
-            amountUsdc: endpoint.priceUsdc,
-            statusCode: upstreamStatus,
-            timestamp: new Date().toISOString(),
-          });
+          void (async () => {
+            try {
+              const recorded = await usageStore.record({
+                id: randomUUID(), // ID of the usage event itself
+                requestId,        // Idempotency key
+                apiKey: apiKeyHeader,
+                apiKeyId: keyRecord.id,
+                apiId: String(apiEntry.id),
+                endpointId: endpoint.endpointId,
+                userId: keyRecord.userId,
+                amountUsdc: endpoint.priceUsdc,
+                statusCode: upstreamStatus,
+                timestamp: new Date().toISOString(),
+              });
 
-          // Only deduct billing if we haven't processed this requestId before
-          if (recorded && endpoint.priceUsdc > 0) {
-            billing.deductCredit(keyRecord.userId, endpoint.priceUsdc).catch((err) => {
-              console.error('Background billing deduction failed:', err);
-            });
-          }
+              // Only deduct billing if we haven't processed this requestId before
+              if (recorded && endpoint.priceUsdc > 0) {
+                billing.deductCredit(keyRecord.userId, endpoint.priceUsdc).catch((err) => {
+                  console.error('Background billing deduction failed:', err);
+                });
+              }
+            } catch (err) {
+              console.error('Background usage recording failed:', err);
+            }
+          })();
         });
       }
     } catch (error) {

--- a/src/services/revenueSettlementService.ts
+++ b/src/services/revenueSettlementService.ts
@@ -45,7 +45,7 @@ export class RevenueSettlementService {
   }
 
   private async runBatchOnce(): Promise<{ processed: number; settledAmount: number; errors: number }> {
-    const unsettled = this.usageStore.getUnsettledEvents();
+    const unsettled = await this.usageStore.getUnsettledEvents();
     if (unsettled.length === 0) {
       return { processed: 0, settledAmount: 0, errors: 0 };
     }
@@ -100,7 +100,7 @@ export class RevenueSettlementService {
         created_at: new Date().toISOString(),
       };
       try {
-        this.settlementStore.create(settlement);
+        await this.settlementStore.create(settlement);
       } catch (error) {
         errors++;
         console.error(
@@ -127,38 +127,38 @@ export class RevenueSettlementService {
       // 3. Update settlement status and events
       if (result.success && result.txHash) {
         try {
-          this.settlementStore.updateStatus(settlementId, 'completed', result.txHash);
-          this.usageStore.markAsSettled(eventIds, settlementId);
+          await this.settlementStore.updateStatus(settlementId, 'completed', result.txHash);
+          await this.usageStore.markAsSettled(eventIds, settlementId);
 
           processed += events.length;
           settledAmount += totalAmount;
         } catch (error) {
           errors++;
-          this.recordFailedSettlement(
-            settlementId,
-            developerId,
-            `Finalization failed after payout: ${this.getErrorMessage(error)}`,
+        await this.recordFailedSettlement(
+          settlementId,
+          developerId,
+          `Finalization failed after payout: ${this.getErrorMessage(error)}`,
             true,
           );
         }
       } else {
         // Failed: record failure, do NOT mark events as settled so they retry next batch
         errors++;
-        this.recordFailedSettlement(settlementId, developerId, result.error);
+        await this.recordFailedSettlement(settlementId, developerId, result.error);
       }
     }
 
     return { processed, settledAmount, errors };
   }
 
-  private recordFailedSettlement(
+  private async recordFailedSettlement(
     settlementId: string,
     developerId: string,
     errorMessage?: string,
     clearTxHash = false,
-  ): void {
+  ): Promise<void> {
     try {
-      this.settlementStore.updateStatus(
+      await this.settlementStore.updateStatus(
         settlementId,
         'failed',
         clearTxHash ? null : undefined,

--- a/src/services/settlementStore.ts
+++ b/src/services/settlementStore.ts
@@ -32,3 +32,104 @@ export class InMemorySettlementStore implements SettlementStore {
 export function createSettlementStore(): InMemorySettlementStore {
   return new InMemorySettlementStore();
 }
+
+interface SettlementStoreRow {
+  external_id: string;
+  developer_id: string;
+  amount_usdc: string | number;
+  status: Settlement['status'];
+  stellar_tx_hash: string | null;
+  created_at: Date | string;
+}
+
+export interface SettlementStoreQueryable {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+const toNumber = (value: string | number): number =>
+  typeof value === 'number' ? value : Number(value);
+
+const mapSettlementRow = (row: SettlementStoreRow): Settlement => ({
+  id: row.external_id,
+  developerId: row.developer_id,
+  amount: toNumber(row.amount_usdc),
+  status: row.status,
+  tx_hash: row.stellar_tx_hash,
+  created_at: row.created_at instanceof Date ? row.created_at.toISOString() : new Date(row.created_at).toISOString(),
+});
+
+export class PostgresSettlementStore implements SettlementStore {
+  constructor(private readonly db: SettlementStoreQueryable) {}
+
+  async create(settlement: Settlement): Promise<void> {
+    await this.db.query(
+      `
+        INSERT INTO settlements (
+          external_id,
+          developer_id,
+          amount_usdc,
+          stellar_tx_hash,
+          status,
+          created_at,
+          completed_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+      `,
+      [
+        settlement.id,
+        settlement.developerId,
+        settlement.amount,
+        settlement.tx_hash,
+        settlement.status,
+        settlement.created_at,
+        settlement.status === 'completed' ? settlement.created_at : null,
+      ],
+    );
+  }
+
+  async updateStatus(id: string, status: Settlement['status'], txHash?: string | null): Promise<void> {
+    const setClauses = ['status = $2'];
+    const params: unknown[] = [id, status];
+
+    if (txHash !== undefined) {
+      params.push(txHash);
+      setClauses.push(`stellar_tx_hash = $${params.length}`);
+    }
+
+    params.push(status === 'completed' ? new Date() : null);
+    setClauses.push(`completed_at = $${params.length}`);
+
+    await this.db.query(
+      `
+        UPDATE settlements
+        SET ${setClauses.join(', ')}
+        WHERE external_id = $1
+      `,
+      params,
+    );
+  }
+
+  async getDeveloperSettlements(developerId: string): Promise<Settlement[]> {
+    const result = await this.db.query<SettlementStoreRow>(
+      `
+        SELECT
+          external_id,
+          developer_id,
+          amount_usdc,
+          status,
+          stellar_tx_hash,
+          created_at
+        FROM settlements
+        WHERE developer_id = $1
+        ORDER BY created_at DESC, id DESC
+      `,
+      [developerId],
+    );
+
+    return result.rows.map(mapSettlementRow);
+  }
+}
+
+export function createPostgresSettlementStore(db: SettlementStoreQueryable): PostgresSettlementStore {
+  return new PostgresSettlementStore(db);
+}

--- a/src/services/usageStore.ts
+++ b/src/services/usageStore.ts
@@ -58,3 +58,222 @@ export class InMemoryUsageStore implements UsageStore {
 export function createUsageStore(): InMemoryUsageStore {
   return new InMemoryUsageStore();
 }
+
+interface UsageStoreClient {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
+  release(): void;
+}
+
+export interface UsageStoreQueryable {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
+  connect(): Promise<UsageStoreClient>;
+}
+
+interface UsageEventRow {
+  id: string | number;
+  request_id: string;
+  api_key: string | null;
+  api_key_id: string;
+  api_id: string;
+  endpoint_id: string;
+  user_id: string;
+  amount_usdc: string | number;
+  status_code: number;
+  created_at: Date | string;
+  settlement_external_id: string | null;
+}
+
+const toNumber = (value: string | number): number =>
+  typeof value === 'number' ? value : Number(value);
+
+const mapUsageEventRow = (row: UsageEventRow): UsageEvent => ({
+  id: String(row.id),
+  requestId: row.request_id,
+  apiKey: row.api_key ?? row.api_key_id,
+  apiKeyId: row.api_key_id,
+  apiId: row.api_id,
+  endpointId: row.endpoint_id,
+  userId: row.user_id,
+  amountUsdc: toNumber(row.amount_usdc),
+  statusCode: row.status_code,
+  timestamp: row.created_at instanceof Date ? row.created_at.toISOString() : new Date(row.created_at).toISOString(),
+  settlementId: row.settlement_external_id ?? undefined,
+});
+
+const usageEventSelect = `
+  SELECT
+    ue.id,
+    ue.request_id,
+    ue.api_key,
+    ue.api_key_id,
+    ue.api_id,
+    ue.endpoint_id,
+    rl.developer_id AS user_id,
+    ue.amount_usdc,
+    ue.status_code,
+    ue.created_at,
+    s.external_id AS settlement_external_id
+  FROM usage_events ue
+  INNER JOIN revenue_ledger rl
+    ON rl.usage_event_id = ue.id
+  LEFT JOIN settlements s
+    ON s.id = rl.settlement_id
+`;
+
+export class PostgresUsageStore implements UsageStore {
+  constructor(private readonly db: UsageStoreQueryable) {}
+
+  async record(event: UsageEvent): Promise<boolean> {
+    if (await this.hasEvent(event.requestId)) {
+      return false;
+    }
+
+    const client = await this.db.connect();
+
+    try {
+      await client.query('BEGIN');
+
+      const insertResult = await client.query<{ id: string | number }>(
+        `
+          INSERT INTO usage_events (
+            user_id,
+            api_id,
+            endpoint_id,
+            api_key_id,
+            api_key,
+            amount_usdc,
+            request_id,
+            status_code,
+            created_at
+          )
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+          ON CONFLICT (request_id) DO NOTHING
+          RETURNING id
+        `,
+        [
+          event.userId,
+          event.apiId,
+          event.endpointId,
+          event.apiKeyId,
+          event.apiKey,
+          event.amountUsdc,
+          event.requestId,
+          event.statusCode,
+          event.timestamp,
+        ],
+      );
+
+      const inserted = insertResult.rows[0];
+      if (!inserted) {
+        await client.query('ROLLBACK');
+        return false;
+      }
+
+      await client.query(
+        `
+          INSERT INTO revenue_ledger (
+            api_id,
+            developer_id,
+            amount_usdc,
+            usage_event_id,
+            created_at
+          )
+          VALUES ($1, $2, $3, $4, $5)
+          ON CONFLICT (usage_event_id) DO NOTHING
+        `,
+        [
+          event.apiId,
+          event.userId,
+          event.amountUsdc,
+          inserted.id,
+          event.timestamp,
+        ],
+      );
+
+      await client.query('COMMIT');
+      return true;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async hasEvent(requestId: string): Promise<boolean> {
+    const result = await this.db.query<{ exists: number }>(
+      'SELECT 1 AS exists FROM usage_events WHERE request_id = $1 LIMIT 1',
+      [requestId],
+    );
+    return Boolean(result.rows[0]);
+  }
+
+  async getEvents(apiKey?: string): Promise<UsageEvent[]> {
+    const params: unknown[] = [];
+    const where = apiKey ? 'WHERE ue.api_key = $1 OR ue.api_key_id = $1' : '';
+    if (apiKey) {
+      params.push(apiKey);
+    }
+
+    const result = await this.db.query<UsageEventRow>(
+      `
+        ${usageEventSelect}
+        ${where}
+        ORDER BY ue.created_at ASC, ue.id ASC
+      `,
+      params,
+    );
+
+    return result.rows.map(mapUsageEventRow);
+  }
+
+  async getUnsettledEvents(): Promise<UsageEvent[]> {
+    const result = await this.db.query<UsageEventRow>(
+      `
+        ${usageEventSelect}
+        WHERE rl.settlement_id IS NULL
+          AND ue.amount_usdc > 0
+        ORDER BY ue.created_at ASC, ue.id ASC
+      `,
+    );
+
+    return result.rows.map(mapUsageEventRow);
+  }
+
+  async markAsSettled(eventIds: string[], settlementId: string): Promise<void> {
+    if (eventIds.length === 0) {
+      return;
+    }
+
+    const settlementResult = await this.db.query<{ id: string | number }>(
+      `
+        SELECT id
+        FROM settlements
+        WHERE external_id = $1
+        LIMIT 1
+      `,
+      [settlementId],
+    );
+
+    const persistedSettlementId = settlementResult.rows[0]?.id;
+    if (persistedSettlementId === undefined) {
+      return;
+    }
+
+    const eventIdParams = eventIds.map((id) => Number(id));
+    const placeholders = eventIdParams.map((_, index) => `$${index + 2}`).join(', ');
+
+    await this.db.query(
+      `
+        UPDATE revenue_ledger
+        SET settlement_id = $1
+        WHERE usage_event_id IN (${placeholders})
+      `,
+      [persistedSettlementId, ...eventIdParams],
+    );
+  }
+}
+
+export function createPostgresUsageStore(db: UsageStoreQueryable): PostgresUsageStore {
+  return new PostgresUsageStore(db);
+}

--- a/src/types/awaitable.ts
+++ b/src/types/awaitable.ts
@@ -1,0 +1,1 @@
+export type Awaitable<T> = T | Promise<T>;

--- a/src/types/developer.ts
+++ b/src/types/developer.ts
@@ -1,3 +1,5 @@
+import type { Awaitable } from './awaitable.js';
+
 export interface Settlement {
   id: string;
   developerId: string; // the dev receiving the payout
@@ -24,7 +26,7 @@ export interface DeveloperRevenueResponse {
 }
 
 export interface SettlementStore {
-  create(settlement: Settlement): void;
-  updateStatus(id: string, status: Settlement['status'], txHash?: string | null): void;
-  getDeveloperSettlements(developerId: string): Settlement[];
+  create(settlement: Settlement): Awaitable<void>;
+  updateStatus(id: string, status: Settlement['status'], txHash?: string | null): Awaitable<void>;
+  getDeveloperSettlements(developerId: string): Awaitable<Settlement[]>;
 }

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from 'express';
+import type { Awaitable } from './awaitable.js';
 
 /** Represents a registered API key mapping to a developer and API. */
 export interface ApiKey {
@@ -58,11 +59,11 @@ export interface RateLimiter {
 /** Interface for recording and querying usage events. */
 export interface UsageStore {
   /** Record an event. Returns false if requestId already exists (idempotent). */
-  record(event: UsageEvent): boolean;
-  hasEvent(requestId: string): boolean;
-  getEvents(apiKey?: string): UsageEvent[];
-  getUnsettledEvents(): UsageEvent[];
-  markAsSettled(eventIds: string[], settlementId: string): void;
+  record(event: UsageEvent): Awaitable<boolean>;
+  hasEvent(requestId: string): Awaitable<boolean>;
+  getEvents(apiKey?: string): Awaitable<UsageEvent[]>;
+  getUnsettledEvents(): Awaitable<UsageEvent[]>;
+  markAsSettled(eventIds: string[], settlementId: string): Awaitable<void>;
 }
 
 /** A registered API with its upstream base URL and endpoint pricing. */


### PR DESCRIPTION
## Overview
This PR persists developer settlement and usage revenue data to PostgreSQL so `/api/developers/revenue` survives process restarts and can scale beyond a single process. It adds PostgreSQL-backed `SettlementStore` and `UsageStore` implementations while keeping the in-memory stores available for unit tests.

## Related Issue
Closes #307

## Changes

### ⚙️ Persistent Revenue Stores
- **[MODIFY]** `src/services/settlementStore.ts`
- Added `PostgresSettlementStore` backed by the `settlements` table.
- Preserved external settlement IDs via `settlements.external_id`.
- Kept newest-first settlement ordering and status update behavior aligned with the in-memory store.

- **[MODIFY]** `src/services/usageStore.ts`
- Added `PostgresUsageStore` backed by `usage_events` and `revenue_ledger`.
- Persisted unsettled usage so developer revenue survives restarts.
- Preserved idempotent usage recording by `requestId` and settlement linking.

- **[ADD]** `src/types/awaitable.ts`
- Added a shared `Awaitable<T>` helper so store contracts support both in-memory and PostgreSQL implementations.

- **[MODIFY]** `src/types/developer.ts`
- Updated `SettlementStore` to support awaitable persistence methods.

- **[MODIFY]** `src/types/gateway.ts`
- Updated `UsageStore` to support awaitable persistence methods.

### 🌐 Runtime Wiring
- **[MODIFY]** `src/index.ts`
- Switched the runtime app wiring from in-memory stores to PostgreSQL-backed stores.

- **[MODIFY]** `src/routes/developerRoutes.ts`
- Updated revenue reads to await persistent store calls.
- Preserved the revenue invariant: `total_earned = completed + pending + usage`.

- **[MODIFY]** `src/services/revenueSettlementService.ts`
- Updated settlement batch processing to work with the persistent async stores.

- **[MODIFY]** `src/routes/gatewayRoutes.ts`
- Awaited usage persistence on the legacy gateway path.

- **[MODIFY]** `src/routes/proxyRoutes.ts`
- Updated background metering to await persistent usage writes safely.

### 🧪 Tests
- **[ADD]** `src/__tests__/persistentStores.test.ts`
- Added `pg-mem` coverage for persisted settlements.
- Added idempotent persisted usage coverage.
- Added settlement-linking coverage.
- Added a restart-style developer revenue check using fresh store instances against the same database.

- **[KEEP]** `src/__tests__/settlementStore.test.ts`
- Kept the in-memory store coverage intact for unit-test workflows.

### 🔧 Database and Docs
- **[ADD]** `migrations/005_add_persistent_store_columns.sql`
- Added `settlements.external_id` to preserve app-facing settlement IDs.
- Added `usage_events.api_key` and `usage_events.status_code` needed by the persistent usage store.
- Added a unique `revenue_ledger(usage_event_id)` index for safe idempotent writes.

- **[MODIFY]** `README.md`
- Documented the new persistent revenue store behavior and migration requirements.

- **[MODIFY]** `SETTLEMENT_STORE_DOCUMENTATION.md`
- Documented the PostgreSQL-backed persistence path and revenue invariants.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Revenue summary invariants hold against persisted data | ✅ |
| Data survives a process restart | ✅ |
| In-memory stores remain usable in unit tests | ✅ |
| PostgreSQL-backed settlement store is implemented | ✅ |
| PostgreSQL-backed usage store is implemented | ✅ |
| Targeted tests pass successfully | ✅ |
| Typecheck passes successfully | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Run the targeted settlement and persistence tests
npm test -- src/__tests__/settlementStore.test.ts src/__tests__/persistentStores.test.ts

# 3. Verify TypeScript types
npm run typecheck

# 4. Optional: inspect the changed files
git diff -- src/services/settlementStore.ts src/services/usageStore.ts src/routes/developerRoutes.ts src/services/revenueSettlementService.ts src/index.ts migrations/005_add_persistent_store_columns.sql
```

## Notes
- I also probed the existing `src/__tests__/developerRevenue.test.ts` suite while working on this issue and found unrelated pre-existing failures around the unauthorized response body shape and very high decimal precision expectations. I left those unchanged to keep this PR focused on issue `#307`.

## Screenshots

### ✅ Targeted persistence tests pass
A screenshot of:

```bash
npm test -- src/__tests__/settlementStore.test.ts src/__tests__/persistentStores.test.ts
```
<img width="629" height="275" alt="image" src="https://github.com/user-attachments/assets/2ba4074d-749c-408a-90e2-ce8d4da8a537" />
### ✅ Typecheck passes
A screenshot of:

```bash
npm run typecheck
```
<img width="427" height="84" alt="image" src="https://github.com/user-attachments/assets/eb55c6f2-21f4-43dc-83f8-7a2470199b7c" />
