### PR TITLE
task: enforce unique active api_key prefixes

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,72 +1,81 @@
-# PR Description for Issue #236
+# task: enforce unique active api_key prefixes
 
-## chore(backend): add pagination defaults and max limits enforcement across list endpoints
+## Summary
 
-### Summary
+The gateway auth flow in `src/middleware/gatewayApiKeyAuth.ts` performs a
+prefix-based lookup before a timing-safe full-key hash comparison.  Without a
+database-level guarantee, two active keys could share the same prefix, making
+the lookup ambiguous and potentially allowing one key to shadow another.
 
-This PR addresses issue #236 by implementing consistent pagination defaults and maximum limit enforcement across all list endpoints in the `callora-backend` repository. This improves API consistency, performance, and protects against unbounded queries that could be used for DoS attacks.
+This PR adds the missing constraint and its regression tests.
 
-### 🧪 Implementation Details
+---
 
-- **Core Pagination Helper**: Updated `src/lib/pagination.ts` to support both `offset/limit` and `page/limit` pagination.
-- **Default Limits**: Enforced a `DEFAULT_LIMIT` of 20 and a `MAX_LIMIT` of 100.
-- **Input Normalization**: Parsed and clamped invalid inputs (NaN, negative, zero) to safe defaults.
-- **Refactoring**: Updated `src/app.ts`, `src/routes/admin.ts`, and `src/routes/developerRoutes.ts` to use the shared `parsePagination` and `paginatedResponse` helpers consistently.
-- **Repository Updates**: Extended `UsageEventsRepository` (both In-Memory and PG implementations) to support pagination (`limit` and `offset`).
-- **Endpoint Improvements**: Implemented full public API listing in `GET /api/apis` and standardized response formats.
+## Changes
 
-### 📋 Key Findings & Security Notes
+### `migrations/0006_api_key_prefix_unique.sql` (new)
+Adds a **partial unique index** on `api_keys (prefix) WHERE revoked = FALSE`.
 
-#### Security and Data Integrity Assumptions
-⚠️ **Security Note**: By enforcing a `MAX_LIMIT` of 100, we prevent potentially expensive database queries that could return thousands of rows, which could be used as an application-layer DoS vector.
-- **Input Sanitization**: All pagination parameters are parsed as integers and clamped to safe ranges (limit 1-100, offset >= 0). This prevents unexpected behavior or SQL injection through pagination parameters.
-- **Consistency**: Using a single source of truth (`parsePagination`) ensures that all list endpoints behave identically, reducing developer error when adding new endpoints.
-- **Default Behavior**: If no pagination parameters are provided, the system defaults to the first page (offset 0) with a limit of 20, ensuring stable and predictable API responses without overwhelming the backend or client.
-
-### 📁 Files Changed
-
-- `src/lib/pagination.ts` - Core pagination logic
-- `src/lib/__tests__/pagination.test.ts` - Unit tests
-- `src/app.ts` - Refactored endpoints
-- `src/repositories/usageEventsRepository.ts` - Interface updates
-- `src/repositories/usageEventsRepository.pg.ts` - PostgreSQL implementation updates
-- `src/routes/admin.ts` - Admin routes
-- `src/routes/developerRoutes.ts` - Developer analytics routes
-
-### 🚀 Test Results
-
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS uq_api_keys_prefix_active
+  ON api_keys (prefix)
+  WHERE revoked = FALSE;
 ```
-▶ parsePagination
-  ✔ returns defaults when no query params given
-  ✔ parses valid limit and offset
-  ✔ clamps limit to max 100
-  ✔ clamps limit to min 1
-  ✔ clamps offset to min 0
-  ✔ handles non-numeric strings gracefully
-  ✔ truncates floating-point limit via parseInt
-  ✔ clamps a huge limit (Number.MAX_SAFE_INTEGER) to 100
-  ✔ calculates offset based on page and limit
-  ✔ uses default limit when only page is provided
-  ✔ prefers page over offset when both are provided
-  ✔ handles invalid page values gracefully
-...
-✔ parsePagination (2.98ms)
-▶ paginatedResponse
-  ✔ wraps data and meta into the envelope
-  ✔ works without total in meta
-  ✔ returns exactly "data" and "meta" top-level keys
-...
-✔ paginatedResponse (1.05ms)
 
-ℹ tests 32
-ℹ suites 2
-ℹ pass 32
-ℹ fail 0
+- Active keys are guaranteed to have unique prefixes at the database level.
+- Revoked keys are excluded so a prefix can be reused after revocation.
+
+### `migrations/0006_api_key_prefix_unique.down.sql` (new)
+Rollback: `DROP INDEX IF EXISTS uq_api_keys_prefix_active;`
+
+### `src/repositories/apiKeyRepository.prefix.test.ts` (new)
+Constraint regression tests using **pg-mem** (no external DB required):
+
+| Test | Covers |
+|------|--------|
+| Allows unique active prefix | Happy path |
+| Allows two active keys with different prefixes | Happy path |
+| Rejects duplicate active prefix | Collision — acceptance criterion 1 |
+| Rejects duplicate prefix for different `api_id` | Collision variant |
+| Allows prefix reuse after revocation | Revocation — acceptance criterion 2 |
+| Allows multiple revoked keys with same prefix | Revocation variant |
+| Does not block new active key when revoked key exists | Revocation — acceptance criterion 3 |
+| Allows multiple NULL-prefix rows | Documents NULL semantics |
+| Prefix lookup returns exactly one row | Mirrors gateway middleware query |
+| Prefix lookup returns zero rows after revocation | Mirrors gateway middleware query |
+
+### `tests/helpers/db.ts` (updated)
+Added `prefix VARCHAR(16)` column and the partial unique index to the shared
+pg-mem schema used by integration tests, keeping it in sync with the real
+PostgreSQL schema.
+
+### `docs/gateway-api-key-auth.md` (updated)
+Added a **Prefix uniqueness guarantee** section documenting the new index and
+pointing to the regression tests.
+
+### `migrations/README.md` (updated)
+Added migration 0006 to the table.
+
+---
+
+## Acceptance criteria
+
+- [x] Inserting a duplicate active prefix fails at the database level
+- [x] Revoked keys do not block reuse of a prefix
+- [x] Tests cover collision and revocation cases
+
+---
+
+## Testing
+
+Tests run with Jest + pg-mem (no external PostgreSQL required):
+
+```bash
+npm test -- --testPathPattern="apiKeyRepository.prefix.test"
 ```
-- **Total Test Cases**: 32 unit tests
-- **Result**: All passing
 
-### 🔧 Commands Run
-- `npm run lint` - Success (0 errors)
-- `npx tsx --test src/lib/__tests__/pagination.test.ts` - Success (32/32 tests passed)
-- `git checkout -b feature/pagination-defaults-max` - Success
+All 10 constraint regression tests pass.
+
+---
+
+closes #309

--- a/docs/gateway-api-key-auth.md
+++ b/docs/gateway-api-key-auth.md
@@ -71,3 +71,16 @@ The database-backed middleware supports:
 To support revocation in environments that do not yet have the column, apply:
 
 - `migrations/0005_add_api_key_revocation.sql`
+
+### Prefix uniqueness guarantee
+
+Migration `0006_api_key_prefix_unique.sql` adds a **partial unique index** on
+`api_keys (prefix) WHERE revoked = FALSE`.  This guarantees that the
+prefix-based lookup in step 3 of the validation flow always returns at most one
+active candidate, eliminating any ambiguity before the full hash comparison.
+
+Revoked keys are excluded from the index so a prefix can be legitimately reused
+after a key is revoked (e.g. after rotation).
+
+Constraint regression tests live in:
+`src/repositories/apiKeyRepository.prefix.test.ts`

--- a/migrations/0006_api_key_prefix_unique.down.sql
+++ b/migrations/0006_api_key_prefix_unique.down.sql
@@ -1,0 +1,4 @@
+-- Rollback: 0006_api_key_prefix_unique
+-- Drops the partial unique index that enforces prefix uniqueness among active keys.
+
+DROP INDEX IF EXISTS uq_api_keys_prefix_active;

--- a/migrations/0006_api_key_prefix_unique.sql
+++ b/migrations/0006_api_key_prefix_unique.sql
@@ -1,0 +1,15 @@
+-- Migration: 0006_api_key_prefix_unique
+-- Purpose: Enforce uniqueness of api_keys.prefix among active (non-revoked) keys.
+--
+-- The gateway auth flow in src/middleware/gatewayApiKeyAuth.ts performs a
+-- prefix-based lookup before a timing-safe full-key hash comparison.  Without
+-- a database-level guarantee, two active keys could share the same prefix,
+-- making the lookup ambiguous and potentially allowing one key to shadow another.
+--
+-- A partial unique index (WHERE revoked = FALSE) is used instead of a plain
+-- UNIQUE constraint so that revoked keys do not block prefix reuse — a new
+-- active key may legitimately reuse a prefix that was previously revoked.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_api_keys_prefix_active
+  ON api_keys (prefix)
+  WHERE revoked = FALSE;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -42,6 +42,7 @@ Examples:
 | 005  | `005_add_persistent_store_columns.sql` | Adds `external_id`, `api_key`, `status_code` columns |
 | 0004 | `0004_create_developers.sql` | `developers` profile table |
 | 0005 | `0005_add_api_key_revocation.sql` | Adds `revoked` column to `api_keys` |
+| 0006 | `0006_api_key_prefix_unique.sql` | Partial unique index on `api_keys.prefix` for active keys |
 
 > **Note:** `add_refresh_tokens.sql` lacks a numeric prefix and will be rejected by the runner.
 > It must be renamed to `0006_add_refresh_tokens.sql` (or the next available number) before use.

--- a/src/repositories/apiKeyRepository.prefix.test.ts
+++ b/src/repositories/apiKeyRepository.prefix.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Constraint regression tests for api_keys.prefix uniqueness (issue #309).
+ *
+ * The gateway auth flow performs a prefix-based lookup before a timing-safe
+ * full-key hash comparison.  Without a database-level guarantee, two active
+ * keys could share the same prefix, making the lookup ambiguous.
+ *
+ * These tests verify the partial unique index introduced in migration
+ * 0006_api_key_prefix_unique.sql using an in-process pg-mem database so no
+ * external PostgreSQL instance is required.
+ *
+ * Acceptance criteria (from issue #309):
+ *   ✓ Inserting a duplicate active prefix fails at the database level.
+ *   ✓ Revoked keys do not block reuse of a prefix.
+ *   ✓ Tests cover collision and revocation cases.
+ */
+
+import { DataType, newDb } from 'pg-mem';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an isolated pg-mem database that mirrors the api_keys schema
+ * including the partial unique index from migration 0006.
+ */
+function createPrefixTestDb() {
+  const db = newDb();
+
+  // Register gen_random_uuid() so DEFAULT expressions work.
+  let counter = 0;
+  db.public.registerFunction({
+    name: 'gen_random_uuid',
+    returns: DataType.uuid,
+    implementation: () => {
+      counter++;
+      return `00000000-0000-4000-a000-${String(counter).padStart(12, '0')}`;
+    },
+  });
+
+  db.public.none(`
+    CREATE TABLE users (
+      id   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      wallet_address TEXT UNIQUE NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE api_keys (
+      id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id    UUID REFERENCES users(id),
+      api_id     TEXT NOT NULL,
+      key_hash   TEXT NOT NULL,
+      -- prefix column — the first 16 characters of the raw API key.
+      -- Used by the gateway middleware for an efficient pre-filter lookup
+      -- before the full timing-safe hash comparison.
+      prefix     VARCHAR(16),
+      revoked    BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+
+    -- Partial unique index (migration 0006_api_key_prefix_unique.sql).
+    -- Only active (non-revoked) keys must have unique prefixes.
+    -- Revoked keys are excluded so a prefix can be reused after revocation.
+    CREATE UNIQUE INDEX uq_api_keys_prefix_active
+      ON api_keys (prefix)
+      WHERE revoked = FALSE;
+  `);
+
+  const { Pool } = db.adapters.createPg();
+  const pool = new Pool();
+
+  return { db, pool, async end() { await pool.end(); } };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('api_keys.prefix partial unique index (migration 0006)', () => {
+  let ctx: ReturnType<typeof createPrefixTestDb>;
+  let pool: ReturnType<typeof createPrefixTestDb>['pool'];
+
+  beforeEach(() => {
+    ctx = createPrefixTestDb();
+    pool = ctx.pool;
+  });
+
+  afterEach(async () => {
+    await ctx.end();
+  });
+
+  // ── Happy-path ────────────────────────────────────────────────────────────
+
+  it('allows inserting an active key with a unique prefix', async () => {
+    const result = await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', 'ck_live_prefix1')
+       RETURNING id, prefix, revoked`,
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].prefix).toBe('ck_live_prefix1');
+    expect(result.rows[0].revoked).toBe(false);
+  });
+
+  it('allows two active keys with different prefixes', async () => {
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', 'ck_live_prefix1')`,
+    );
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-b', 'ck_live_prefix2')`,
+    );
+
+    const { rows } = await pool.query(
+      `SELECT prefix FROM api_keys WHERE revoked = FALSE ORDER BY prefix`,
+    );
+    expect(rows.map((r: { prefix: string }) => r.prefix)).toEqual([
+      'ck_live_prefix1',
+      'ck_live_prefix2',
+    ]);
+  });
+
+  // ── Collision enforcement ─────────────────────────────────────────────────
+
+  it('rejects a second active key with a duplicate prefix (collision case)', async () => {
+    // Insert the first active key.
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', 'ck_live_prefix1')`,
+    );
+
+    // Attempting to insert a second active key with the same prefix must fail.
+    await expect(
+      pool.query(
+        `INSERT INTO api_keys (api_id, key_hash, prefix)
+         VALUES ('api-2', 'hash-b', 'ck_live_prefix1')`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a duplicate active prefix even for a different api_id', async () => {
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', 'ck_live_shared_p')`,
+    );
+
+    await expect(
+      pool.query(
+        `INSERT INTO api_keys (api_id, key_hash, prefix)
+         VALUES ('api-3', 'hash-c', 'ck_live_shared_p')`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  // ── Revocation allows prefix reuse ────────────────────────────────────────
+
+  it('allows a new active key to reuse a prefix after the original key is revoked', async () => {
+    // Insert and then revoke the first key.
+    const insert = await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', 'ck_live_prefix1')
+       RETURNING id`,
+    );
+    const keyId: string = insert.rows[0].id;
+
+    await pool.query(
+      `UPDATE api_keys SET revoked = TRUE WHERE id = $1`,
+      [keyId],
+    );
+
+    // The revoked key must no longer appear in the active set.
+    const active = await pool.query(
+      `SELECT id FROM api_keys WHERE prefix = 'ck_live_prefix1' AND revoked = FALSE`,
+    );
+    expect(active.rows).toHaveLength(0);
+
+    // A new active key with the same prefix must be accepted.
+    const reuse = await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-b', 'ck_live_prefix1')
+       RETURNING id, prefix, revoked`,
+    );
+    expect(reuse.rows).toHaveLength(1);
+    expect(reuse.rows[0].prefix).toBe('ck_live_prefix1');
+    expect(reuse.rows[0].revoked).toBe(false);
+  });
+
+  it('allows multiple revoked keys to share the same prefix', async () => {
+    // Insert two keys with the same prefix, revoking each before inserting the next.
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', 'ck_live_prefix1')`,
+    );
+    await pool.query(
+      `UPDATE api_keys SET revoked = TRUE WHERE prefix = 'ck_live_prefix1'`,
+    );
+
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-b', 'ck_live_prefix1')`,
+    );
+    await pool.query(
+      `UPDATE api_keys SET revoked = TRUE WHERE prefix = 'ck_live_prefix1'`,
+    );
+
+    const { rows } = await pool.query(
+      `SELECT id FROM api_keys WHERE prefix = 'ck_live_prefix1' AND revoked = TRUE`,
+    );
+    expect(rows).toHaveLength(2);
+  });
+
+  // ── Revoked key does not block a new active key ───────────────────────────
+
+  it('does not block a new active key when a revoked key with the same prefix exists', async () => {
+    // Insert and revoke.
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', 'ck_live_prefix1')`,
+    );
+    await pool.query(
+      `UPDATE api_keys SET revoked = TRUE WHERE prefix = 'ck_live_prefix1'`,
+    );
+
+    // New active key — must succeed.
+    await expect(
+      pool.query(
+        `INSERT INTO api_keys (api_id, key_hash, prefix)
+         VALUES ('api-1', 'hash-b', 'ck_live_prefix1')`,
+      ),
+    ).resolves.toBeDefined();
+
+    // Exactly one active key with this prefix.
+    const { rows } = await pool.query(
+      `SELECT id FROM api_keys WHERE prefix = 'ck_live_prefix1' AND revoked = FALSE`,
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  // ── NULL prefix is excluded from the constraint ───────────────────────────
+
+  it('allows multiple rows with NULL prefix (index does not cover NULLs)', async () => {
+    // NULL prefixes are not covered by the unique index (standard SQL NULL
+    // semantics: NULL ≠ NULL).  This test documents that behaviour.
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix) VALUES ('api-1', 'hash-a', NULL)`,
+    );
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix) VALUES ('api-1', 'hash-b', NULL)`,
+    );
+
+    const { rows } = await pool.query(
+      `SELECT id FROM api_keys WHERE prefix IS NULL`,
+    );
+    expect(rows).toHaveLength(2);
+  });
+
+  // ── Lookup path mirrors the gateway middleware ────────────────────────────
+
+  it('returns exactly one row for a prefix lookup when the index is enforced', async () => {
+    const prefix = 'ck_live_prefix1';
+
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', $1)`,
+      [prefix],
+    );
+
+    // This is the query pattern used by createDatabaseGatewayApiKeyAuthMiddleware.
+    const { rows } = await pool.query(
+      `SELECT id, prefix, key_hash, revoked
+       FROM api_keys
+       WHERE prefix = $1 AND revoked = FALSE`,
+      [prefix],
+    );
+
+    // The partial unique index guarantees at most one active row per prefix.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].prefix).toBe(prefix);
+  });
+
+  it('returns zero rows for a prefix lookup after the key is revoked', async () => {
+    const prefix = 'ck_live_prefix1';
+
+    await pool.query(
+      `INSERT INTO api_keys (api_id, key_hash, prefix)
+       VALUES ('api-1', 'hash-a', $1)`,
+      [prefix],
+    );
+    await pool.query(
+      `UPDATE api_keys SET revoked = TRUE WHERE prefix = $1`,
+      [prefix],
+    );
+
+    const { rows } = await pool.query(
+      `SELECT id FROM api_keys WHERE prefix = $1 AND revoked = FALSE`,
+      [prefix],
+    );
+
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -26,9 +26,16 @@ export function createTestDb() {
       user_id UUID REFERENCES users(id),
       api_id TEXT NOT NULL,
       key_hash TEXT NOT NULL,
+      prefix VARCHAR(16),
       revoked BOOLEAN DEFAULT FALSE,
       created_at TIMESTAMP DEFAULT NOW()
     );
+
+    -- Partial unique index: only active (non-revoked) keys must have unique prefixes.
+    -- Revoked keys are excluded so a prefix can be reused after revocation.
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_api_keys_prefix_active
+      ON api_keys (prefix)
+      WHERE revoked = FALSE;
 
     CREATE TABLE IF NOT EXISTS usage_logs (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
# task: enforce unique active api_key prefixes

## Summary

The gateway auth flow in `src/middleware/gatewayApiKeyAuth.ts` performs a
prefix-based lookup before a timing-safe full-key hash comparison.  Without a
database-level guarantee, two active keys could share the same prefix, making
the lookup ambiguous and potentially allowing one key to shadow another.

This PR adds the missing constraint and its regression tests.

---

## Changes

### `migrations/0006_api_key_prefix_unique.sql` (new)
Adds a **partial unique index** on `api_keys (prefix) WHERE revoked = FALSE`.

```sql
CREATE UNIQUE INDEX IF NOT EXISTS uq_api_keys_prefix_active
  ON api_keys (prefix)
  WHERE revoked = FALSE;
```

- Active keys are guaranteed to have unique prefixes at the database level.
- Revoked keys are excluded so a prefix can be reused after revocation.

### `migrations/0006_api_key_prefix_unique.down.sql` (new)
Rollback: `DROP INDEX IF EXISTS uq_api_keys_prefix_active;`

### `src/repositories/apiKeyRepository.prefix.test.ts` (new)
Constraint regression tests using **pg-mem** (no external DB required):

| Test | Covers |
|------|--------|
| Allows unique active prefix | Happy path |
| Allows two active keys with different prefixes | Happy path |
| Rejects duplicate active prefix | Collision — acceptance criterion 1 |
| Rejects duplicate prefix for different `api_id` | Collision variant |
| Allows prefix reuse after revocation | Revocation — acceptance criterion 2 |
| Allows multiple revoked keys with same prefix | Revocation variant |
| Does not block new active key when revoked key exists | Revocation — acceptance criterion 3 |
| Allows multiple NULL-prefix rows | Documents NULL semantics |
| Prefix lookup returns exactly one row | Mirrors gateway middleware query |
| Prefix lookup returns zero rows after revocation | Mirrors gateway middleware query |

### `tests/helpers/db.ts` (updated)
Added `prefix VARCHAR(16)` column and the partial unique index to the shared
pg-mem schema used by integration tests, keeping it in sync with the real
PostgreSQL schema.

### `docs/gateway-api-key-auth.md` (updated)
Added a **Prefix uniqueness guarantee** section documenting the new index and
pointing to the regression tests.

### `migrations/README.md` (updated)
Added migration 0006 to the table.

---

## Acceptance criteria

- [x] Inserting a duplicate active prefix fails at the database level
- [x] Revoked keys do not block reuse of a prefix
- [x] Tests cover collision and revocation cases

---

## Testing

Tests run with Jest + pg-mem (no external PostgreSQL required):

```bash
npm test -- --testPathPattern="apiKeyRepository.prefix.test"
```

All 10 constraint regression tests pass.

---

closes #309
