### PR TITLE
feat: reconcile pending settlements against Horizon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,8 @@ SOROBAN_BILLING_RPC_TIMEOUT_MS=5000
 HORIZON_ENABLED=false
 HORIZON_URL=https://horizon-testnet.stellar.org
 HORIZON_TIMEOUT=2000
+SETTLEMENT_STATUS_SYNC_INTERVAL_MS=60000
+SETTLEMENT_STATUS_SYNC_TIMEOUT_MS=5000
 
 # -----------------------------------------------------------------------------
 # Stellar / Soroban network selection

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ See [docs/gateway-api-key-auth.md](./docs/gateway-api-key-auth.md) for the full 
 - Read methods support time-bounded lookups by `userId` or `apiId`, plus aggregate totals for user spend and API revenue.
 - Amounts are handled as smallest-unit `bigint` values in application code, even though the backing column is named `amount_usdc`.
 
+## Settlement status sync
+
+- Successful payout submissions remain `pending` with a `tx_hash` until Horizon confirms the on-chain outcome.
+- A background settlement-status sync job polls the active network Horizon URL from `config.stellar.horizonUrl`.
+- Confirmed transactions transition settlements to `completed`, while unsuccessful or missing transactions transition them to `failed`.
+- Transient Horizon failures are retried with exponential backoff and do not flip settlement status if retries are exhausted.
+- `completed_at` is set only after Horizon confirms the transaction.
+
 ## Local setup
 
 1. **Prerequisites:** Node.js 18+
@@ -82,7 +90,7 @@ When refreshing it:
 1. Keep settlement IDs globally unique.
 2. Keep each settlement under the matching developer key and `developerId`.
 3. Use non-negative finite amounts and valid ISO-8601 `created_at` timestamps.
-4. Keep `tx_hash` as `null` for `pending` settlements and non-empty for `completed` settlements.
+4. Keep `tx_hash` as either `null` or a non-empty transaction hash for `pending` settlements, and non-empty for `completed` settlements.
 5. Update usage revenue so fixture summaries stay aligned with the live route semantics: `total_earned = completed + pending + usage` and `available_to_withdraw = usage`.
 
 Run `npm run lint`, `npm run typecheck`, and `npm test` after editing the fixture.
@@ -144,6 +152,8 @@ The app validates all environment variables at startup using [Zod](https://zod.d
 | `HORIZON_ENABLED` | No | `false` | Enable Horizon health check |
 | `HORIZON_URL` | If `HORIZON_ENABLED=true` | — | Horizon endpoint URL |
 | `HORIZON_TIMEOUT` | No | `2000` | Horizon timeout (ms) |
+| `SETTLEMENT_STATUS_SYNC_INTERVAL_MS` | No | `60000` | Settlement-status sync polling interval (ms) |
+| `SETTLEMENT_STATUS_SYNC_TIMEOUT_MS` | No | `5000` | Per-request Horizon timeout for settlement sync (ms) |
 | `HEALTH_CHECK_DB_TIMEOUT` | No | `2000` | DB health check timeout (ms) |
 | `APP_VERSION` | No | `1.0.0` | Reported in health check responses |
 | `LOG_LEVEL` | No | `info` | `trace` / `debug` / `info` / `warn` / `error` / `fatal` |
@@ -184,6 +194,8 @@ STELLAR_MAINNET_SETTLEMENT_CONTRACT_ID=CC...MAINNET_SETTLEMENT
 # Optional transaction builder overrides
 STELLAR_BASE_FEE=100
 STELLAR_TRANSACTION_TIMEOUT=300
+SETTLEMENT_STATUS_SYNC_INTERVAL_MS=60000
+SETTLEMENT_STATUS_SYNC_TIMEOUT_MS=5000
 ```
 
 Notes:

--- a/src/__tests__/revenueSettlementService.test.ts
+++ b/src/__tests__/revenueSettlementService.test.ts
@@ -67,8 +67,9 @@ describe('RevenueSettlementService', () => {
     expect(settlements[0]).toMatchObject({
       developerId: 'dev_1',
       amount: 6,
-      status: 'completed',
+      status: 'pending',
       tx_hash: '0xmocktx_dev_1',
+      completed_at: null,
     });
 
     expect(usageStore.getUnsettledEvents()).toHaveLength(0);
@@ -168,8 +169,9 @@ describe('RevenueSettlementService', () => {
     expect(result).toEqual({ processed: 1, settledAmount: 7, errors: 1 });
     expect(settlementStore.getDeveloperSettlements('dev_1')).toHaveLength(0);
     expect(settlementStore.getDeveloperSettlements('dev_2')[0]).toMatchObject({
-      status: 'completed',
+      status: 'pending',
       tx_hash: '0xmocktx_dev_2',
+      completed_at: null,
     });
     expect(usageStore.getUnsettledEvents().map((event) => event.id)).toEqual(['e1']);
 
@@ -233,12 +235,177 @@ describe('RevenueSettlementService', () => {
       tx_hash: null,
     });
     expect(settlementStore.getDeveloperSettlements('dev_2')[0]).toMatchObject({
-      status: 'completed',
+      status: 'pending',
       tx_hash: '0xmocktx_dev_2',
+      completed_at: null,
     });
     expect(usageStore.getUnsettledEvents().map((event) => event.id)).toEqual(['e1']);
 
     updateStatusSpy.mockRestore();
+  });
+
+  it('reconciles pending settlements to completed when Horizon confirms the transaction', async () => {
+    settlementStore.create({
+      id: 'stl_1',
+      developerId: 'dev_1',
+      amount: 12,
+      status: 'pending',
+      tx_hash: 'tx-confirmed',
+      created_at: '2026-04-01T00:00:00.000Z',
+    });
+
+    service = new RevenueSettlementService(usageStore, settlementStore, apiRegistry, client, {
+      fetchImpl: jest.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ successful: true }),
+      })) as unknown as typeof fetch,
+      horizonUrl: 'https://horizon-testnet.stellar.org/',
+    });
+
+    const result = await service.reconcilePendingSettlements();
+
+    expect(result).toEqual({ checked: 1, completed: 1, failed: 0, errors: 0 });
+    expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
+      status: 'completed',
+      tx_hash: 'tx-confirmed',
+    });
+    expect(settlementStore.getDeveloperSettlements('dev_1')[0]?.completed_at).toBeTruthy();
+  });
+
+  it('reconciles pending settlements to failed when Horizon reports an unsuccessful transaction', async () => {
+    settlementStore.create({
+      id: 'stl_1',
+      developerId: 'dev_1',
+      amount: 12,
+      status: 'pending',
+      tx_hash: 'tx-failed',
+      created_at: '2026-04-01T00:00:00.000Z',
+    });
+
+    service = new RevenueSettlementService(usageStore, settlementStore, apiRegistry, client, {
+      fetchImpl: jest.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ successful: false }),
+      })) as unknown as typeof fetch,
+      horizonUrl: 'https://horizon-testnet.stellar.org/',
+    });
+
+    const result = await service.reconcilePendingSettlements();
+
+    expect(result).toEqual({ checked: 1, completed: 0, failed: 1, errors: 0 });
+    expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
+      status: 'failed',
+      tx_hash: 'tx-failed',
+      completed_at: null,
+    });
+  });
+
+  it('treats missing Horizon transactions as failed settlements', async () => {
+    settlementStore.create({
+      id: 'stl_1',
+      developerId: 'dev_1',
+      amount: 12,
+      status: 'pending',
+      tx_hash: 'tx-missing',
+      created_at: '2026-04-01T00:00:00.000Z',
+    });
+
+    service = new RevenueSettlementService(usageStore, settlementStore, apiRegistry, client, {
+      fetchImpl: jest.fn(async () => ({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      })) as unknown as typeof fetch,
+      horizonUrl: 'https://horizon-testnet.stellar.org/',
+    });
+
+    const result = await service.reconcilePendingSettlements();
+
+    expect(result).toEqual({ checked: 1, completed: 0, failed: 1, errors: 0 });
+    expect(settlementStore.getDeveloperSettlements('dev_1')[0]?.status).toBe('failed');
+  });
+
+  it('retries transient Horizon errors with backoff and completes once Horizon succeeds', async () => {
+    settlementStore.create({
+      id: 'stl_1',
+      developerId: 'dev_1',
+      amount: 12,
+      status: 'pending',
+      tx_hash: 'tx-retry',
+      created_at: '2026-04-01T00:00:00.000Z',
+    });
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ successful: true }),
+      });
+
+    const setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation(((fn: (...args: unknown[]) => void) => {
+        fn();
+        return 0 as unknown as NodeJS.Timeout;
+      }) as typeof setTimeout);
+
+    service = new RevenueSettlementService(usageStore, settlementStore, apiRegistry, client, {
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      horizonUrl: 'https://horizon-testnet.stellar.org/',
+      horizonMaxRetries: 1,
+      horizonRetryBaseDelayMs: 1,
+    });
+
+    const result = await service.reconcilePendingSettlements();
+
+    expect(result).toEqual({ checked: 1, completed: 1, failed: 0, errors: 0 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('does not flip settlement status when Horizon transient errors exhaust retries', async () => {
+    settlementStore.create({
+      id: 'stl_1',
+      developerId: 'dev_1',
+      amount: 12,
+      status: 'pending',
+      tx_hash: 'tx-still-pending',
+      created_at: '2026-04-01T00:00:00.000Z',
+    });
+
+    const setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation(((fn: (...args: unknown[]) => void) => {
+        fn();
+        return 0 as unknown as NodeJS.Timeout;
+      }) as typeof setTimeout);
+
+    service = new RevenueSettlementService(usageStore, settlementStore, apiRegistry, client, {
+      fetchImpl: jest.fn(async () => {
+        throw new TypeError('fetch failed');
+      }) as unknown as typeof fetch,
+      horizonUrl: 'https://horizon-testnet.stellar.org/',
+      horizonMaxRetries: 1,
+      horizonRetryBaseDelayMs: 1,
+    });
+
+    const result = await service.reconcilePendingSettlements();
+
+    expect(result).toEqual({ checked: 1, completed: 0, failed: 0, errors: 1 });
+    expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
+      status: 'pending',
+      tx_hash: 'tx-still-pending',
+      completed_at: null,
+    });
+    setTimeoutSpy.mockRestore();
   });
 });
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -57,6 +57,8 @@ export const envSchema = z
       .default(false),
     HORIZON_URL: z.string().url().optional(),
     HORIZON_TIMEOUT: z.coerce.number().default(2_000),
+    SETTLEMENT_STATUS_SYNC_INTERVAL_MS: z.coerce.number().int().positive().default(60_000),
+    SETTLEMENT_STATUS_SYNC_TIMEOUT_MS: z.coerce.number().int().positive().default(5_000),
 
     // Stellar network configuration
     STELLAR_NETWORK: stellarNetworkSchema.optional(),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -134,6 +134,11 @@ export const config = {
         }
       : undefined,
 
+  settlementSync: {
+    intervalMs: env.SETTLEMENT_STATUS_SYNC_INTERVAL_MS,
+    timeoutMs: env.SETTLEMENT_STATUS_SYNC_TIMEOUT_MS,
+  },
+
   stellar: {
     network: selectedNetwork,
     baseFee: String(env.STELLAR_BASE_FEE),

--- a/src/data/developerData.ts
+++ b/src/data/developerData.ts
@@ -100,8 +100,12 @@ export function assertDeveloperDataIntegrity(): void {
         throw new Error(`Settlement ${settlement.id} has invalid created_at ${settlement.created_at}.`);
       }
 
-      if (settlement.status === 'pending' && settlement.tx_hash !== null) {
-        throw new Error(`Pending settlement ${settlement.id} must not include a transaction hash.`);
+      if (
+        settlement.status === 'pending' &&
+        settlement.tx_hash !== null &&
+        settlement.tx_hash.trim().length === 0
+      ) {
+        throw new Error(`Pending settlement ${settlement.id} cannot use an empty transaction hash.`);
       }
 
       if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ import { createBillingService } from './services/billingService.js';
 import { createRateLimiter } from './services/rateLimiter.js';
 import { createUsageStore } from './services/usageStore.js';
 import { createSettlementStore } from './services/settlementStore.js';
+import { RevenueSettlementService } from './services/revenueSettlementService.js';
+import { createSettlementStatusSyncJob } from './services/settlementStatusSyncJob.js';
 import { createApiRegistry } from './data/apiRegistry.js';
 import { ApiKey } from './types/gateway.js';
 import { config } from './config/index.js';
@@ -120,6 +122,23 @@ if (isDirectExecution) {
   const usageStore = createUsageStore();
   const settlementStore = createSettlementStore();
   const registry = createApiRegistry();
+  const revenueSettlementService = new RevenueSettlementService(
+    usageStore,
+    settlementStore,
+    registry,
+    {
+      distribute: async () => ({
+        success: false,
+        error: 'Runtime settlement distribution is not configured in this process',
+      }),
+    },
+    {
+      horizonRequestTimeoutMs: config.settlementSync.timeoutMs,
+    },
+  );
+  const settlementStatusSyncJob = createSettlementStatusSyncJob(revenueSettlementService, {
+    intervalMs: config.settlementSync.intervalMs,
+  });
 
   const apiKeys = new Map<string, ApiKey>([
     ['test-key-1', { key: 'test-key-1', developerId: 'dev_001', apiId: 'api_001' }],
@@ -165,6 +184,7 @@ if (isDirectExecution) {
   const PORT = config.port;
 
   const closeAllDataResources = async () => {
+    settlementStatusSyncJob.stop();
     await closeDb();
     await Promise.allSettled([
       closePgPool(),
@@ -177,6 +197,7 @@ if (isDirectExecution) {
   async function startServer() {
     try {
       await initializeDb();
+      settlementStatusSyncJob.start();
       
       const server = app.listen(PORT, () => {
         console.log(`Callora backend listening on http://localhost:${PORT}`);

--- a/src/services/revenueSettlementService.ts
+++ b/src/services/revenueSettlementService.ts
@@ -2,16 +2,33 @@ import { Settlement, SettlementStore } from '../types/developer.js';
 import { ApiRegistry, UsageEvent, UsageStore } from '../types/gateway.js';
 import { SorobanSettlementClient } from './sorobanSettlement.js';
 import { randomUUID } from 'node:crypto';
+import { config } from '../config/index.js';
+import {
+  RETRIABLE_HTTP_STATUSES,
+  TransientError,
+  isTransientNetworkError,
+  withRetry,
+} from '../lib/retry.js';
 
 export interface RevenueSettlementOptions {
   /** Minimum accumulated USDC to trigger a payout (default: 5.00) */
   minPayoutUsdc?: number;
   /** Maximum number of events to process per developer per batch (to avoid hitting transaction limits) */
   maxEventsPerBatch?: number;
+  horizonUrl?: string;
+  fetchImpl?: typeof fetch;
+  horizonRequestTimeoutMs?: number;
+  horizonMaxRetries?: number;
+  horizonRetryBaseDelayMs?: number;
+}
+
+interface HorizonTransactionResponse {
+  successful?: boolean;
 }
 
 export class RevenueSettlementService {
   private batchTail: Promise<void> = Promise.resolve();
+  private reconcileTail: Promise<void> = Promise.resolve();
 
   constructor(
     private usageStore: UsageStore,
@@ -127,7 +144,7 @@ export class RevenueSettlementService {
       // 3. Update settlement status and events
       if (result.success && result.txHash) {
         try {
-          this.settlementStore.updateStatus(settlementId, 'completed', result.txHash);
+          this.settlementStore.updateStatus(settlementId, 'pending', result.txHash);
           this.usageStore.markAsSettled(eventIds, settlementId);
 
           processed += events.length;
@@ -149,6 +166,110 @@ export class RevenueSettlementService {
     }
 
     return { processed, settledAmount, errors };
+  }
+
+  async reconcilePendingSettlements(): Promise<{
+    checked: number;
+    completed: number;
+    failed: number;
+    errors: number;
+  }> {
+    const previousRun = this.reconcileTail.catch(() => undefined);
+    let releaseRun!: () => void;
+    this.reconcileTail = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+
+    await previousRun;
+
+    try {
+      return await this.reconcilePendingSettlementsOnce();
+    } finally {
+      releaseRun();
+    }
+  }
+
+  private async reconcilePendingSettlementsOnce(): Promise<{
+    checked: number;
+    completed: number;
+    failed: number;
+    errors: number;
+  }> {
+    const pendingSettlements = this.settlementStore
+      .getPendingSettlements()
+      .filter((settlement) => Boolean(settlement.tx_hash));
+
+    let checked = 0;
+    let completed = 0;
+    let failed = 0;
+    let errors = 0;
+
+    for (const settlement of pendingSettlements) {
+      checked++;
+
+      try {
+        const horizonStatus = await this.checkSettlementTransaction(settlement.tx_hash!);
+
+        if (horizonStatus === 'completed') {
+          this.settlementStore.updateStatus(settlement.id, 'completed');
+          completed++;
+        } else if (horizonStatus === 'failed') {
+          this.settlementStore.updateStatus(settlement.id, 'failed');
+          failed++;
+        }
+      } catch (error) {
+        errors++;
+        console.error(
+          `Settlement ${settlement.id} could not be reconciled against Horizon:`,
+          this.getErrorMessage(error),
+        );
+      }
+    }
+
+    return { checked, completed, failed, errors };
+  }
+
+  private async checkSettlementTransaction(txHash: string): Promise<'completed' | 'failed'> {
+    const horizonUrl = this.options.horizonUrl ?? config.stellar.horizonUrl;
+    const requestTimeoutMs = this.options.horizonRequestTimeoutMs ?? config.settlementSync.timeoutMs;
+    const fetchImpl = this.options.fetchImpl ?? fetch;
+
+    const response = await withRetry(
+      async () => {
+        const url = new URL(`transactions/${encodeURIComponent(txHash)}`, horizonUrl).toString();
+        const res = await fetchImpl(url, {
+          headers: { accept: 'application/json' },
+          signal: AbortSignal.timeout(requestTimeoutMs),
+        });
+
+        if (RETRIABLE_HTTP_STATUSES.has(res.status)) {
+          throw new TransientError(`Horizon returned retriable status ${res.status}`);
+        }
+
+        if (res.status === 404) {
+          return 'failed' as const;
+        }
+
+        if (!res.ok) {
+          throw new Error(`Horizon returned non-success status ${res.status}`);
+        }
+
+        const body = (await res.json()) as HorizonTransactionResponse;
+        return body.successful === false ? 'failed' as const : 'completed' as const;
+      },
+      {
+        maxAttempts: (this.options.horizonMaxRetries ?? 3) + 1,
+        baseDelayMs: this.options.horizonRetryBaseDelayMs ?? 500,
+        shouldRetry: (error) => {
+          if (error instanceof DOMException && error.name === 'AbortError') {
+            return false;
+          }
+          return isTransientNetworkError(error);
+        },
+      },
+    );
+
+    return response;
   }
 
   private recordFailedSettlement(

--- a/src/services/settlementStatusSyncJob.ts
+++ b/src/services/settlementStatusSyncJob.ts
@@ -1,0 +1,55 @@
+import { RevenueSettlementService } from './revenueSettlementService.js';
+
+interface SettlementStatusSyncJobOptions {
+  intervalMs: number;
+  logger?: Pick<typeof console, 'error'>;
+}
+
+export interface SettlementStatusSyncJob {
+  start(): void;
+  stop(): void;
+}
+
+export function createSettlementStatusSyncJob(
+  service: RevenueSettlementService,
+  options: SettlementStatusSyncJobOptions,
+): SettlementStatusSyncJob {
+  const logger = options.logger ?? console;
+  let timer: NodeJS.Timeout | null = null;
+  let running = false;
+
+  const tick = async (): Promise<void> => {
+    if (running) {
+      return;
+    }
+
+    running = true;
+    try {
+      await service.reconcilePendingSettlements();
+    } catch (error) {
+      logger.error('Settlement status sync job failed:', error);
+    } finally {
+      running = false;
+    }
+  };
+
+  return {
+    start() {
+      if (timer) {
+        return;
+      }
+
+      timer = setInterval(() => {
+        void tick();
+      }, options.intervalMs);
+    },
+    stop() {
+      if (!timer) {
+        return;
+      }
+
+      clearInterval(timer);
+      timer = null;
+    },
+  };
+}

--- a/src/services/settlementStore.ts
+++ b/src/services/settlementStore.ts
@@ -4,7 +4,10 @@ export class InMemorySettlementStore implements SettlementStore {
   private settlements: Settlement[] = [];
 
   create(settlement: Settlement): void {
-    this.settlements.push(settlement);
+    this.settlements.push({
+      ...settlement,
+      completed_at: settlement.completed_at ?? null,
+    });
   }
 
   updateStatus(id: string, status: Settlement['status'], txHash?: string | null): void {
@@ -14,6 +17,7 @@ export class InMemorySettlementStore implements SettlementStore {
       if (txHash !== undefined) {
         s.tx_hash = txHash;
       }
+      s.completed_at = status === 'completed' ? new Date().toISOString() : null;
     }
   }
 
@@ -21,6 +25,12 @@ export class InMemorySettlementStore implements SettlementStore {
     return this.settlements
       .filter((s) => s.developerId === developerId)
       .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+  }
+
+  getPendingSettlements(): Settlement[] {
+    return this.settlements
+      .filter((s) => s.status === 'pending')
+      .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
   }
 
   /** Helper for tests */

--- a/src/types/developer.ts
+++ b/src/types/developer.ts
@@ -5,6 +5,7 @@ export interface Settlement {
   status: 'pending' | 'completed' | 'failed';
   tx_hash: string | null;
   created_at: string; // ISO-8601
+  completed_at?: string | null;
 }
 
 export interface RevenueSummary {
@@ -27,4 +28,5 @@ export interface SettlementStore {
   create(settlement: Settlement): void;
   updateStatus(id: string, status: Settlement['status'], txHash?: string | null): void;
   getDeveloperSettlements(developerId: string): Settlement[];
+  getPendingSettlements(): Settlement[];
 }

--- a/tests/integration/billing.test.ts
+++ b/tests/integration/billing.test.ts
@@ -1412,6 +1412,25 @@ class DatabaseSettlementStore implements SettlementStore {
   getDeveloperSettlements(developerId: string): Settlement[] {
     throw new Error("Not implemented for integration test");
   }
+
+  getPendingSettlements(): Settlement[] {
+    const result = this.db.public.query(`
+      SELECT id, developer_id, amount, status, tx_hash, created_at
+      FROM settlements
+      WHERE status = 'pending'
+      ORDER BY created_at ASC
+    `);
+
+    return result.rows.map((row: any) => ({
+      id: row.id,
+      developerId: row.developer_id,
+      amount: Number(row.amount),
+      status: row.status,
+      tx_hash: row.tx_hash,
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+      completed_at: null,
+    }));
+  }
 }
 
 class DatabaseApiRegistry implements ApiRegistry {


### PR DESCRIPTION
## Overview
This PR adds an on-chain settlement-status sync flow so pending developer payouts are reconciled against the configured Horizon network and eventually transition to `completed` or `failed`. It closes the payout loop by polling Horizon for each pending settlement `tx_hash`, retrying transient Horizon failures with backoff, and setting `completed_at` only after on-chain confirmation.

## Related Issue
Closes #310

## Changes

### ⚙️ Settlement Reconciliation
- **[MODIFY]** `src/services/revenueSettlementService.ts`
- Added `reconcilePendingSettlements()` to query pending settlements and reconcile each `tx_hash` against Horizon.
- Reused `withRetry(...)` from `src/lib/retry.ts` for transient Horizon failures.
- Updated payout flow so successful submission leaves settlements in `pending` with a transaction hash until confirmation.
- Ensured `completed_at` is set only when Horizon confirms the transaction.

- **[ADD]** `src/services/settlementStatusSyncJob.ts`
- Added a background sync job that periodically runs settlement reconciliation.
- Prevents overlapping reconciliation runs and logs failures without crashing the app.

### 🌐 Runtime Wiring
- **[MODIFY]** `src/index.ts`
- Wired the settlement-status sync job into app startup.
- Ensured the job stops during graceful shutdown.
- Reused the active `STELLAR_NETWORK` Horizon configuration via `config.stellar.horizonUrl`.

### 🧱 Store and Model Updates
- **[MODIFY]** `src/types/developer.ts`
- Added `completed_at` to the settlement shape.
- Extended `SettlementStore` with `getPendingSettlements()` for reconciliation.

- **[MODIFY]** `src/services/settlementStore.ts`
- Added pending-settlement reads to the in-memory store.
- Updated status transitions so `completed_at` is populated only on confirmed completion.

### 🧪 Tests
- **[MODIFY]** `src/__tests__/revenueSettlementService.test.ts`
- Added coverage for Horizon-confirmed settlement completion.
- Added coverage for unsuccessful Horizon transactions.
- Added coverage for missing Horizon transactions.
- Added coverage for retryable Horizon errors succeeding after backoff.
- Added coverage for exhausted transient Horizon errors leaving status unchanged.

- **[MODIFY]** `tests/integration/billing.test.ts`
- Updated the integration-test `SettlementStore` helper to support pending-settlement queries.

### 🔧 Configuration and Docs
- **[MODIFY]** `src/config/env.ts`
- Added environment validation for settlement sync interval and request timeout.

- **[MODIFY]** `src/config/index.ts`
- Added settlement sync config values to the exported runtime config.

- **[MODIFY]** `.env.example`
- Added `SETTLEMENT_STATUS_SYNC_INTERVAL_MS`.
- Added `SETTLEMENT_STATUS_SYNC_TIMEOUT_MS`.

- **[MODIFY]** `README.md`
- Documented the new Horizon-based settlement reconciliation flow.
- Documented the new environment variables and the pending-with-tx-hash lifecycle.

- **[MODIFY]** `src/data/developerData.ts`
- Updated fixture validation to allow pending settlements with a non-empty transaction hash after payout submission.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Pending settlements transition to completed/failed based on on-chain status | ✅ |
| Transient Horizon errors are retried with backoff and do not flip status | ✅ |
| `completed_at` is set only on confirmation | ✅ |
| Horizon sync honors the selected `STELLAR_NETWORK` configuration | ✅ |
| Background sync job is wired into the app lifecycle | ✅ |
| Revenue settlement service tests pass successfully | ✅ |
| Typecheck passes successfully | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Run the settlement reconciliation tests
npm test -- src/__tests__/revenueSettlementService.test.ts

# 3. Verify TypeScript types
npm run typecheck

# 4. Optional: inspect the changed files
git diff -- src/services/revenueSettlementService.ts src/services/settlementStatusSyncJob.ts src/services/settlementStore.ts src/index.ts src/config/env.ts src/config/index.ts .env.example README.md
```

## Screenshots

### ✅ Revenue settlement service tests pass
A screenshot of:

```bash
npm test -- src/__tests__/revenueSettlementService.test.ts
```
<img width="605" height="309" alt="image" src="https://github.com/user-attachments/assets/0b602e1f-0392-43a0-b331-784b358d00bb" />
