### PR TITLE
task: add typed events and safe unsubscribe to emitter

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
   setupFiles: ["<rootDir>/jest.env-setup.cjs"],
   testMatch: ["**/?(*.)+(spec|test).ts"],
   // Exclude tests that use Node.js native test runner
-  testPathIgnorePatterns: ["/node_modules/", "event.emitter.test.ts"],
+  testPathIgnorePatterns: ["/node_modules/"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: {
     "^(.*/)?generated/prisma/client(\\.js)?$":

--- a/src/events/README.md
+++ b/src/events/README.md
@@ -1,248 +1,109 @@
-# Event Emitter Documentation
+# Event Emitter Contracts
 
 ## Overview
 
-The `event.emitter.ts` module provides a centralized event system for the Callora backend, handling webhook dispatches for billing and settlement events. This document outlines the threading model, async expectations, and memory safety considerations.
+`src/events/event.emitter.ts` exposes a typed domain-event emitter for billing and usage related webhook fan-out. The API is intentionally small:
 
-## Architecture
+- `calloraEvents.on(event, listener)` registers an event-specific listener and returns an unsubscribe function
+- `calloraEvents.off(event, listener)` removes the exact listener reference
+- `calloraEvents.emit(event, developerId, payload)` synchronously schedules listeners and returns whether any listeners were present
+- `calloraEvents.listenerCount(event)` reports the number of listeners for one event
 
-### Components
+The emitter is strongly typed through a shared event-name to payload map, so unknown events and mismatched payloads fail at compile time.
 
-- **calloraEvents**: Global Node.js EventEmitter instance
-- **handleEvent()**: Async event handler that processes webhook dispatches
-- **WebhookStore**: In-memory store for webhook configurations
-- **dispatchToAll()**: Concurrent webhook dispatcher with retry logic
+## Event Map
 
-### Event Types
+### `new_api_call`
 
-1. `new_api_call`: Triggered when API calls are made
-2. `settlement_completed`: Triggered when settlements are processed
-3. `low_balance_alert`: Triggered when balance falls below threshold
+Used when API usage is recorded for a developer.
 
-## Threading and Async Behavior
-
-### Node.js Event Loop Model
-
-The event emitter operates on Node.js's single-threaded event loop with the following characteristics:
-
-#### Event Emission (Synchronous)
-```typescript
-// Event emission is SYNCHRONOUS and NON-BLOCKING
-calloraEvents.emit('new_api_call', developerId, data);
-// Returns immediately, does not wait for processing
+```ts
+{
+  apiId: string;
+  endpoint: string;
+  method: string;
+  statusCode: number;
+  latencyMs: number;
+  creditsUsed: number;
+}
 ```
 
-#### Event Processing (Asynchronous)
-```typescript
-// Event listeners are ASYNCHRONOUS
-calloraEvents.on('new_api_call', async (developerId, data) => {
-    await handleEvent('new_api_call', developerId, data);
-    // Processing happens in the background
+### `settlement_completed`
+
+Used when a developer settlement completes successfully.
+
+```ts
+{
+  settlementId: string;
+  amount: string;
+  asset: string;
+  txHash: string;
+  settledAt: string;
+}
+```
+
+### `low_balance_alert`
+
+Used when a developer or consumer balance falls below the configured threshold.
+
+```ts
+{
+  currentBalance: string;
+  thresholdBalance: string;
+  asset: string;
+}
+```
+
+## Typing Guarantees
+
+```ts
+calloraEvents.emit('new_api_call', developerId, {
+  apiId: 'api_123',
+  endpoint: '/v1/messages',
+  method: 'POST',
+  statusCode: 200,
+  latencyMs: 42,
+  creditsUsed: 1,
+});
+
+// Type error: event name is unknown
+calloraEvents.emit('unknown_event', developerId, payload);
+
+// Type error: payload shape does not match new_api_call
+calloraEvents.emit('new_api_call', developerId, {
+  settlementId: 'settlement_123',
 });
 ```
 
-### Concurrency Model
+## Unsubscribe Safety
 
-1. **Event Emission**: Synchronous, O(1) operation
-2. **Webhook Dispatch**: Asynchronous, concurrent using `Promise.allSettled()`
-3. **Error Handling**: Non-blocking, errors don't affect other webhooks
+Listeners are removed by exact function identity. Both of the following are safe and idempotent:
 
-### Event Loop Phases
+```ts
+const unsubscribe = calloraEvents.on('new_api_call', listener);
 
-```
-┌───────────────────────────┐
-└─> emit(event, data)       │  Synchronous
-    ┌─────────────────────┐ │
-    │ add to event queue  │ │
-    └─────────────────────┘ │
-┌───────────────────────────┐
-│ Event Loop Processing     │
-└─> handleEvent()           │  Asynchronous
-    ┌─────────────────────┐ │
-    │ WebhookStore lookup │ │  Synchronous
-    └─────────────────────┘ │
-    ┌─────────────────────┐ │
-    │ dispatchToAll()     │ │  Asynchronous
-    └─────────────────────┘ │
-┌───────────────────────────┐
-│ Webhook Delivery          │
-└─> HTTP requests           │  Concurrent, with retries
+unsubscribe();
+unsubscribe(); // safe no-op
+
+calloraEvents.off('new_api_call', listener);
+calloraEvents.off('new_api_call', listener); // safe no-op
 ```
 
-## Memory Safety
+Unsubscribing one listener does not affect any other listener registered for the same event.
 
-### Potential Memory Leaks
+## Async Behavior
 
-1. **Event Listener Accumulation**
-   - **Risk**: Low - listeners are added once at module load
-   - **Mitigation**: Fixed number of listeners (3), no dynamic addition
+- `emit(...)` is synchronous and does not await webhook delivery
+- listeners may return promises
+- async listener failures are caught and logged so one failing listener does not break the rest
+- webhook dispatch remains filtered by event type and `developerId`
 
-2. **WebhookStore Growth**
-   - **Risk**: Medium - Map grows with webhook registrations
-   - **Mitigation**: Provide cleanup methods, monitor store size
+## Built-in Webhook Bridge
 
-3. **Pending Promise Accumulation**
-   - **Risk**: Low - `Promise.allSettled()` prevents hanging promises
-   - **Mitigation**: Timeout on webhook requests (10s per attempt)
+The module registers one built-in listener per documented event:
 
-### Memory Management Guidelines
+- `new_api_call`
+- `settlement_completed`
+- `low_balance_alert`
 
-#### WebhookStore Management
-```typescript
-// Register webhook
-WebhookStore.register(config);
-
-// Clean up when no longer needed
-WebhookStore.delete(developerId);
-
-// Monitor store size
-const storeSize = WebhookStore.list().length;
-if (storeSize > MAX_WEBHOOKS) {
-    // Implement cleanup strategy
-}
-```
-
-#### Event Listener Management
-```typescript
-// Listeners are static - no cleanup needed
-// But you can check count if needed
-const listenerCount = calloraEvents.listenerCount('new_api_call');
-```
-
-## Performance Characteristics
-
-### Hot Path Behavior
-
-1. **Event Emission**: ~0.1ms (synchronous)
-2. **WebhookStore Lookup**: ~0.01ms per webhook config
-3. **Webhook Dispatch**: 10s timeout per attempt, max 5 retries
-
-### Throughput Estimates
-
-- **Events/second**: 10,000+ (emission only)
-- **Webhook deliveries**: Limited by network latency and timeouts
-- **Memory overhead**: ~1KB per registered webhook
-
-## Error Handling
-
-### Async Error Propagation
-
-```typescript
-// Errors in handleEvent() are NOT propagated to emit()
-calloraEvents.emit('new_api_call', developerId, data);
-// Always succeeds, even if webhook processing fails
-
-// Errors are logged but don't crash the process
-logger.error('[webhook] Failed to deliver...', error);
-```
-
-### Error Recovery
-
-1. **Webhook Failures**: Automatic retry with exponential backoff
-2. **Network Timeouts**: 10s timeout per attempt
-3. **Unhandled Rejections**: Caught by `Promise.allSettled()`
-
-## Best Practices
-
-### For Event Emitters
-
-```typescript
-// ✅ DO: Emit events synchronously
-calloraEvents.emit('new_api_call', developerId, data);
-
-// ❌ DON'T: Wait for event processing
-await calloraEvents.emit('new_api_call', developerId, data); // Doesn't work
-```
-
-### For Webhook Consumers
-
-```typescript
-// ✅ DO: Handle webhooks idempotently
-if (alreadyProcessed(eventId)) {
-    return 200; // Acknowledge but don't reprocess
-}
-
-// ✅ DO: Respond quickly
-return 200; // Acknowledge immediately, process asynchronously
-
-// ❌ DON'T: Block webhook processing
-await longRunningOperation(); // May cause timeouts
-```
-
-### For Memory Management
-
-```typescript
-// ✅ DO: Monitor webhook store size
-setInterval(() => {
-    const size = WebhookStore.list().length;
-    if (size > THRESHOLD) {
-        logger.warn(`WebhookStore size: ${size}`);
-    }
-}, 60000);
-
-// ✅ DO: Clean up unused webhooks
-WebhookStore.delete(developerId);
-```
-
-## Monitoring and Debugging
-
-### Key Metrics
-
-1. **Event Rate**: Events emitted per second
-2. **Webhook Success Rate**: Percentage of successful deliveries
-3. **WebhookStore Size**: Number of registered webhooks
-4. **Memory Usage**: Heap size over time
-
-### Debug Logging
-
-```typescript
-// Enable debug logging
-DEBUG=webhook:* npm start
-
-// Monitor event emissions
-DEBUG=events:* npm start
-```
-
-## Security Considerations
-
-### Event Data Validation
-
-- Event emitter does not validate payload structure
-- Webhook consumers should validate incoming data
-- Use type guards and schema validation
-
-### Rate Limiting
-
-- No built-in rate limiting on event emission
-- Implement application-level rate limiting if needed
-- Monitor webhook delivery rates to prevent abuse
-
-## Testing Considerations
-
-### Unit Testing
-
-- Mock `dispatchToAll()` to avoid HTTP calls
-- Test async behavior with proper timing
-- Verify memory usage under load
-
-### Integration Testing
-
-- Test full webhook delivery flow
-- Verify error handling and retry logic
-- Test concurrent event processing
-
-## Future Improvements
-
-### Potential Enhancements
-
-1. **Event Batching**: Batch multiple events for better throughput
-2. **Circuit Breaker**: Stop webhook delivery after repeated failures
-3. **Metrics Collection**: Built-in performance metrics
-4. **Event Replay**: Store events for replay capability
-5. **Webhook Deduplication**: Prevent duplicate webhook deliveries
-
-### Scalability Considerations
-
-- Consider external message queue for high-volume scenarios
-- Implement webhook delivery partitioning for better parallelism
-- Add webhook delivery priority queues
+Each built-in listener resolves matching webhook subscriptions from `WebhookStore` and forwards the typed payload through `dispatchToAll(...)`.

--- a/src/events/event.emitter.test.ts
+++ b/src/events/event.emitter.test.ts
@@ -1,408 +1,196 @@
-/**
- * Event Emitter Unit Tests
- * 
- * Comprehensive test coverage for event emitter utilities, memory leak safety,
- * and async behavior in Node.js event loop.
- */
-
-import assert from 'node:assert/strict';
-import { calloraEvents } from './event.emitter.js';
+import { dispatchToAll } from '../webhooks/webhook.dispatcher.js';
 import { WebhookStore } from '../webhooks/webhook.store.js';
-import type { 
-    WebhookConfig, 
-    NewApiCallData,
-    SettlementCompletedData,
-    LowBalanceAlertData 
-} from '../webhooks/webhook.types.js';
+import {
+  calloraEvents,
+  type CalloraEventListener,
+  type CalloraEventPayloadMap,
+} from './event.emitter.js';
 
 jest.mock('../webhooks/webhook.dispatcher.js', () => ({
-    dispatchToAll: jest.fn(async () => undefined),
+  dispatchToAll: jest.fn(async () => undefined),
 }));
 
-describe('Event Emitter - Memory Leak Safety', () => {
-    beforeEach(() => {
-        // Clear webhook store before each test
-        WebhookStore.clear();
-        
+const mockedDispatchToAll = jest.mocked(dispatchToAll);
+
+async function flushAsyncListeners(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('calloraEvents', () => {
+  beforeEach(() => {
+    mockedDispatchToAll.mockClear();
+    WebhookStore.clear();
+  });
+
+  afterEach(() => {
+    WebhookStore.clear();
+  });
+
+  it('registers one built-in listener per documented event', () => {
+    expect(calloraEvents.listenerCount('new_api_call')).toBe(1);
+    expect(calloraEvents.listenerCount('settlement_completed')).toBe(1);
+    expect(calloraEvents.listenerCount('low_balance_alert')).toBe(1);
+  });
+
+  it('dispatches registered webhook configs with the correct typed payload', async () => {
+    WebhookStore.register({
+      developerId: 'dev_123',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call'],
+      createdAt: new Date(),
     });
 
-    afterEach(() => {
-        // Clean up webhook store after each test
-        WebhookStore.clear();
-        
+    const payload: CalloraEventPayloadMap['new_api_call'] = {
+      apiId: 'api_123',
+      endpoint: '/v1/messages',
+      method: 'POST',
+      statusCode: 200,
+      latencyMs: 42,
+      creditsUsed: 1,
+    };
+
+    expect(calloraEvents.emit('new_api_call', 'dev_123', payload)).toBe(true);
+    await flushAsyncListeners();
+
+    expect(mockedDispatchToAll).toHaveBeenCalledTimes(1);
+    expect(mockedDispatchToAll).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          developerId: 'dev_123',
+          url: 'https://example.com/webhook',
+        }),
+      ],
+      expect.objectContaining({
+        event: 'new_api_call',
+        developerId: 'dev_123',
+        data: payload,
+      }),
+    );
+  });
+
+  it('unsubscribe removes only the target listener and is idempotent', async () => {
+    const first = jest.fn<void, [string, CalloraEventPayloadMap['new_api_call']]>();
+    const second = jest.fn<void, [string, CalloraEventPayloadMap['new_api_call']]>();
+    const unsubscribeFirst = calloraEvents.on('new_api_call', first as CalloraEventListener<'new_api_call'>);
+    calloraEvents.on('new_api_call', second as CalloraEventListener<'new_api_call'>);
+
+    expect(calloraEvents.listenerCount('new_api_call')).toBe(3);
+
+    unsubscribeFirst();
+    unsubscribeFirst();
+
+    expect(calloraEvents.listenerCount('new_api_call')).toBe(2);
+
+    calloraEvents.emit('new_api_call', 'dev_456', {
+      apiId: 'api_456',
+      endpoint: '/v1/test',
+      method: 'GET',
+      statusCode: 200,
+      latencyMs: 15,
+      creditsUsed: 2,
     });
 
-    test('event listeners are properly registered on module load', () => {
-        const listenerCount = calloraEvents.listenerCount('new_api_call') +
-                            calloraEvents.listenerCount('settlement_completed') +
-                            calloraEvents.listenerCount('low_balance_alert');
-        
-        assert.equal(listenerCount, 3, 'Should have exactly 3 event listeners registered');
-        assert.equal(calloraEvents.listenerCount('new_api_call'), 1, 'Should have 1 new_api_call listener');
-        assert.equal(calloraEvents.listenerCount('settlement_completed'), 1, 'Should have 1 settlement_completed listener');
-        assert.equal(calloraEvents.listenerCount('low_balance_alert'), 1, 'Should have 1 low_balance_alert listener');
+    await flushAsyncListeners();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledWith(
+      'dev_456',
+      expect.objectContaining({
+        apiId: 'api_456',
+      }),
+    );
+
+    calloraEvents.off('new_api_call', second as CalloraEventListener<'new_api_call'>);
+    calloraEvents.off('new_api_call', second as CalloraEventListener<'new_api_call'>);
+    expect(calloraEvents.listenerCount('new_api_call')).toBe(1);
+  });
+
+  it('does not dispatch webhooks for a different developer', async () => {
+    WebhookStore.register({
+      developerId: 'dev_owner',
+      url: 'https://example.com/webhook',
+      events: ['settlement_completed'],
+      createdAt: new Date(),
     });
 
-    test('event emission does not accumulate listeners', async () => {
-        const initialListenerCount = calloraEvents.listenerCount('new_api_call');
-        
-        // Emit multiple events
-        const developerId = 'dev_test_123';
-        const apiCallData: NewApiCallData = {
-            apiId: 'api_123',
-            endpoint: '/test',
-            method: 'GET',
-            statusCode: 200,
-            latencyMs: 100,
-            creditsUsed: 1
-        };
-
-        // Emit events multiple times
-        for (let i = 0; i < 10; i++) {
-            calloraEvents.emit('new_api_call', developerId, apiCallData);
-        }
-
-        // Wait a bit for async processing
-        await new Promise(resolve => setTimeout(resolve, 50));
-
-        // Listener count should not change
-        assert.equal(
-            calloraEvents.listenerCount('new_api_call'), 
-            initialListenerCount, 
-            'Event emission should not accumulate listeners'
-        );
+    calloraEvents.emit('settlement_completed', 'dev_other', {
+      settlementId: 'settlement_123',
+      amount: '100.50',
+      asset: 'XLM',
+      txHash: 'tx_hash_123',
+      settledAt: new Date().toISOString(),
     });
 
-    test('handleEvent function handles webhook dispatch failures gracefully', async () => {
-        // Register webhook configs that will fail
-        const failingConfig: WebhookConfig = {
-            developerId: 'dev_fail_123',
-            url: 'https://example.com/fail',
-            events: ['new_api_call'],
-            createdAt: new Date()
-        };
+    await flushAsyncListeners();
+    expect(mockedDispatchToAll).not.toHaveBeenCalled();
+  });
 
-        WebhookStore.register(failingConfig);
+  it('supports typed listeners for each event payload shape', () => {
+    const newApiListener: CalloraEventListener<'new_api_call'> = (_developerId, payload) => {
+      expect(payload.apiId).toBeDefined();
+      expect(payload.creditsUsed).toBeGreaterThanOrEqual(0);
+    };
 
-        // Emit event - should not throw despite webhook failures
-        const developerId = 'dev_fail_123';
-        const apiCallData: NewApiCallData = {
-            apiId: 'api_123',
-            endpoint: '/test',
-            method: 'GET',
-            statusCode: 200,
-            latencyMs: 100,
-            creditsUsed: 1
-        };
+    const settlementListener: CalloraEventListener<'settlement_completed'> = (_developerId, payload) => {
+      expect(payload.settlementId).toBeDefined();
+      expect(payload.txHash).toBeDefined();
+    };
 
-        // This should not throw
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', developerId, apiCallData);
-        });
+    const lowBalanceListener: CalloraEventListener<'low_balance_alert'> = (_developerId, payload) => {
+      expect(payload.currentBalance).toBeDefined();
+      expect(payload.thresholdBalance).toBeDefined();
+    };
 
-        // Wait for async processing
-        await new Promise(resolve => setTimeout(resolve, 100));
+    const offNewApi = calloraEvents.on('new_api_call', newApiListener);
+    const offSettlement = calloraEvents.on('settlement_completed', settlementListener);
+    const offLowBalance = calloraEvents.on('low_balance_alert', lowBalanceListener);
+
+    calloraEvents.emit('new_api_call', 'dev_1', {
+      apiId: 'api_1',
+      endpoint: '/v1/test',
+      method: 'GET',
+      statusCode: 200,
+      latencyMs: 20,
+      creditsUsed: 1,
+    });
+    calloraEvents.emit('settlement_completed', 'dev_1', {
+      settlementId: 'settlement_1',
+      amount: '3.50',
+      asset: 'XLM',
+      txHash: 'hash_1',
+      settledAt: new Date().toISOString(),
+    });
+    calloraEvents.emit('low_balance_alert', 'dev_1', {
+      currentBalance: '5.00',
+      thresholdBalance: '10.00',
+      asset: 'USDC',
     });
 
-    test('multiple concurrent events are handled without memory accumulation', async () => {
-        // Register multiple webhook configs
-        const configs: WebhookConfig[] = [];
-        for (let i = 0; i < 5; i++) {
-            configs.push({
-                developerId: `dev_${i}`,
-                url: `https://example.com/webhook${i}`,
-                events: ['new_api_call'],
-                createdAt: new Date()
-            });
-            WebhookStore.register(configs[i]);
-        }
+    offNewApi();
+    offSettlement();
+    offLowBalance();
+  });
 
-        // Track memory usage pattern (simplified)
-        const initialListenerCount = calloraEvents.listenerCount('new_api_call');
-        
-        // Emit many concurrent events
-        const promises: Promise<void>[] = [];
-        for (let i = 0; i < 20; i++) {
-            const promise = new Promise<void>((resolve) => {
-                const developerId = `dev_${i % 5}`;
-                const apiCallData: NewApiCallData = {
-                    apiId: `api_${i}`,
-                    endpoint: '/test',
-                    method: 'GET',
-                    statusCode: 200,
-                    latencyMs: 100,
-                    creditsUsed: 1
-                };
+  it('rejects unknown events and wrong payloads at compile time', () => {
+    const validPayload: CalloraEventPayloadMap['new_api_call'] = {
+      apiId: 'api_typecheck',
+      endpoint: '/v1/typecheck',
+      method: 'GET',
+      statusCode: 200,
+      latencyMs: 30,
+      creditsUsed: 1,
+    };
 
-                calloraEvents.emit('new_api_call', developerId, apiCallData);
-                setTimeout(resolve, 10); // Small delay to simulate real usage
-            });
-            promises.push(promise);
-        }
+    expect(calloraEvents.emit('new_api_call', 'dev_typecheck', validPayload)).toBe(true);
 
-        await Promise.all(promises);
-        await new Promise(resolve => setTimeout(resolve, 200)); // Wait for all async processing
+    if (false) {
+      // @ts-expect-error unknown event names must not compile
+      calloraEvents.emit('unknown_event', 'dev_typecheck', validPayload);
 
-        // Listener count should remain stable
-        assert.equal(
-            calloraEvents.listenerCount('new_api_call'),
-            initialListenerCount,
-            'Listener count should remain stable after many concurrent events'
-        );
-    });
-
-    test('webhook store cleanup prevents memory leaks', () => {
-        // Add many webhook configs
-        const initialCount = WebhookStore.list().length;
-        
-        for (let i = 0; i < 100; i++) {
-            WebhookStore.register({
-                developerId: `dev_${i}`,
-                url: `https://example.com/webhook${i}`,
-                events: ['new_api_call'],
-                createdAt: new Date()
-            });
-        }
-
-        assert.equal(WebhookStore.list().length, initialCount + 100, 'Webhook store should contain all registered configs');
-
-        // Clean up all configs using clear method
-        WebhookStore.clear();
-
-        assert.equal(WebhookStore.list().length, 0, 'Webhook store should be empty after clear');
-    });
-
-    test('event payload structure is maintained correctly', async () => {
-        const testConfig: WebhookConfig = {
-            developerId: 'dev_payload_test',
-            url: 'https://example.com/webhook',
-            events: ['new_api_call', 'settlement_completed', 'low_balance_alert'],
-            createdAt: new Date()
-        };
-
-        WebhookStore.register(testConfig);
-
-        // Test new_api_call payload
-        const apiCallData: NewApiCallData = {
-            apiId: 'api_payload_test',
-            endpoint: '/test/endpoint',
-            method: 'POST',
-            statusCode: 201,
-            latencyMs: 250,
-            creditsUsed: 5
-        };
-
-        calloraEvents.emit('new_api_call', 'dev_payload_test', apiCallData);
-        
-        await new Promise(resolve => setTimeout(resolve, 50));
-
-        // In a real test with proper mocking, we'd verify:
-        // assert.equal(capturedPayload?.event, 'new_api_call');
-        // assert.equal(capturedPayload?.developerId, 'dev_payload_test');
-        // assert.equal(capturedPayload?.data.apiId, 'api_payload_test');
-    });
-});
-
-describe('Event Emitter - Async Behavior and Node.js Event Loop', () => {
-    test('async handleEvent does not block event emission', async () => {
-        const startTime = Date.now();
-        
-        const developerId = 'dev_async_test';
-        const apiCallData: NewApiCallData = {
-            apiId: 'api_async_test',
-            endpoint: '/slow',
-            method: 'GET',
-            statusCode: 200,
-            latencyMs: 1000, // Simulate slow processing
-            creditsUsed: 1
-        };
-
-        // Emit event - should return immediately
-        calloraEvents.emit('new_api_call', developerId, apiCallData);
-        
-        const emitDuration = Date.now() - startTime;
-        
-        // Event emission should be fast (non-blocking)
-        assert.ok(emitDuration < 50, 'Event emission should be non-blocking and return quickly');
-
-        // Wait for async processing to complete
-        await new Promise(resolve => setTimeout(resolve, 200));
-    });
-
-    test('multiple event types can be emitted concurrently', async () => {
-        const developerId = 'dev_concurrent_test';
-        
-        const apiCallData: NewApiCallData = {
-            apiId: 'api_concurrent',
-            endpoint: '/test',
-            method: 'GET',
-            statusCode: 200,
-            latencyMs: 100,
-            creditsUsed: 1
-        };
-
-        const settlementData: SettlementCompletedData = {
-            settlementId: 'settlement_123',
-            amount: '100.50',
-            asset: 'XLM',
-            txHash: 'tx_hash_123',
-            settledAt: new Date().toISOString()
-        };
-
-        const balanceData: LowBalanceAlertData = {
-            currentBalance: '5.00',
-            thresholdBalance: '10.00',
-            asset: 'USDC'
-        };
-
-        // Emit all three event types
-        const startTime = Date.now();
-        
-        calloraEvents.emit('new_api_call', developerId, apiCallData);
-        calloraEvents.emit('settlement_completed', developerId, settlementData);
-        calloraEvents.emit('low_balance_alert', developerId, balanceData);
-
-        const emitDuration = Date.now() - startTime;
-        
-        // All emissions should be fast
-        assert.ok(emitDuration < 50, 'Multiple event emissions should be fast');
-
-        // Wait for async processing
-        await new Promise(resolve => setTimeout(resolve, 200));
-    });
-
-    test('event processing order is maintained per event type', async () => {
-        const developerId = 'dev_order_test';
-        const events: string[] = [];
-        
-        // This would require instrumentation of the actual handleEvent function
-        // For now, we test that events can be emitted in sequence
-        
-        const apiCallData: NewApiCallData = {
-            apiId: 'api_order_test',
-            endpoint: '/test',
-            method: 'GET',
-            statusCode: 200,
-            latencyMs: 100,
-            creditsUsed: 1
-        };
-
-        // Emit multiple events in sequence
-        for (let i = 0; i < 5; i++) {
-            calloraEvents.emit('new_api_call', developerId, {
-                ...apiCallData,
-                apiId: `api_order_test_${i}`
-            });
-        }
-
-        await new Promise(resolve => setTimeout(resolve, 200));
-        
-        // In a properly instrumented test, we'd verify processing order
-        assert.ok(true, 'Events emitted in sequence should be processed in order');
-    });
-});
-
-describe('Event Emitter - Error Handling and Edge Cases', () => {
-    test('handles malformed event data gracefully', () => {
-        const developerId = 'dev_malformed_test';
-        
-        // Emit with various malformed data
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', developerId, null);
-        });
-
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', developerId, undefined);
-        });
-
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', developerId, { invalid: 'data' });
-        });
-
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', null, {});
-        });
-
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', undefined, {});
-        });
-    });
-
-    test('handles unknown event types gracefully', () => {
-        const developerId = 'dev_unknown_test';
-        const data = { some: 'data' };
-
-        // Emit unknown event types
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('unknown_event', developerId, data);
-        });
-
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('', developerId, data);
-        });
-
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('another_unknown_event', developerId, data);
-        });
-    });
-
-    test('webhook store errors do not crash event processing', async () => {
-        // This would require mocking WebhookStore to throw errors
-        // For now, we test basic resilience
-        
-        const developerId = 'dev_store_error_test';
-        const apiCallData: NewApiCallData = {
-            apiId: 'api_store_error',
-            endpoint: '/test',
-            method: 'GET',
-            statusCode: 200,
-            latencyMs: 100,
-            creditsUsed: 1
-        };
-
-        assert.doesNotThrow(() => {
-            calloraEvents.emit('new_api_call', developerId, apiCallData);
-        });
-
-        await new Promise(resolve => setTimeout(resolve, 50));
-    });
-
-    test('memory usage remains stable under load', async () => {
-        // Get initial memory usage
-        const initialMemory = process.memoryUsage();
-        const initialListenerCount = calloraEvents.listenerCount('new_api_call');
-
-        // Simulate high load
-        const promises: Promise<void>[] = [];
-        for (let i = 0; i < 1000; i++) {
-            const promise = new Promise<void>((resolve) => {
-                const developerId = `dev_load_${i % 10}`;
-                const apiCallData: NewApiCallData = {
-                    apiId: `api_load_${i}`,
-                    endpoint: '/test',
-                    method: 'GET',
-                    statusCode: 200,
-                    latencyMs: 100,
-                    creditsUsed: 1
-                };
-
-                calloraEvents.emit('new_api_call', developerId, apiCallData);
-                setTimeout(resolve, 1);
-            });
-            promises.push(promise);
-        }
-
-        await Promise.all(promises);
-        await new Promise(resolve => setTimeout(resolve, 500)); // Wait for processing
-
-        const finalMemory = process.memoryUsage();
-        const finalListenerCount = calloraEvents.listenerCount('new_api_call');
-
-        // Listener count should be stable
-        assert.equal(finalListenerCount, initialListenerCount, 'Listener count should remain stable');
-
-        // Memory growth should be reasonable (less than 50MB increase)
-        const memoryGrowth = finalMemory.heapUsed - initialMemory.heapUsed;
-        assert.ok(memoryGrowth < 50 * 1024 * 1024, `Memory growth should be reasonable, was ${memoryGrowth / 1024 / 1024}MB`);
-    });
+      // @ts-expect-error payload shape must match the event name
+      calloraEvents.emit('new_api_call', 'dev_typecheck', { settlementId: 'wrong-shape' });
+    }
+  });
 });

--- a/src/events/event.emitter.ts
+++ b/src/events/event.emitter.ts
@@ -1,55 +1,114 @@
-import { EventEmitter } from 'events';
-import {
-    WebhookEventType,
-    WebhookPayload,
-    NewApiCallData,
-    SettlementCompletedData,
-    LowBalanceAlertData,
-} from '../webhooks/webhook.types.js';
-import { WebhookStore } from '../webhooks/webhook.store.js';
+import { logger } from '../logger.js';
 import { dispatchToAll } from '../webhooks/webhook.dispatcher.js';
+import { WebhookStore } from '../webhooks/webhook.store.js';
+import type {
+  LowBalanceAlertData,
+  NewApiCallData,
+  SettlementCompletedData,
+  WebhookPayload,
+} from '../webhooks/webhook.types.js';
 
-export const calloraEvents = new EventEmitter();
-
-async function handleEvent(
-    event: WebhookEventType,
-    developerId: string,
-    data: Record<string, unknown>
-): Promise<void> {
-    const payload: WebhookPayload = {
-        event,
-        timestamp: new Date().toISOString(),
-        developerId,
-        data,
-    };
-
-    const configs = WebhookStore.getByEvent(event).filter(
-        (cfg: { developerId: string }) => cfg.developerId === developerId
-    );
-
-    if (configs.length > 0) {
-        await dispatchToAll(configs, payload);
-    }
+export interface CalloraEventPayloadMap {
+  new_api_call: NewApiCallData;
+  settlement_completed: SettlementCompletedData;
+  low_balance_alert: LowBalanceAlertData;
 }
 
-// Bind listeners
-calloraEvents.on(
-    'new_api_call',
-    (developerId: string, data: NewApiCallData) => {
-        handleEvent('new_api_call', developerId, data as unknown as Record<string, unknown>);
-    }
-);
+export type CalloraEventName = keyof CalloraEventPayloadMap;
 
-calloraEvents.on(
-    'settlement_completed',
-    (developerId: string, data: SettlementCompletedData) => {
-        handleEvent('settlement_completed', developerId, data as unknown as Record<string, unknown>);
-    }
-);
+export type CalloraEventListener<K extends CalloraEventName> = (
+  developerId: string,
+  data: CalloraEventPayloadMap[K],
+) => void | Promise<void>;
 
-calloraEvents.on(
-    'low_balance_alert',
-    (developerId: string, data: LowBalanceAlertData) => {
-        handleEvent('low_balance_alert', developerId, data as unknown as Record<string, unknown>);
+export type CalloraEventUnsubscribe = () => void;
+
+type ListenerSetMap = {
+  [K in CalloraEventName]: Set<CalloraEventListener<K>>;
+};
+
+const createListenerSetMap = (): ListenerSetMap => ({
+  new_api_call: new Set<CalloraEventListener<'new_api_call'>>(),
+  settlement_completed: new Set<CalloraEventListener<'settlement_completed'>>(),
+  low_balance_alert: new Set<CalloraEventListener<'low_balance_alert'>>(),
+});
+
+async function handleEvent<K extends CalloraEventName>(
+  event: K,
+  developerId: string,
+  data: CalloraEventPayloadMap[K],
+): Promise<void> {
+  const payload: WebhookPayload = {
+    event,
+    timestamp: new Date().toISOString(),
+    developerId,
+    data: data as unknown as Record<string, unknown>,
+  };
+
+  const configs = WebhookStore.getByEvent(event).filter(
+    (cfg: { developerId: string }) => cfg.developerId === developerId,
+  );
+
+  if (configs.length > 0) {
+    await dispatchToAll(configs, payload);
+  }
+}
+
+class TypedCalloraEventEmitter {
+  private readonly listeners: ListenerSetMap = createListenerSetMap();
+
+  on<K extends CalloraEventName>(
+    event: K,
+    listener: CalloraEventListener<K>,
+  ): CalloraEventUnsubscribe {
+    this.listeners[event].add(listener);
+    return () => {
+      this.off(event, listener);
+    };
+  }
+
+  off<K extends CalloraEventName>(event: K, listener: CalloraEventListener<K>): void {
+    this.listeners[event].delete(listener);
+  }
+
+  emit<K extends CalloraEventName>(event: K, developerId: string, data: CalloraEventPayloadMap[K]): boolean {
+    const listeners = [...this.listeners[event]];
+
+    for (const listener of listeners) {
+      void Promise.resolve(listener(developerId, data)).catch((error) => {
+        logger.error(`Unhandled error while processing ${event} listener`, error);
+      });
     }
-);
+
+    return listeners.length > 0;
+  }
+
+  listenerCount<K extends CalloraEventName>(event: K): number {
+    return this.listeners[event].size;
+  }
+
+  removeAllListeners<K extends CalloraEventName>(event?: K): void {
+    if (event) {
+      this.listeners[event].clear();
+      return;
+    }
+
+    for (const listeners of Object.values(this.listeners)) {
+      listeners.clear();
+    }
+  }
+}
+
+export const calloraEvents = new TypedCalloraEventEmitter();
+
+calloraEvents.on('new_api_call', (developerId, data) => {
+  return handleEvent('new_api_call', developerId, data);
+});
+
+calloraEvents.on('settlement_completed', (developerId, data) => {
+  return handleEvent('settlement_completed', developerId, data);
+});
+
+calloraEvents.on('low_balance_alert', (developerId, data) => {
+  return handleEvent('low_balance_alert', developerId, data);
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,3 +32,10 @@ export interface UsageResponse {
   calls: number;
   period: string;
 }
+
+export type {
+  CalloraEventListener,
+  CalloraEventName,
+  CalloraEventPayloadMap,
+  CalloraEventUnsubscribe,
+} from '../events/event.emitter.js';


### PR DESCRIPTION
## Overview
This PR adds typed event contracts and safe unsubscribe behavior to `src/events/event.emitter.ts`, which underpins billing and usage domain-event fan-out. It replaces the untyped raw emitter usage with a typed event-name to payload map, guarantees exact-listener unsubscribe semantics, and documents the available event payloads and runtime behavior.

## Related Issue
Closes #335

## Changes

### ⚙️ Typed Event Contracts
- **[MODIFY]** `src/events/event.emitter.ts`
- Added a typed `CalloraEventPayloadMap` covering all supported domain events.
- Enforced event-name to payload matching through the emitter API.
- Kept the existing built-in webhook bridge listeners while moving them behind the typed wrapper.
- Added typed listener, event-name, and unsubscribe exports for reuse across the codebase.

### 🔒 Safe Unsubscribe Semantics
- **[MODIFY]** `src/events/event.emitter.ts`
- Added exact-listener `off(...)` behavior.
- Made the unsubscribe function returned by `on(...)` idempotent.
- Ensured removing one listener does not affect other listeners on the same event.

### 📘 Event Documentation
- **[MODIFY]** `src/events/README.md`
- Documented the available events and their payload contracts.
- Documented the typed API surface and unsubscribe guarantees.
- Clarified that `emit(...)` is synchronous while webhook delivery remains asynchronous.

### 🧾 Shared Type Exports
- **[MODIFY]** `src/types/index.ts`
- Re-exported the event types so other modules can consume the typed contracts centrally.

### 🧪 Tests
- **[MODIFY]** `src/events/event.emitter.test.ts`
- Added focused coverage for built-in listener registration.
- Added coverage for typed payload dispatch behavior.
- Added coverage for exact-listener unsubscribe and idempotent cleanup.
- Added compile-time contract checks for unknown events and mismatched payloads.

- **[MODIFY]** `jest.config.cjs`
- Removed the stale ignore rule that prevented `src/events/event.emitter.test.ts` from running.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Emitting an unknown event or wrong payload is a type error | ✅ |
| Unsubscribe removes only the target listener and is idempotent | ✅ |
| Events are documented in README.md | ✅ |
| Focused event emitter tests pass successfully | ✅ |
| Existing webhook dispatch pipeline still passes | ✅ |
| Typecheck passes successfully | ✅ |


## Screenshots

### ✅ Event emitter tests pass
A screenshot of:

```bash
npm test -- src/events/event.emitter.test.ts
```
<img width="622" height="308" alt="image" src="https://github.com/user-attachments/assets/d31de965-8963-4144-97b1-3e3b466c6c98" />

### ✅ Webhook dispatch pipeline still passes
A screenshot of:

```bash
npm test -- tests/integration/webhook-dispatch-pipeline.test.ts
```
<img width="613" height="327" alt="image" src="https://github.com/user-attachments/assets/83618391-cbb2-4733-b1a0-e3b3b96b0eff" />
