### PR TITLE
Route label

### DIFF
--- a/src/__tests__/metricsLatency.test.ts
+++ b/src/__tests__/metricsLatency.test.ts
@@ -335,6 +335,174 @@ describe('metricsMiddleware — 404 cardinality protection', () => {
     });
     expect(entry).toBeDefined();
   });
+
+  it('uses sentinel label for pathological routes (excessive segments)', async () => {
+    // Build a path with > 20 segments to trigger sentinel
+    const pathSegments = Array.from({ length: 25 }, (_,i) => `seg${i}`).join('/');
+    const { req, res } = buildReqRes({
+      path: `/${pathSegments}`,
+      routePath: null,
+      statusCode: 404,
+    });
+
+    metricsMiddleware(req, res, jest.fn());
+    res.emit('finish');
+
+    const metric = await getMetricValues('http_requests_total');
+    const entry = findCounter(metric!.values, {
+      status_code: '404',
+    });
+    expect(entry).toBeDefined();
+    // Should be the sentinel label, not the raw path
+    expect(entry!.labels.route).toBe('_unknown');
+  });
+
+  it('normalizes mixed UUID and numeric segments', async () => {
+    const uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const { req, res } = buildReqRes({
+      path: `/api/vault/${uuid}/items/42/details/99`,
+      routePath: null,
+      statusCode: 404,
+    });
+
+    metricsMiddleware(req, res, jest.fn());
+    res.emit('finish');
+
+    const metric = await getMetricValues('http_requests_total');
+    const entry = findCounter(metric!.values, { status_code: '404' });
+    expect(entry).toBeDefined();
+    expect(entry!.labels.route).not.toContain(uuid);
+    expect(entry!.labels.route).not.toContain('/42');
+    expect(entry!.labels.route).not.toContain('/99');
+    expect(entry!.labels.route).toMatch(/\/api\/vault\/:uuid\/items\/:id\/details\/:id/);
+  });
+
+  it('does not normalize when route is matched (Express route pattern)', async () => {
+    const { req, res } = buildReqRes({
+      path: '/api/vault/123/withdraw',
+      routePath: '/api/vault/:vaultId/withdraw',
+      statusCode: 200,
+    });
+
+    metricsMiddleware(req, res, jest.fn());
+    res.emit('finish');
+
+    const metric = await getMetricValues('http_requests_total');
+    const entry = findCounter(metric!.values, { status_code: '200' });
+    expect(entry).toBeDefined();
+    // Should use the Express route template, not sanitized fallback
+    expect(entry!.labels.route).toBe('/api/vault/:vaultId/withdraw');
+  });
+
+  it('handles gateway routes with dynamic apiId correctly', async () => {
+    const { req, res } = buildReqRes({
+      path: '/v1/call/abc-123-def',
+      routePath: '/v1/call/:apiId',
+      statusCode: 200,
+    });
+
+    metricsMiddleware(req, res, jest.fn());
+    res.emit('finish');
+
+    const metric = await getMetricValues('http_requests_total');
+    const entry = findCounter(metric!.values, { status_code: '200' });
+    expect(entry).toBeDefined();
+    expect(entry!.labels.route).toBe('/v1/call/:apiId');
+    expect(entry!.labels.route).not.toContain('abc-123-def');
+  });
+
+  it('caps multiple sequential UUIDs and IDs', async () => {
+    const uuid1 = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const uuid2 = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
+    const { req, res } = buildReqRes({
+      path: `/api/users/${uuid1}/orders/${uuid2}`,
+      routePath: null,
+      statusCode: 404,
+    });
+
+    metricsMiddleware(req, res, jest.fn());
+    res.emit('finish');
+
+    const metric = await getMetricValues('http_requests_total');
+    const entry = findCounter(metric!.values, { status_code: '404' });
+    expect(entry).toBeDefined();
+    expect(entry!.labels.route).not.toContain(uuid1);
+    expect(entry!.labels.route).not.toContain(uuid2);
+    expect(entry!.labels.route).toMatch(/\/api\/users\/:uuid\/orders\/:uuid/);
+  });
+
+  it('preserves baseUrl when normalizing routes', async () => {
+    const { req, res } = buildReqRes({
+      path: '/items/12345',
+      baseUrl: '/api/vault',
+      routePath: null,
+      statusCode: 404,
+    });
+
+    metricsMiddleware(req, res, jest.fn());
+    res.emit('finish');
+
+    const metric = await getMetricValues('http_requests_total');
+    const entry = findCounter(metric!.values, { status_code: '404' });
+    expect(entry).toBeDefined();
+    expect(entry!.labels.route).toBe('/api/vault/items/:id');
+  });
+});
+
+describe('metricsMiddleware — cardinality assertions', () => {
+  it('bounds cardinality of route labels across many different numeric IDs', async () => {
+    const metric = await getMetricValues('http_requests_total');
+    const beforeCount = metric?.values.length ?? 0;
+
+    // Simulate 100 different numeric IDs
+    for (let i = 0; i < 100; i++) {
+      const { req, res } = buildReqRes({
+        path: `/api/items/${i}`,
+        routePath: null,
+        statusCode: 404,
+      });
+      metricsMiddleware(req, res, jest.fn());
+      res.emit('finish');
+    }
+
+    // All requests should be aggregated under the same normalized route
+    const metricsAfter = await getMetricValues('http_requests_total');
+    const entry = findCounter(metricsAfter!.values, {
+      route: '/api/items/:id',
+      status_code: '404',
+    });
+    expect(entry).toBeDefined();
+    expect(entry!.value).toBe(100);
+
+    // Should not have 100 separate entries for each numeric ID
+    const uniqueRoutes = new Set(
+      metricsAfter!.values.map((v) => v.labels.route),
+    );
+    expect(uniqueRoutes.size).toBeLessThan(beforeCount + 10);
+  });
+
+  it('bounds cardinality for bot-like path scanning', async () => {
+    // Simulate bot scanning for paths with random numeric suffixes
+    const randomIds = [999, 12345, 1, 999999, 42, 777];
+    for (const id of randomIds) {
+      const { req, res } = buildReqRes({
+        path: `/admin/users/${id}`,
+        routePath: null,
+        statusCode: 404,
+      });
+      metricsMiddleware(req, res, jest.fn());
+      res.emit('finish');
+    }
+
+    const metric = await getMetricValues('http_requests_total');
+    // All bot requests should be aggregated under a single route label
+    const entry = findCounter(metric!.values, {
+      route: '/admin/users/:id',
+      status_code: '404',
+    });
+    expect(entry).toBeDefined();
+    expect(entry!.value).toBe(randomIds.length);
+  });
 });
 
 describe('metricsMiddleware — histogram buckets', () => {

--- a/src/__tests__/metricsLatency.test.ts
+++ b/src/__tests__/metricsLatency.test.ts
@@ -3,8 +3,10 @@
  *
  * Covers:
  *   - resolveRouteGroup: all route groups, edge cases, unknown paths
- *   - metricsMiddleware: label correctness, route sanitisation, counter/histogram
- *     increments, 404 cardinality protection
+ *   - normalizeRouteForMetrics: route normalization, UUID/ID sanitization,
+ *     sentinel labels for pathological routes
+ *   - metricsMiddleware: label correctness, cardinality protection,
+ *     counter/histogram increments
  */
 
 import { EventEmitter } from 'node:events';

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -160,44 +160,79 @@ export function startUpstreamTimer(apiId: string, method: string): UpstreamTimer
   };
 }
 
+/** Sentinel value for routes that couldn't be recognized and normalized. */
+const UNKNOWN_ROUTE_SENTINEL = '_unknown';
+
+/**
+ * Normalize a route to a safe, low-cardinality template pattern.
+ *
+ * Rules:
+ *   1. If matched via Express routing (req.route.path), use that pattern
+ *      (e.g., /v1/call/:apiId instead of /v1/call/abc123)
+ *   2. If unmatched (404), sanitize numeric IDs and UUIDs by replacing
+ *      them with :id and :uuid placeholders
+ *   3. For deeply nested or suspicious paths, return the sentinel label
+ *
+ * This ensures metrics cardinality stays bounded regardless of URL
+ * parameter values, bot activity, or path-scanning attacks.
+ */
+function normalizeRouteForMetrics(
+  matched: string | undefined,
+  baseUrl: string | undefined,
+  unmatched: string,
+): string {
+  // Prefer matched route pattern from Express routing
+  if (matched) {
+    return (baseUrl || '') + matched;
+  }
+
+  // Sanitize unmatched paths: replace UUIDs and numeric IDs with placeholders
+  let sanitized = unmatched
+    .replace(/\/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}(?=\/|$)/g, '/:uuid')
+    .replace(/\/\d+(?=\/|$)/g, '/:id');
+
+  // Additional safety: if the path is still very long or has too many segments,
+  // cap it to prevent any pathological cases
+  const segments = sanitized.split('/').filter((s) => s.length > 0);
+  if (segments.length > 20) {
+    return UNKNOWN_ROUTE_SENTINEL;
+  }
+
+  return (baseUrl || '') + sanitized;
+}
+
 /**
  * Global middleware to record per-request latency and count metrics.
  *
  * Labels:
  *   method       – HTTP verb (GET, POST, …)
- *   route        – Parameterised route pattern (/api/apis/:id) or sanitised
- *                  fallback for unmatched paths.  Never contains raw user input.
- *   status_code  – HTTP response status as a string.
- *   route_group  – Logical service area (health, billing, vault, …).
+ *   route        – Parameterised route template (/api/apis/:id) or normalized
+ *                  fallback for unmatched paths; uses sentinel for pathological routes
+ *   status_code  – HTTP response status as a string
+ *   route_group  – Logical service area (health, billing, vault, …)
  *
  * Security / cardinality notes:
- *   - `route` uses req.route.path (Express's matched pattern) when available,
- *     so dynamic segments like IDs are collapsed to `:id` / `:uuid`.
- *   - For 404s the path is sanitised by replacing numeric and UUID segments
- *     before being stored, preventing cardinality explosions from bots or
- *     path-scanning attacks.
- *   - `route_group` is derived from the sanitised route, not raw user input.
+ *   - Routes with matched patterns use the template (e.g., /v1/call/:apiId)
+ *   - Unmatched paths (404s) are normalized by collapsing UUIDs and numeric IDs
+ *   - Pathological routes (too many segments) are capped under a sentinel label
+ *   - This prevents cardinality explosion from dynamic path segments, bots, or attacks
  */
 export const metricsMiddleware = (req: Request, res: Response, next: NextFunction): void => {
   const endTimer = httpRequestDuration.startTimer();
 
   res.on('finish', () => {
-    // Use Express's matched route pattern when available (collapses :id, :uuid, etc.)
-    let routePattern = req.route ? req.route.path : req.path;
+    // Normalize the route to a safe cardinality label
+    const routePattern = normalizeRouteForMetrics(
+      req.route?.path,
+      req.baseUrl,
+      req.path,
+    );
 
-    // Sanitise unmatched paths (404s) to prevent cardinality injection
-    if (!req.route) {
-      routePattern = routePattern
-        .replace(/\/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/g, '/:uuid')
-        .replace(/\/\d+/g, '/:id');
-    }
-
-    const fullRoute = (req.baseUrl || '') + routePattern;
-    const routeGroup = resolveRouteGroup(fullRoute);
+    const routeGroup = resolveRouteGroup(routePattern);
 
     const labels = {
       method: req.method,
-      route: fullRoute,
+      route: routePattern,
       status_code: res.statusCode.toString(),
       route_group: routeGroup,
     };


### PR DESCRIPTION
 Added the route-label cardinality control to Prometheus metrics to prevent :apiId path explosion

Description
src/metrics.ts tracks http_requests_total and http_request_duration_seconds, but if labels include raw paths like /v1/call/:apiId, dynamic segments cause unbounded label cardinality. This backend task normalizes route labels to template form so metrics stay bounded and scrapable.

Requirements and Context
Label histograms/counters with the matched route template, not the concrete path.
Cap or bucket unknown routes under a sentinel label.
Keep the protected /api/metrics behavior in production intact.
Must be secure, tested, and documented
Should be efficient and easy to review
Suggested Execution
Fork the repo and create a branch
git checkout -b task/metrics-label-cardinality
Implement changes
src/metrics.ts — normalize route labels
src/middleware/logging.ts — supply matched route
Add a cardinality assertion test
Test and commit
npm test -- src/__tests__/metricsLatency.test.ts
Cover edge cases
Include test output and notes in the PR
Example commit message

task: normalize Prometheus route labels to templates
Acceptance Criteria
 Dynamic path segments collapse to route templates
 Unknown routes map to a bounded sentinel label
 Production metrics auth is unchanged
 closes #329