### PR TITLE
chore: cascade delete api_endpoints with parent apis

### DIFF
--- a/migrations/0012_api_endpoints_cascade.down.sql
+++ b/migrations/0012_api_endpoints_cascade.down.sql
@@ -1,0 +1,41 @@
+-- Roll back api_endpoints.api_id to a non-cascading foreign key.
+DROP INDEX IF EXISTS `idx_api_endpoints_api_id`;
+
+CREATE TABLE `api_endpoints_no_cascade_new` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `api_id` integer NOT NULL,
+  `path` text NOT NULL,
+  `method` text DEFAULT 'GET' NOT NULL,
+  `price_per_call_usdc` text DEFAULT '0.01' NOT NULL,
+  `description` text,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  `updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+  FOREIGN KEY (`api_id`) REFERENCES `apis`(`id`)
+);
+
+INSERT INTO `api_endpoints_no_cascade_new` (
+  `id`,
+  `api_id`,
+  `path`,
+  `method`,
+  `price_per_call_usdc`,
+  `description`,
+  `created_at`,
+  `updated_at`
+)
+SELECT
+  `id`,
+  `api_id`,
+  `path`,
+  `method`,
+  `price_per_call_usdc`,
+  `description`,
+  `created_at`,
+  `updated_at`
+FROM `api_endpoints`;
+
+DROP TABLE `api_endpoints`;
+ALTER TABLE `api_endpoints_no_cascade_new` RENAME TO `api_endpoints`;
+
+CREATE INDEX `idx_api_endpoints_api_id` ON `api_endpoints` (`api_id`);
+

--- a/migrations/0012_api_endpoints_cascade.sql
+++ b/migrations/0012_api_endpoints_cascade.sql
@@ -1,0 +1,42 @@
+-- Rebuild api_endpoints so its api_id foreign key cascades when the parent API
+-- row is deleted. SQLite requires table rebuilds for foreign-key changes.
+DROP INDEX IF EXISTS `idx_api_endpoints_api_id`;
+
+CREATE TABLE `api_endpoints_cascade_new` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `api_id` integer NOT NULL,
+  `path` text NOT NULL,
+  `method` text DEFAULT 'GET' NOT NULL,
+  `price_per_call_usdc` text DEFAULT '0.01' NOT NULL,
+  `description` text,
+  `created_at` integer DEFAULT (unixepoch()) NOT NULL,
+  `updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+  FOREIGN KEY (`api_id`) REFERENCES `apis`(`id`) ON DELETE CASCADE
+);
+
+INSERT INTO `api_endpoints_cascade_new` (
+  `id`,
+  `api_id`,
+  `path`,
+  `method`,
+  `price_per_call_usdc`,
+  `description`,
+  `created_at`,
+  `updated_at`
+)
+SELECT
+  `id`,
+  `api_id`,
+  `path`,
+  `method`,
+  `price_per_call_usdc`,
+  `description`,
+  `created_at`,
+  `updated_at`
+FROM `api_endpoints`;
+
+DROP TABLE `api_endpoints`;
+ALTER TABLE `api_endpoints_cascade_new` RENAME TO `api_endpoints`;
+
+CREATE INDEX `idx_api_endpoints_api_id` ON `api_endpoints` (`api_id`);
+

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -43,6 +43,7 @@ Examples:
 | 0004 | `0004_create_developers.sql` | `developers` profile table |
 | 0005 | `0005_add_api_key_revocation.sql` | Adds `revoked` column to `api_keys` |
 | 0006 | `0006_api_key_prefix_unique.sql` | Partial unique index on `api_keys.prefix` for active keys |
+| 0012 | `0012_api_endpoints_cascade.sql` | Rebuilds `api_endpoints.api_id` with `ON DELETE CASCADE` |
 
 > **Note:** `add_refresh_tokens.sql` lacks a numeric prefix and will be rejected by the runner.
 > It must be renamed to `0006_add_refresh_tokens.sql` (or the next available number) before use.

--- a/src/repositories/apiRepository.drizzle.test.ts
+++ b/src/repositories/apiRepository.drizzle.test.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+function createLegacyApiTables(db: Database.Database): void {
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE apis (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      developer_id integer NOT NULL,
+      name text NOT NULL,
+      description text,
+      base_url text NOT NULL,
+      logo_url text,
+      category text,
+      status text DEFAULT 'draft' NOT NULL,
+      created_at integer DEFAULT (unixepoch()) NOT NULL,
+      updated_at integer DEFAULT (unixepoch()) NOT NULL
+    );
+
+    CREATE TABLE api_endpoints (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      api_id integer NOT NULL,
+      path text NOT NULL,
+      method text DEFAULT 'GET' NOT NULL,
+      price_per_call_usdc text DEFAULT '0.01' NOT NULL,
+      description text,
+      created_at integer DEFAULT (unixepoch()) NOT NULL,
+      updated_at integer DEFAULT (unixepoch()) NOT NULL,
+      FOREIGN KEY (api_id) REFERENCES apis(id)
+    );
+
+    CREATE INDEX idx_api_endpoints_api_id ON api_endpoints (api_id);
+  `);
+}
+
+function readMigration(filename: string): string {
+  return fs.readFileSync(path.join(process.cwd(), 'migrations', filename), 'utf8');
+}
+
+function apiEndpointForeignKey(db: Database.Database): { on_delete: string } {
+  const row = db
+    .prepare("PRAGMA foreign_key_list('api_endpoints')")
+    .all()
+    .find((entry) => {
+      const fk = entry as { table: string; from: string };
+      return fk.table === 'apis' && fk.from === 'api_id';
+    });
+
+  if (!row) throw new Error('api_endpoints.api_id foreign key not found');
+  return row as { on_delete: string };
+}
+
+describe('api_endpoints cascade migration', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createLegacyApiTables(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  test('deleting an API cascades to its endpoints after migration', () => {
+    db.exec(readMigration('0012_api_endpoints_cascade.sql'));
+
+    expect(apiEndpointForeignKey(db).on_delete.toUpperCase()).toBe('CASCADE');
+
+    db.exec(`
+      INSERT INTO apis (id, developer_id, name, base_url, status)
+      VALUES (1, 42, 'Weather', 'https://weather.test', 'active');
+
+      INSERT INTO api_endpoints (id, api_id, path, method, price_per_call_usdc)
+      VALUES (10, 1, '/forecast', 'GET', '0.01');
+    `);
+
+    db.prepare('DELETE FROM apis WHERE id = ?').run(1);
+
+    const orphanCount = db
+      .prepare('SELECT COUNT(*) AS count FROM api_endpoints WHERE api_id = ?')
+      .get(1) as { count: number };
+
+    expect(orphanCount.count).toBe(0);
+  });
+
+  test('down migration restores the non-cascading foreign key', () => {
+    db.exec(readMigration('0012_api_endpoints_cascade.sql'));
+    db.exec(readMigration('0012_api_endpoints_cascade.down.sql'));
+
+    expect(apiEndpointForeignKey(db).on_delete.toUpperCase()).toBe('NO ACTION');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a reversible SQLite migration that rebuilds `api_endpoints.api_id` with `ON DELETE CASCADE`
- document the new migration in `migrations/README.md`
- add Jest coverage that applies the migration, deletes a parent API row, and asserts endpoint rows are removed by the database-level cascade

Closes #407

## Validation
- confirmed the up migration contains `ON DELETE CASCADE` and the down migration restores a non-cascading FK
- confirmed the Jest test reads the migration SQL and checks `PRAGMA foreign_key_list('api_endpoints')`
- `npm ci` could not complete locally because `better-sqlite3` has no prebuilt binary for Node 24 on this machine and `node-gyp` could not find a runnable Python installation, so `npm test -- apiRepository` could not be run locally.
