### PR TITLE
chore: warm listings cache before server starts

### DIFF
--- a/src/__tests__/listingsCache.test.ts
+++ b/src/__tests__/listingsCache.test.ts
@@ -621,3 +621,119 @@ describe('Edge cases', () => {
     expect(cache.size).toBe(0);
   });
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 7. warmupListingsCache
+// ═════════════════════════════════════════════════════════════════════════════
+
+import { warmupListingsCache } from '../lib/listingsCache.js';
+
+describe('warmupListingsCache', () => {
+  const silentLogger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('populates the cache with the default page on success', async () => {
+    const cache = new ListingsCache<string[]>({ ttlMs: 30_000 });
+    const listPublic = jest.fn().mockResolvedValue(['api-1', 'api-2']);
+
+    const result = await warmupListingsCache(cache, listPublic, {
+      timeoutMs: 1_000,
+      logger: silentLogger,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.entriesLoaded).toBe(1);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+
+    const key = buildCacheKey({ limit: 20, offset: 0 });
+    expect(cache.get(key)).toEqual(['api-1', 'api-2']);
+  });
+
+  it('logs completion with duration on success', async () => {
+    const cache = new ListingsCache<string[]>({ ttlMs: 30_000 });
+    const listPublic = jest.fn().mockResolvedValue([]);
+
+    await warmupListingsCache(cache, listPublic, {
+      timeoutMs: 1_000,
+      logger: silentLogger,
+    });
+
+    expect(silentLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('warmup completed'),
+    );
+  });
+
+  it('returns success=false and warns when DB is unreachable', async () => {
+    const cache = new ListingsCache<string[]>({ ttlMs: 30_000 });
+    const listPublic = jest.fn().mockRejectedValue(new Error('DB connection refused'));
+
+    const result = await warmupListingsCache(cache, listPublic, {
+      timeoutMs: 1_000,
+      logger: silentLogger,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.entriesLoaded).toBe(0);
+    expect(result.reason).toContain('DB connection refused');
+    expect(cache.size).toBe(0);
+    expect(silentLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('warmup skipped'),
+    );
+  });
+
+  it('times out and returns success=false when listPublic is too slow', async () => {
+    jest.useFakeTimers();
+    const cache = new ListingsCache<string[]>({ ttlMs: 30_000 });
+
+    const listPublic = jest.fn().mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), 10_000)),
+    );
+
+    const warmupPromise = warmupListingsCache(cache, listPublic, {
+      timeoutMs: 500,
+      logger: silentLogger,
+    });
+
+    jest.advanceTimersByTime(600);
+    const result = await warmupPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('timed out');
+    expect(cache.size).toBe(0);
+    expect(silentLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('warmup skipped'),
+    );
+
+    jest.useRealTimers();
+  });
+
+  it('boot continues even when warmup fails', async () => {
+    const cache = new ListingsCache<string[]>({ ttlMs: 30_000 });
+    const listPublic = jest.fn().mockRejectedValue(new Error('DB down'));
+
+    await expect(
+      warmupListingsCache(cache, listPublic, {
+        timeoutMs: 1_000,
+        logger: silentLogger,
+      }),
+    ).resolves.toMatchObject({ success: false });
+  });
+
+  it('does not throw when listPublic returns empty array', async () => {
+    const cache = new ListingsCache<unknown[]>({ ttlMs: 30_000 });
+    const listPublic = jest.fn().mockResolvedValue([]);
+
+    const result = await warmupListingsCache(cache, listPublic, {
+      timeoutMs: 1_000,
+      logger: silentLogger,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.entriesLoaded).toBe(1);
+    const key = buildCacheKey({ limit: 20, offset: 0 });
+    expect(cache.get(key)).toEqual([]);
+  });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -104,6 +104,8 @@ export const envSchema = z
 
     // Health check
     HEALTH_CHECK_DB_TIMEOUT: z.coerce.number().default(2_000),
+    APIS_CACHE_TTL_MS: z.coerce.number().int().positive().optional(),
+    LISTINGS_CACHE_WARMUP_TIMEOUT_MS: z.coerce.number().int().positive().default(5_000),
     APP_VERSION: z.string().default("1.0.0"),
 
     // Logging

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -192,4 +192,7 @@ export const config = {
   idempotency: {
     retentionWindowSeconds: env.IDEMPOTENCY_RETENTION_WINDOW_SECONDS,
   },
+  listingsCache: {
+    warmupTimeoutMs: env.LISTINGS_CACHE_WARMUP_TIMEOUT_MS,
+  },
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import { createPostgresSettlementStore } from './services/settlementStore.js';
 import { createApiRegistry } from './data/apiRegistry.js';
 import { ApiKey } from './types/gateway.js';
 import { config } from './config/index.js';
-import { pool } from './db.js';
+import { listingsCache } from './lib/listingsCache.js';
 
 // Helper for Jest/CommonJS compat
 const isDirectExecution = process.argv[1] && (process.argv[1].endsWith('index.ts') || process.argv[1].endsWith('index.js'));
@@ -340,6 +340,22 @@ if (isDirectExecution) {
   async function startServer() {
     try {
       await initializeDb();
+
+      // Warm the listings cache before accepting traffic so the first
+      // request after a deploy is served from cache, not from a cold DB hit.
+      const { warmupListingsCache } = await import('./lib/listingsCache.js');
+      const { defaultApiRepository } = await import('./repositories/apiRepository.js');
+      await warmupListingsCache(
+        listingsCache,
+        (params) => defaultApiRepository.listPublic({
+          limit: params.limit,
+          offset: params.offset,
+          category: params.category,
+          search: params.search,
+        }),
+        { timeoutMs: config.listingsCache.warmupTimeoutMs },
+      );
+
       revenueLedgerIndexerJob.start();
       settlementStatusSyncJob.start();
       

--- a/src/lib/listingsCache.ts
+++ b/src/lib/listingsCache.ts
@@ -150,3 +150,73 @@ const envTtl = Number(process.env.APIS_CACHE_TTL_MS);
 export const listingsCache = new ListingsCache({
   ttlMs: Number.isFinite(envTtl) && envTtl > 0 ? envTtl : 30_000,
 });
+
+// ── Warmup ────────────────────────────────────────────────────────────────────
+
+export interface WarmupOptions {
+  /** Maximum time in ms to wait for the warmup query. Default: 5 000. */
+  timeoutMs?: number;
+  /** Logger interface — defaults to console. */
+  logger?: Pick<typeof console, 'log' | 'warn' | 'error'>;
+}
+
+export interface WarmupResult {
+  success: boolean;
+  durationMs: number;
+  entriesLoaded: number;
+  reason?: string;
+}
+
+/**
+ * Prime the listings cache from the repository before the HTTP server starts.
+ *
+ * Design decisions
+ * ────────────────
+ * • Time-bounded: a configurable timeout prevents a slow DB from blocking boot.
+ * • Fail-open: any error (DB unreachable, timeout) is logged and boot continues.
+ * • Default params: seeds the most common page (limit=20, offset=0) so the
+ *   majority of first-hit requests are served from cache after deploy.
+ *
+ * Security notes
+ * ──────────────
+ * • Only calls `listPublic` — no privileged data is loaded into the cache.
+ * • Cache keys are built with `buildCacheKey` — same validated params as
+ *   live requests, preventing any cache-key injection at warmup time.
+ *
+ * @param cache    The ListingsCache instance to prime.
+ * @param listPublic  Function that fetches the public listing (mirrors repository.listPublic).
+ * @param options  Timeout and logger overrides.
+ */
+export async function warmupListingsCache<T>(
+  cache: ListingsCache<T>,
+  listPublic: (params: ListingsCacheKeyParams) => Promise<T>,
+  options: WarmupOptions = {},
+): Promise<WarmupResult> {
+  const { timeoutMs = 5_000, logger = console } = options;
+  const started = Date.now();
+
+  const defaultParams: ListingsCacheKeyParams = { limit: 20, offset: 0 };
+
+  try {
+    const result = await Promise.race([
+      listPublic(defaultParams),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`Warmup timed out after ${timeoutMs}ms`)), timeoutMs),
+      ),
+    ]);
+
+    const key = buildCacheKey(defaultParams);
+    cache.set(key, result);
+
+    const durationMs = Date.now() - started;
+    logger.log(`[listingsCache] warmup completed in ${durationMs}ms — 1 entry loaded`);
+
+    return { success: true, durationMs, entriesLoaded: 1 };
+  } catch (err) {
+    const durationMs = Date.now() - started;
+    const reason = err instanceof Error ? err.message : String(err);
+    logger.warn(`[listingsCache] warmup skipped: ${reason} (${durationMs}ms elapsed)`);
+
+    return { success: false, durationMs, entriesLoaded: 0, reason };
+  }
+}


### PR DESCRIPTION
Closes #395

## What this PR does
Adds a warmup hook to listingsCache that primes the cache from
apiRepository after DB pool initialization, before the HTTP server
starts listening — eliminating the slow first hit after deploys.

## Changes

### src/lib/listingsCache.ts
- Added warmupListingsCache() — async function that primes the cache
  with the default page (limit=20, offset=0) before server start
- Added WarmupOptions interface (timeoutMs, logger)
- Added WarmupResult interface (success, durationMs, entriesLoaded, reason)
- Time-bounded via Promise.race with configurable timeout
- Fail-open: DB errors and timeouts are caught and logged, boot continues

### src/index.ts
- Imported listingsCache singleton
- Called warmupListingsCache() in startServer() after initializeDb()
- Uses config.listingsCache.warmupTimeoutMs for timeout

### src/config/index.ts
- Added listingsCache.warmupTimeoutMs config key

### src/config/env.ts
- Added LISTINGS_CACHE_WARMUP_TIMEOUT_MS env var (default: 5000ms)
- Added APIS_CACHE_TTL_MS env var

### src/__tests__/listingsCache.test.ts
- Added 6 warmup tests covering:
  - Success path with cache population
  - Duration logging on success
  - DB unreachable — returns success=false, warns, boot continues
  - Timeout exceeded — returns success=false with timeout reason
  - Boot continues even when warmup fails
  - Empty result array handled correctly

## Acceptance Criteria
- [x] Warmup runs at boot and logs duration
- [x] Configurable timeout via LISTINGS_CACHE_WARMUP_TIMEOUT_MS env var
- [x] Boot continues if warmup fails (fail-open)
- [x] Tests cover timeout path and DB-down path

## Security Notes
- Only listPublic is called — no privileged data loaded into cache
- Cache keys use buildCacheKey — same validated params as live requests