### PR TITLE
feat(security): rate-limit webhook registration and management endpoints

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -202,3 +202,20 @@ After 5 failures, the event is dropped and logged server-side.
 | POST   | `/api/webhooks`                   | Register webhook         |
 | GET    | `/api/webhooks/:developerId`      | View current webhook     |
 | DELETE | `/api/webhooks/:developerId`      | Remove webhook           |
+
+---
+
+## Rate Limiting
+
+The webhook management endpoints (`POST /`, `GET /:developerId`, `DELETE /:developerId`) are
+protected by an IP-based rate limiter. The signed inbound delivery route
+(`POST /deliver/:developerId`) is **not** rate-limited here because it is
+protected independently by HMAC signature verification.
+
+| Env variable                      | Default (fallback)                    | Description                          |
+|-----------------------------------|---------------------------------------|--------------------------------------|
+| `WEBHOOK_RATE_LIMIT_WINDOW_MS`    | `REST_RATE_LIMIT_WINDOW_MS` (60 000)  | Window length in milliseconds        |
+| `WEBHOOK_RATE_LIMIT_MAX_REQUESTS` | `REST_RATE_LIMIT_MAX_REQUESTS` (100)  | Max requests per IP per window       |
+
+When the limit is exceeded, the server responds with **HTTP 429** and a
+`Retry-After` header indicating how many seconds to wait before retrying.

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -37,9 +37,17 @@ export const envSchema = z
 
     // Proxy / Gateway
     UPSTREAM_URL: z.string().url().default("http://localhost:4000"),
+    UPSTREAM_HOST_ALLOWLIST: z.string().optional(),
     PROXY_TIMEOUT_MS: z.coerce.number().default(30_000),
     REST_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
     REST_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(100),
+    WEBHOOK_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().optional(),
+    WEBHOOK_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().optional(),
+    // Generic rate limiter (optional legacy config)
+    RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().optional(),
+    RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().optional(),
+    RATE_LIMIT_STORE: z.string().optional(),
+    RATE_LIMIT_PG_TABLE: z.string().optional(),
 
     // CORS
     CORS_ALLOWED_ORIGINS: z.string().default("http://localhost:5173"),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -133,6 +133,11 @@ export const config = {
     maxRequests: env.REST_RATE_LIMIT_MAX_REQUESTS,
   },
 
+  webhookRateLimit: {
+    windowMs: env.WEBHOOK_RATE_LIMIT_WINDOW_MS ?? env.REST_RATE_LIMIT_WINDOW_MS,
+    maxRequests: env.WEBHOOK_RATE_LIMIT_MAX_REQUESTS ?? env.REST_RATE_LIMIT_MAX_REQUESTS,
+  },
+
   rateLimiter: {
     maxRequests: env.RATE_LIMIT_MAX_REQUESTS,
     windowMs: env.RATE_LIMIT_WINDOW_MS,

--- a/src/webhooks/webhook.routes.ts
+++ b/src/webhooks/webhook.routes.ts
@@ -8,8 +8,18 @@ import {
   verifyWebhookSignature,
 } from './webhook.signature.js';
 import { AppError, BadRequestError, NotFoundError } from '../errors/index.js';
+import { createRestRateLimitMiddleware } from '../middleware/restRateLimit.js';
+import { config } from '../config/index.js';
 
 const router = Router();
+
+/**
+ * Rate limiter for webhook management routes (POST /, GET /:id, DELETE /:id).
+ * Keys on client IP (unauthenticated routes). Window and max are configurable
+ * via WEBHOOK_RATE_LIMIT_WINDOW_MS / WEBHOOK_RATE_LIMIT_MAX_REQUESTS, falling
+ * back to the global REST rate-limit settings.
+ */
+const webhookMgmtRateLimit = createRestRateLimitMiddleware(config.webhookRateLimit);
 
 const VALID_EVENTS: WebhookEventType[] = [
   'new_api_call',
@@ -18,7 +28,7 @@ const VALID_EVENTS: WebhookEventType[] = [
 ];
 
 // POST /api/webhooks — Register a webhook
-router.post('/', express.json(), async (req: Request, res: Response, next: NextFunction) => {
+router.post('/', webhookMgmtRateLimit, express.json(), async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { developerId, url, events, secret } = req.body;
 
@@ -69,7 +79,7 @@ router.post('/', express.json(), async (req: Request, res: Response, next: NextF
 });
 
 // GET /api/webhooks/:developerId — Get webhook config
-router.get('/:developerId', (req: Request, res: Response) => {
+router.get('/:developerId', webhookMgmtRateLimit, (req: Request, res: Response) => {
   const config = WebhookStore.get(req.params.developerId);
   if (!config) {
     throw new NotFoundError(
@@ -84,7 +94,7 @@ router.get('/:developerId', (req: Request, res: Response) => {
 });
 
 // DELETE /api/webhooks/:developerId — Remove webhook
-router.delete('/:developerId', (req: Request, res: Response) => {
+router.delete('/:developerId', webhookMgmtRateLimit, (req: Request, res: Response) => {
   WebhookStore.delete(req.params.developerId);
   return res.json({ message: 'Webhook removed.' });
 });

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -9,6 +9,7 @@ import { dispatchWebhook } from '../../src/webhooks/webhook.dispatcher.js';
 import { WebhookEventType } from '../../src/webhooks/webhook.types.js';
 import { requestIdMiddleware } from '../../src/middleware/requestId.js';
 import { errorHandler } from '../../src/middleware/errorHandler.js';
+import { InMemoryRestRateLimiter, createRestRateLimitMiddleware } from '../../src/middleware/restRateLimit.js';
 
 // Mock the logger to avoid console output in tests
 // Must use `var` so the variable is hoisted with the jest.mock() call (same as mockDnsLookup below)
@@ -22,6 +23,7 @@ var mockLogger = {
 
 jest.mock('../../src/logger.js', () => ({
   logger: mockLogger,
+  runWithRequestContext: <T>(_ctx: unknown, callback: () => T): T => callback(),
 }));
 
 // Mock DNS resolution for URL validation tests
@@ -30,15 +32,32 @@ jest.mock('../../src/logger.js', () => ({
 // temporal dead zone when Jest runs the factory at module load time.
 // eslint-disable-next-line no-var
 var mockDnsLookup = jest.fn();
-jest.mock('dns/promises', () => ({
-  lookup: mockDnsLookup,
-}));
+jest.mock('dns/promises', () => {
+  // Access mockDnsLookup lazily so the jest.fn() assignment has run by the time
+  // any module requires dns/promises (factory is called lazily, not at hoist time).
+  const lookupFn = (...args: unknown[]) => mockDnsLookup(...args);
+  return { __esModule: true, default: { lookup: lookupFn }, lookup: lookupFn };
+});
 
 function buildWebhookApp() {
   const app = express();
   app.use(requestIdMiddleware);
   app.use(express.json());
   app.use('/api/webhooks', webhookRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+/**
+ * Builds a test app with an external InMemoryRestRateLimiter scoped to the
+ * webhook router, used to verify 429/Retry-After behaviour.
+ */
+function buildWebhookAppWithRateLimit(windowMs: number, maxRequests: number) {
+  const limiter = new InMemoryRestRateLimiter(windowMs, maxRequests);
+  const rateLimitMiddleware = createRestRateLimitMiddleware({ windowMs, maxRequests }, limiter);
+  const app = express();
+  app.use(requestIdMiddleware);
+  app.use('/api/webhooks', rateLimitMiddleware, webhookRoutes);
   app.use(errorHandler);
   return app;
 }
@@ -674,5 +693,67 @@ describe('URL Validation Security Tests', () => {
     mockDnsLookup.mockResolvedValue([{ address: '192.168.1.100', family: 4 }]);
 
     await expect(validateWebhookUrl('https://localhost:3000/webhook')).resolves.toBeUndefined();
+  });
+});
+
+describe('Webhook Management Rate Limiting Tests', () => {
+  // Uses a real HTTPS URL so the real validator passes without needing the dns mock
+  const validPayload = {
+    developerId: 'dev-rl-test',
+    url: 'https://example.com/webhook',
+    events: ['new_api_call'],
+  };
+
+  beforeEach(() => {
+    WebhookStore.list().forEach(c => WebhookStore.delete(c.developerId));
+    jest.clearAllMocks();
+    // dns/promises is mocked at file level; restore a passing implementation so
+    // validateWebhookUrl succeeds for the public URL used in these tests.
+    mockDnsLookup.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+  });
+
+  it('POST /api/webhooks returns 429 with Retry-After once limit is exceeded', async () => {
+    const app = buildWebhookAppWithRateLimit(60_000, 2);
+
+    await request(app).post('/api/webhooks').send(validPayload).expect(201);
+    await request(app).post('/api/webhooks').send(validPayload).expect(201);
+
+    const res = await request(app).post('/api/webhooks').send(validPayload).expect(429);
+    expect(res.headers['retry-after']).toBeDefined();
+    expect(Number(res.headers['retry-after'])).toBeGreaterThan(0);
+  });
+
+  it('DELETE /api/webhooks/:developerId returns 429 with Retry-After once limit is exceeded', async () => {
+    const app = buildWebhookAppWithRateLimit(60_000, 1);
+    WebhookStore.register({ developerId: 'dev-rl-del', url: 'https://example.com/wh', events: ['new_api_call'], createdAt: new Date() });
+
+    await request(app).delete('/api/webhooks/dev-rl-del').expect(200);
+
+    const res = await request(app).delete('/api/webhooks/dev-rl-del').expect(429);
+    expect(res.headers['retry-after']).toBeDefined();
+    expect(Number(res.headers['retry-after'])).toBeGreaterThan(0);
+  });
+
+  it('POST /deliver/:developerId is not rate-limited by the management limiter', async () => {
+    // The webhook.routes.ts applies webhookMgmtRateLimit only to POST /, GET /:id,
+    // DELETE /:id — the deliver route has no rate-limit middleware.
+    // Build an app without global express.json() so captureRawBody can consume
+    // the stream, then confirm deliver returns non-429 (401 for bad signature).
+    const app = express();
+    app.use(requestIdMiddleware);
+    app.use('/api/webhooks', webhookRoutes);
+    app.use(errorHandler);
+
+    WebhookStore.register({ developerId: 'dev-rl-deliver', url: 'https://example.com/wh', events: ['new_api_call'], secret: 'sec', createdAt: new Date() });
+
+    const deliverRes = await request(app)
+      .post('/api/webhooks/deliver/dev-rl-deliver')
+      .set('Content-Type', 'application/json')
+      .set('X-Callora-Timestamp', new Date().toISOString())
+      .set('X-Callora-Signature-256', 'sha256=invalidsignature')
+      .send('{}');
+
+    expect(deliverRes.status).not.toBe(429);
+    expect(deliverRes.status).not.toBe(404);
   });
 });


### PR DESCRIPTION
## Summary

Closes #382

Applies IP-based rate limiting to the three webhook management routes — `POST /`, `GET /:developerId`, and `DELETE /:developerId` — reusing the existing `createRestRateLimitMiddleware` from `src/middleware/restRateLimit.ts`. The signed inbound delivery route (`POST /deliver/:developerId`) is untouched.

## Changes

- **`src/webhooks/webhook.routes.ts`** — wires `webhookMgmtRateLimit` middleware onto the three management routes
- **`src/config/env.ts`** — adds optional `WEBHOOK_RATE_LIMIT_WINDOW_MS` / `WEBHOOK_RATE_LIMIT_MAX_REQUESTS` env vars
- **`src/config/index.ts`** — exposes `config.webhookRateLimit`, falling back to global REST rate-limit values
- **`docs/webhooks.md`** — documents the new rate-limit behaviour and env vars
- **`tests/integration/webhooks.test.ts`** — adds `Webhook Management Rate Limiting Tests` asserting 429 + `Retry-After` on POST and DELETE, and confirming the deliver route is not affected

## Acceptance criteria met

- POST and DELETE return 429 with `Retry-After` once the window limit is exceeded ✅
- Limiting keys on client IP for unauthenticated routes ✅
- `POST /deliver/:developerId` pipeline and raw-body handling unchanged ✅
- Limits configurable via env vars, validated in `src/config/env.ts` ✅
- `docs/webhooks.md` documents the new limits ✅
- Integration tests assert 429/Retry-After on register and delete ✅

## Testing

```
npx jest tests/integration/webhooks.test.ts -t "Rate Limiting" --no-coverage
# 3 passed
```