### PR TITLE
feat: add developer profile read/update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 API gateway, usage metering, and billing services for the Callora API marketplace. Talks to Soroban contracts and Horizon for on-chain settlement.
 
+## Developer Profile Endpoints
+
+- `GET /api/developers/me` returns the authenticated developer profile and auto-creates a blank profile row on first access.
+- `PATCH /api/developers/me` updates profile fields for the authenticated developer.
+- PATCH validation enforces a valid `website` URL and a supported `category` enum value.
+
 ## Tech stack
 
 - **Node.js** + **TypeScript**

--- a/src/__tests__/developerRevenue.test.ts
+++ b/src/__tests__/developerRevenue.test.ts
@@ -4,18 +4,59 @@ import { createDeveloperRouter } from '../routes/developerRoutes.js';
 import { createSettlementStore } from '../services/settlementStore.js';
 import { createUsageStore } from '../services/usageStore.js';
 import { errorHandler } from '../middleware/errorHandler.js';
-import { SettlementStore } from '../types/developer.js';
+import { DeveloperProfile, SettlementStore } from '../types/developer.js';
 import { UsageStore } from '../types/gateway.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 let settlementStore: SettlementStore;
 let usageStore: UsageStore;
+const devProfiles = new Map<string, DeveloperProfile>();
+
+const developerRepository = {
+  async findByUserId(userId: string) {
+    return devProfiles.get(userId);
+  },
+  async getOrCreateByUserId(userId: string) {
+    const existing = devProfiles.get(userId);
+    if (existing) {
+      return existing;
+    }
+
+    const created: DeveloperProfile = {
+      id: devProfiles.size + 1,
+      user_id: userId,
+      name: null,
+      website: null,
+      description: null,
+      category: null,
+      created_at: new Date('2026-01-01T00:00:00.000Z'),
+      updated_at: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    devProfiles.set(userId, created);
+    return created;
+  },
+  async upsertProfile(userId: string, data: {
+    name?: string | null;
+    website?: string | null;
+    description?: string | null;
+    category?: DeveloperProfile['category'];
+  }) {
+    const existing = await this.getOrCreateByUserId(userId);
+    const updated: DeveloperProfile = {
+      ...existing,
+      ...data,
+      updated_at: new Date('2026-02-01T00:00:00.000Z'),
+    };
+    devProfiles.set(userId, updated);
+    return updated;
+  },
+};
 
 function buildApp() {
   const app = express();
   app.use(express.json());
-  app.use('/api/developers', createDeveloperRouter({ settlementStore, usageStore }));
+  app.use('/api/developers', createDeveloperRouter({ settlementStore, usageStore, developerRepository }));
   app.use(errorHandler);
   return app;
 }
@@ -91,6 +132,27 @@ function seedData() {
 beforeAll(() => {
   settlementStore = createSettlementStore();
   usageStore = createUsageStore();
+  devProfiles.clear();
+  devProfiles.set('dev_001', {
+    id: 1,
+    user_id: 'dev_001',
+    name: 'Revenue Dev',
+    website: null,
+    description: null,
+    category: 'analytics',
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    updated_at: new Date('2026-01-01T00:00:00.000Z'),
+  });
+  devProfiles.set('dev_002', {
+    id: 2,
+    user_id: 'dev_002',
+    name: 'Second Dev',
+    website: null,
+    description: null,
+    category: 'finance',
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    updated_at: new Date('2026-01-01T00:00:00.000Z'),
+  });
   seedData();
 
   return new Promise<void>((resolve) => {

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -213,6 +213,29 @@ const createDeveloperRepository = (profile?: Developer): DeveloperRepository => 
     }
     return undefined;
   },
+  async getOrCreateByUserId(userId: string) {
+    if (profile && profile.user_id === userId) {
+      return profile;
+    }
+    return {
+      id: 999,
+      user_id: userId,
+      name: null,
+      website: null,
+      description: null,
+      category: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+  },
+  async upsertProfile(userId: string, data) {
+    const current = profile && profile.user_id === userId ? profile : await this.getOrCreateByUserId(userId);
+    return {
+      ...current,
+      ...data,
+      updated_at: new Date(),
+    };
+  },
 });
 
 const usageEventsForApis = () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import type { Server } from 'http';
 import { createDeveloperRouter } from './routes/developerRoutes.js';
 import { createGatewayRouter } from './routes/gatewayRoutes.js';
 import { createProxyRouter } from './routes/proxyRoutes.js';
+import { defaultDeveloperRepository } from './repositories/developerRepository.js';
 import { createBillingService } from './services/billingService.js';
 import { createRateLimiter } from './services/rateLimiter.js';
 import { createUsageStore } from './services/usageStore.js';
@@ -130,6 +131,7 @@ if (isDirectExecution) {
   const developerRouter = createDeveloperRouter({
     settlementStore,
     usageStore,
+    developerRepository: defaultDeveloperRepository,
   });
   app.use('/api/developers', developerRouter);
 

--- a/src/repositories/developerRepository.ts
+++ b/src/repositories/developerRepository.ts
@@ -1,13 +1,18 @@
 import { eq } from 'drizzle-orm';
 import { db, schema } from '../db/index.js';
 import type { Developer, NewDeveloper } from '../db/schema.js';
+import type { UpdateDeveloperProfileInput } from '../types/developer.js';
 
 export interface DeveloperRepository {
   findByUserId(userId: string): Promise<Developer | undefined>;
+  getOrCreateByUserId(userId: string): Promise<Developer>;
+  upsertProfile(userId: string, data: UpdateDeveloperProfileInput): Promise<Developer>;
 }
 
 export const defaultDeveloperRepository: DeveloperRepository = {
   findByUserId,
+  getOrCreateByUserId,
+  upsertProfile,
 };
 
 export async function findByUserId(userId: string): Promise<Developer | undefined> {
@@ -19,12 +24,31 @@ export async function findByUserId(userId: string): Promise<Developer | undefine
   return rows[0];
 }
 
-export async function upsert(userId: string, data: {
-  name?: string | null;
-  website?: string | null;
-  description?: string | null;
-  category?: string | null;
-}): Promise<Developer> {
+export async function getOrCreateByUserId(userId: string): Promise<Developer> {
+  const existing = await findByUserId(userId);
+  if (existing) {
+    return existing;
+  }
+
+  const [inserted] = await db
+    .insert(schema.developers)
+    .values({
+      user_id: userId,
+      name: null,
+      website: null,
+      description: null,
+      category: null,
+    } as NewDeveloper)
+    .returning();
+
+  if (!inserted) throw new Error('Developer insert failed');
+  return inserted;
+}
+
+export async function upsertProfile(
+  userId: string,
+  data: UpdateDeveloperProfileInput,
+): Promise<Developer> {
   const existing = await findByUserId(userId);
   const now = new Date();
 
@@ -57,3 +81,5 @@ export async function upsert(userId: string, data: {
   if (!inserted) throw new Error('Developer insert failed');
   return inserted;
 }
+
+export const upsert = upsertProfile;

--- a/src/routes/developerRoutes.test.ts
+++ b/src/routes/developerRoutes.test.ts
@@ -2,6 +2,8 @@ import request from 'supertest';
 import express from 'express';
 import { createDeveloperRouter } from './developerRoutes.js';
 import { errorHandler } from '../middleware/errorHandler.js';
+import type { Developer } from '../db/schema.js';
+import type { UpdateDeveloperProfileInput } from '../types/developer.js';
 
 const mockSettlementStore = {
   create: jest.fn(),
@@ -17,12 +19,31 @@ const mockUsageStore = {
   markAsSettled: jest.fn(),
 };
 
+const makeDeveloper = (overrides: Partial<Developer> = {}): Developer => ({
+  id: 1,
+  user_id: 'dev-1',
+  name: null,
+  website: null,
+  description: null,
+  category: null,
+  created_at: new Date('2026-01-01T00:00:00.000Z'),
+  updated_at: new Date('2026-01-01T00:00:00.000Z'),
+  ...overrides,
+});
+
+const mockDeveloperRepository = {
+  findByUserId: jest.fn(),
+  getOrCreateByUserId: jest.fn(),
+  upsertProfile: jest.fn<Promise<Developer>, [string, UpdateDeveloperProfileInput]>(),
+};
+
 const app = express();
 app.use(express.json());
 // Mount the router
 app.use('/api/developers', createDeveloperRouter({
   settlementStore: mockSettlementStore as any,
   usageStore: mockUsageStore as any,
+  developerRepository: mockDeveloperRepository as any,
 }));
 // Error handler to catch UnauthorizedError
 app.use(errorHandler);
@@ -62,5 +83,111 @@ describe('GET /api/developers/revenue', () => {
     expect(res.body.pagination.limit).toBe(100);
     expect(res.body.pagination.total).toBe(2);
     expect(res.body.settlements.length).toBe(2);
+  });
+});
+
+describe('GET /api/developers/me', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).get('/api/developers/me');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the authenticated developer profile and auto-creates on first access', async () => {
+    const profile = makeDeveloper({ name: 'Callora Dev', category: 'analytics' });
+    mockDeveloperRepository.getOrCreateByUserId.mockResolvedValue(profile);
+
+    const res = await request(app)
+      .get('/api/developers/me')
+      .set('x-user-id', 'dev-1');
+
+    expect(res.status).toBe(200);
+    expect(mockDeveloperRepository.getOrCreateByUserId).toHaveBeenCalledWith('dev-1');
+    expect(res.body).toMatchObject({
+      id: 1,
+      user_id: 'dev-1',
+      name: 'Callora Dev',
+      category: 'analytics',
+    });
+  });
+});
+
+describe('PATCH /api/developers/me', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).patch('/api/developers/me').send({ name: 'Nope' });
+    expect(res.status).toBe(401);
+  });
+
+  it('validates website URL and category enum', async () => {
+    const res = await request(app)
+      .patch('/api/developers/me')
+      .set('x-user-id', 'dev-1')
+      .send({ website: 'not-a-url', category: 'unknown' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_ERROR');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body.website' }),
+        expect.objectContaining({ field: 'body.category' }),
+      ]),
+    );
+  });
+
+  it('rejects an empty patch body', async () => {
+    const res = await request(app)
+      .patch('/api/developers/me')
+      .set('x-user-id', 'dev-1')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_ERROR');
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body', message: 'At least one profile field must be provided' }),
+      ]),
+    );
+  });
+
+  it('persists profile updates for the authenticated developer', async () => {
+    const updated = makeDeveloper({
+      name: 'Updated Dev',
+      website: 'https://example.com',
+      description: 'Ships API products',
+      category: 'developer-tools',
+      updated_at: new Date('2026-02-01T00:00:00.000Z'),
+    });
+    mockDeveloperRepository.upsertProfile.mockResolvedValue(updated);
+
+    const res = await request(app)
+      .patch('/api/developers/me')
+      .set('x-user-id', 'dev-1')
+      .send({
+        name: 'Updated Dev',
+        website: 'https://example.com',
+        description: 'Ships API products',
+        category: 'developer-tools',
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockDeveloperRepository.upsertProfile).toHaveBeenCalledWith('dev-1', {
+      name: 'Updated Dev',
+      website: 'https://example.com',
+      description: 'Ships API products',
+      category: 'developer-tools',
+    });
+    expect(res.body).toMatchObject({
+      user_id: 'dev-1',
+      name: 'Updated Dev',
+      website: 'https://example.com',
+      category: 'developer-tools',
+    });
   });
 });

--- a/src/routes/developerRoutes.ts
+++ b/src/routes/developerRoutes.ts
@@ -2,18 +2,24 @@ import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
 import { validate } from '../middleware/validate.js';
-import { DeveloperRevenueResponse, SettlementStore } from '../types/developer.js';
+import {
+  developerCategoryEnum,
+  DeveloperRevenueResponse,
+  SettlementStore,
+} from '../types/developer.js';
 import { UsageStore } from '../types/gateway.js';
 import { UnauthorizedError } from '../errors/index.js';
+import type { DeveloperRepository } from '../repositories/developerRepository.js';
 
 export interface DeveloperRoutesDeps {
   settlementStore: SettlementStore;
   usageStore: UsageStore;
+  developerRepository: DeveloperRepository;
 }
 
 export function createDeveloperRouter(deps: DeveloperRoutesDeps): Router {
   const router = Router();
-  const { settlementStore, usageStore } = deps;
+  const { settlementStore, usageStore, developerRepository } = deps;
 
   // Validation schema for revenue query parameters
   const revenueQuerySchema = z.object({
@@ -34,6 +40,48 @@ export function createDeveloperRouter(deps: DeveloperRoutesDeps): Router {
       .transform((val) => (val ? parseInt(val, 10) : undefined))
       .pipe(z.number().int().min(1).optional()),
   });
+
+  const developerProfilePatchSchema = z
+    .object({
+      name: z.string().trim().min(1).max(120).nullable().optional(),
+      website: z.string().trim().url().nullable().optional(),
+      description: z.string().trim().max(500).nullable().optional(),
+      category: z.enum(developerCategoryEnum).nullable().optional(),
+    })
+    .refine((value) => Object.keys(value).length > 0, {
+      message: 'At least one profile field must be provided',
+      path: [],
+    });
+
+  router.get(
+    '/me',
+    requireAuth,
+    async (_req: Request, res: Response<unknown, AuthenticatedLocals>) => {
+      const user = res.locals.authenticatedUser;
+      if (!user) {
+        throw new UnauthorizedError();
+      }
+
+      const profile = await developerRepository.getOrCreateByUserId(user.id);
+      res.json(profile);
+    },
+  );
+
+  router.patch(
+    '/me',
+    requireAuth,
+    validate({ body: developerProfilePatchSchema }),
+    async (req: Request, res: Response<unknown, AuthenticatedLocals>) => {
+      const user = res.locals.authenticatedUser;
+      if (!user) {
+        throw new UnauthorizedError();
+      }
+
+      const body = developerProfilePatchSchema.parse(req.body);
+      const profile = await developerRepository.upsertProfile(user.id, body);
+      res.json(profile);
+    },
+  );
 
   /**
    * GET /api/developers/revenue

--- a/src/types/developer.ts
+++ b/src/types/developer.ts
@@ -1,3 +1,35 @@
+export const developerCategoryEnum = [
+  'ai',
+  'analytics',
+  'data',
+  'developer-tools',
+  'finance',
+  'productivity',
+  'search',
+  'security',
+  'weather',
+] as const;
+
+export type DeveloperCategory = typeof developerCategoryEnum[number];
+
+export interface DeveloperProfile {
+  id: number;
+  user_id: string;
+  name: string | null;
+  website: string | null;
+  description: string | null;
+  category: DeveloperCategory | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface UpdateDeveloperProfileInput {
+  name?: string | null;
+  website?: string | null;
+  description?: string | null;
+  category?: DeveloperCategory | null;
+}
+
 export interface Settlement {
   id: string;
   developerId: string; // the dev receiving the payout

--- a/tests/integration/protected.test.ts
+++ b/tests/integration/protected.test.ts
@@ -157,6 +157,23 @@ const stubDeveloperRepository: DeveloperRepository = {
   async findByUserId(userId: string) {
     return userId === testDeveloper.user_id ? testDeveloper : undefined;
   },
+  async getOrCreateByUserId(userId: string) {
+    return userId === testDeveloper.user_id
+      ? testDeveloper
+      : {
+          ...testDeveloper,
+          id: 8,
+          user_id: userId,
+        };
+  },
+  async upsertProfile(userId: string, data) {
+    const current = await this.getOrCreateByUserId(userId);
+    return {
+      ...current,
+      ...data,
+      updated_at: new Date(),
+    };
+  },
 };
 
 class StubApiRepository implements ApiRepository {


### PR DESCRIPTION
## Overview
This PR adds authenticated developer profile endpoints backed by the Drizzle `developers` table so the marketplace can read and edit the caller's profile. It introduces `GET /api/developers/me` and `PATCH /api/developers/me`, auto-creates a profile row on first access, and validates editable profile fields before persistence.

## Related Issue
Closes #326

## Changes

### 👤 Developer Profile Endpoints
- **[MODIFY]** `src/routes/developerRoutes.ts`
- Added `GET /api/developers/me` to return the authenticated developer profile.
- Added `PATCH /api/developers/me` to update profile fields for the authenticated developer.
- Auto-creates a blank profile row on first access when a developer profile does not yet exist.
- Added Zod validation for editable fields including URL validation for `website` and enum validation for `category`.

### 🗄️ Repository Support
- **[MODIFY]** `src/repositories/developerRepository.ts`
- Extended the repository contract with `getOrCreateByUserId` and `upsertProfile`.
- Reused the Drizzle-backed repository to persist profile updates keyed by authenticated `user_id`.

### 🧾 Types
- **[MODIFY]** `src/types/developer.ts`
- Added shared developer profile types.
- Added a reusable developer category enum for route validation and profile typing.

### 🌐 Runtime Wiring
- **[MODIFY]** `src/index.ts`
- Wired the real developer repository into the dedicated developer router used by the running server.

### 🧪 Tests
- **[MODIFY]** `src/routes/developerRoutes.test.ts`
- Added coverage for authenticated profile reads, first-access creation, PATCH validation, and persisted updates.

- **[MODIFY]** `src/__tests__/developerRevenue.test.ts`
- Updated test setup to satisfy the expanded developer repository contract.

- **[MODIFY]** `src/app.test.ts`
- Updated developer repository test stubs to satisfy the expanded contract.

- **[MODIFY]** `tests/integration/protected.test.ts`
- Updated integration test stubs to satisfy the expanded developer repository contract.

### 📚 Documentation
- **[MODIFY]** `README.md`
- Documented the new developer profile endpoints and first-access behavior.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| `GET /api/developers/me` returns the caller's profile | ✅ |
| `PATCH` validates fields and persists changes | ✅ |
| First access creates the profile row | ✅ |
| `website` must be a valid URL | ✅ |
| `category` must match the supported enum | ✅ |



## Screenshots

### ✅ Developer route tests pass
A screenshot of:

```bash
npm test -- src/routes/developerRoutes.test.ts
```
<img width="600" height="332" alt="image" src="https://github.com/user-attachments/assets/f573f1fc-29e5-4e0b-9eba-6d7257953c00" />

