### PR TITLE
feat: webhook signing key rotation with grace window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ UPSTREAM_URL=http://localhost:4000
 PROXY_TIMEOUT_MS=30000
 REST_RATE_LIMIT_WINDOW_MS=60000
 REST_RATE_LIMIT_MAX_REQUESTS=100
+WEBHOOK_SECRET_ROTATION_GRACE_MS=86400000
 
 # -----------------------------------------------------------------------------
 # CORS — comma-separated list of allowed origins

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -65,6 +65,10 @@ In production, unexpected non-`AppError` messages are masked to `"Internal serve
 }
 ```
 
+Pagination query validation uses this same envelope. Invalid integer fields such
+as `limit=10.0`, `limit=1e2`, or `limit=0x10` return HTTP 400 with
+`code: "VALIDATION_ERROR"` and a `details` entry for `query.limit`.
+
 ## Error classes from `src/errors/index.ts`
 
 Every subclass accepts an optional custom `code` argument. The table lists the

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -116,6 +116,31 @@ For example, if the timestamp is `2026-05-31T10:00:00.000Z` and body is `{"event
 4. **Timing-safe comparison** — Compare using constant-time method
 5. **Check timestamp** — Reject if outside 5-minute tolerance window (replay protection)
 
+### Signing Secret Rotation
+
+Rotate a webhook signing secret with:
+
+```http
+POST /api/webhooks/:developerId/rotate-secret
+```
+
+The response includes the new secret exactly once:
+
+```json
+{
+  "message": "Webhook secret rotated successfully.",
+  "developerId": "dev_abc123",
+  "secret": "new-secret-value",
+  "previous_expires_at": "2026-06-26T12:00:00.000Z"
+}
+```
+
+During the grace window, signatures made with either the new secret or the
+immediately previous secret are accepted. After `previous_expires_at`, only the
+current secret is accepted. A second rotation replaces the previous secret with
+the formerly current secret. The grace window is configured with
+`WEBHOOK_SECRET_ROTATION_GRACE_MS` and defaults to 24 hours.
+
 #### Example Implementation
 
 ```typescript
@@ -201,6 +226,7 @@ After 5 failures, the event is dropped and logged server-side.
 |--------|-----------------------------------|--------------------------|
 | POST   | `/api/webhooks`                   | Register webhook         |
 | GET    | `/api/webhooks/:developerId`      | View current webhook     |
+| POST   | `/api/webhooks/:developerId/rotate-secret` | Rotate signing secret |
 | DELETE | `/api/webhooks/:developerId`      | Remove webhook           |
 
 ---

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -43,6 +43,7 @@ export const envSchema = z
     REST_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(100),
     WEBHOOK_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().optional(),
     WEBHOOK_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().optional(),
+    WEBHOOK_SECRET_ROTATION_GRACE_MS: z.coerce.number().int().positive().default(24 * 60 * 60 * 1000),
     // Generic rate limiter (optional legacy config)
     RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().optional(),
     RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().optional(),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -138,6 +138,10 @@ export const config = {
     maxRequests: env.WEBHOOK_RATE_LIMIT_MAX_REQUESTS ?? env.REST_RATE_LIMIT_MAX_REQUESTS,
   },
 
+  webhooks: {
+    secretRotationGraceMs: env.WEBHOOK_SECRET_ROTATION_GRACE_MS,
+  },
+
   rateLimiter: {
     maxRequests: env.RATE_LIMIT_MAX_REQUESTS,
     windowMs: env.RATE_LIMIT_WINDOW_MS,

--- a/src/lib/__tests__/pagination.test.ts
+++ b/src/lib/__tests__/pagination.test.ts
@@ -80,6 +80,18 @@ describe('parsePagination', () => {
     assertValidationError(() => parsePagination({ limit: '10.7' }), 'query.limit');
   });
 
+  it('rejects fractional limit even when the fractional part is zero', () => {
+    assertValidationError(() => parsePagination({ limit: '10.0' }), 'query.limit');
+  });
+
+  it('rejects scientific notation for limit', () => {
+    assertValidationError(() => parsePagination({ limit: '1e2' }), 'query.limit');
+  });
+
+  it('rejects hexadecimal notation for limit', () => {
+    assertValidationError(() => parsePagination({ limit: '0x10' }), 'query.limit');
+  });
+
   it('rejects floating-point offset', () => {
     assertValidationError(() => parsePagination({ offset: '5.9' }), 'query.offset');
   });

--- a/src/webhooks/webhook.routes.ts
+++ b/src/webhooks/webhook.routes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import express from 'express';
+import crypto from 'crypto';
 import { validateWebhookUrl, WebhookValidationError } from './webhook.validator.js';
 import { WebhookStore } from './webhook.store.js';
 import { WebhookEventType } from './webhook.types.js';
@@ -10,6 +11,7 @@ import {
 import { AppError, BadRequestError, NotFoundError } from '../errors/index.js';
 import { createRestRateLimitMiddleware } from '../middleware/restRateLimit.js';
 import { config } from '../config/index.js';
+import { logger } from '../logger.js';
 
 const router = Router();
 
@@ -26,6 +28,10 @@ const VALID_EVENTS: WebhookEventType[] = [
   'settlement_completed',
   'low_balance_alert',
 ];
+
+function generateWebhookSecret(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
 
 // POST /api/webhooks — Register a webhook
 router.post('/', webhookMgmtRateLimit, express.json(), async (req: Request, res: Response, next: NextFunction) => {
@@ -63,7 +69,7 @@ router.post('/', webhookMgmtRateLimit, express.json(), async (req: Request, res:
       developerId,
       url,
       events: events as WebhookEventType[],
-      secret: secret ?? undefined,
+      secret_current: secret ?? undefined,
       createdAt: new Date(),
     });
 
@@ -89,8 +95,48 @@ router.get('/:developerId', webhookMgmtRateLimit, (req: Request, res: Response) 
   }
   // Never expose the secret
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { secret: _s, ...safeConfig } = config;
+  const {
+    secret: _s,
+    secret_current: _sc,
+    secret_previous: _sp,
+    ...safeConfig
+  } = config;
   return res.json(safeConfig);
+});
+
+// POST /api/webhooks/:developerId/rotate-secret — Rotate webhook signing secret
+router.post('/:developerId/rotate-secret', webhookMgmtRateLimit, (req: Request, res: Response) => {
+  const existing = WebhookStore.get(req.params.developerId);
+  if (!existing) {
+    throw new NotFoundError(
+      'No webhook registered for this developer.',
+      'WEBHOOK_NOT_FOUND'
+    );
+  }
+
+  const newSecret = generateWebhookSecret();
+  const previousExpiresAt = new Date(Date.now() + config.webhooks.secretRotationGraceMs);
+  const rotated = WebhookStore.rotateSecret(req.params.developerId, newSecret, previousExpiresAt);
+
+  if (!rotated) {
+    throw new NotFoundError(
+      'No webhook registered for this developer.',
+      'WEBHOOK_NOT_FOUND'
+    );
+  }
+
+  logger.audit('WEBHOOK_SECRET_ROTATED', req.params.developerId, {
+    developerId: req.params.developerId,
+    previousExpiresAt: rotated.previous_expires_at?.toISOString(),
+    hadPreviousSecret: Boolean(existing.secret_current ?? existing.secret),
+  });
+
+  return res.status(200).json({
+    message: 'Webhook secret rotated successfully.',
+    developerId: req.params.developerId,
+    secret: newSecret,
+    previous_expires_at: rotated.previous_expires_at?.toISOString(),
+  });
 });
 
 // DELETE /api/webhooks/:developerId — Remove webhook
@@ -115,7 +161,7 @@ router.post(
   '/deliver/:developerId',
   captureRawBody,
   // Attach the stored secret so verifyWebhookSignature can read it
-  (req: Request & { webhookSecret?: string }, res: Response, next) => {
+  (req: Request & { webhookSecrets?: string[] }, res: Response, next) => {
     const config = WebhookStore.get(req.params.developerId);
     if (!config) {
       next(new NotFoundError(
@@ -124,7 +170,7 @@ router.post(
       ));
       return;
     }
-    req.webhookSecret = config.secret;
+    req.webhookSecrets = WebhookStore.getActiveSecrets(config);
     next();
   },
   verifyWebhookSignature,

--- a/src/webhooks/webhook.signature.test.ts
+++ b/src/webhooks/webhook.signature.test.ts
@@ -12,6 +12,7 @@ import {
   TIMESTAMP_HEADER,
   SIGNATURE_TOLERANCE_MS,
 } from './webhook.signature.js';
+import { WebhookStore } from './webhook.store.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -26,16 +27,19 @@ function makeReq(
   overrides: Partial<{
     headers: Record<string, string>;
     webhookSecret: string;
+    webhookSecrets: string[];
     rawBody: Buffer;
   }> = {}
-): Request & { webhookSecret?: string; rawBody?: Buffer } {
+): Request & { webhookSecret?: string; webhookSecrets?: string[]; rawBody?: Buffer } {
   const emitter = new EventEmitter() as unknown as Request & {
     webhookSecret?: string;
+    webhookSecrets?: string[];
     rawBody?: Buffer;
     headers: Record<string, string>;
   };
   emitter.headers = overrides.headers ?? {};
   emitter.webhookSecret = overrides.webhookSecret;
+  emitter.webhookSecrets = overrides.webhookSecrets;
   emitter.rawBody = overrides.rawBody;
   return emitter;
 }
@@ -135,6 +139,12 @@ test('safeCompare returns false for different hex strings of the same length', (
 test('safeCompare returns false when lengths differ', () => {
   const a = 'abcd';
   const b = 'abcdef';
+  assert.equal(safeCompare(a, b), false);
+});
+
+test('safeCompare returns false for malformed hex with the expected length', () => {
+  const a = crypto.randomBytes(32).toString('hex');
+  const b = 'z'.repeat(64);
   assert.equal(safeCompare(a, b), false);
 });
 
@@ -328,6 +338,81 @@ test('verifyWebhookSignature calls next() for a valid signature', (done) => {
   });
   const res = makeRes();
   verifyWebhookSignature(req, res, () => { done(); });
+});
+
+test('verifyWebhookSignature accepts a signature from the current secret when multiple secrets are configured', (done) => {
+  const ts = makeTimestamp();
+  const body = Buffer.from('{"event":"new_api_call"}');
+  const sig = computeSignature('current-secret', ts, body);
+
+  const req = makeReq({
+    webhookSecrets: ['current-secret', 'previous-secret'],
+    headers: {
+      [TIMESTAMP_HEADER]: ts,
+      [SIGNATURE_HEADER]: `sha256=${sig}`,
+    },
+    rawBody: body,
+  });
+  const res = makeRes();
+  verifyWebhookSignature(req, res, () => { done(); });
+});
+
+test('verifyWebhookSignature accepts a signature from the unexpired previous secret', (done) => {
+  const ts = makeTimestamp();
+  const body = Buffer.from('{"event":"new_api_call"}');
+  const sig = computeSignature('previous-secret', ts, body);
+
+  const req = makeReq({
+    webhookSecrets: ['current-secret', 'previous-secret'],
+    headers: {
+      [TIMESTAMP_HEADER]: ts,
+      [SIGNATURE_HEADER]: `sha256=${sig}`,
+    },
+    rawBody: body,
+  });
+  const res = makeRes();
+  verifyWebhookSignature(req, res, () => { done(); });
+});
+
+test('verifyWebhookSignature rejects a previous secret after its grace window is removed', () => {
+  const ts = makeTimestamp();
+  const body = Buffer.from('{"event":"new_api_call"}');
+  const sig = computeSignature('previous-secret', ts, body);
+
+  const req = makeReq({
+    webhookSecrets: ['current-secret'],
+    headers: {
+      [TIMESTAMP_HEADER]: ts,
+      [SIGNATURE_HEADER]: `sha256=${sig}`,
+    },
+    rawBody: body,
+  });
+  const res = makeRes();
+  const { nextCalled, error } = collectNextError((next) => verifyWebhookSignature(req, res, next));
+  assert.equal(nextCalled, true);
+  assert.equal((error as { name?: string }).name, 'UnauthorizedError');
+  assert.equal((error as { code?: string }).code, 'INVALID_WEBHOOK_SIGNATURE');
+});
+
+test('WebhookStore.getActiveSecrets excludes the previous secret after previous_expires_at', () => {
+  const config = {
+    developerId: 'dev-expired',
+    url: 'https://example.com/webhook',
+    events: ['new_api_call'],
+    secret_current: 'current-secret',
+    secret_previous: 'previous-secret',
+    previous_expires_at: new Date('2026-06-25T12:00:00.000Z'),
+    createdAt: new Date('2026-06-25T11:00:00.000Z'),
+  };
+
+  assert.deepEqual(
+    WebhookStore.getActiveSecrets(config, new Date('2026-06-25T11:59:59.000Z')),
+    ['current-secret', 'previous-secret'],
+  );
+  assert.deepEqual(
+    WebhookStore.getActiveSecrets(config, new Date('2026-06-25T12:00:01.000Z')),
+    ['current-secret'],
+  );
 });
 
 test('verifyWebhookSignature handles empty rawBody gracefully', (done) => {

--- a/src/webhooks/webhook.signature.ts
+++ b/src/webhooks/webhook.signature.ts
@@ -37,6 +37,7 @@ export function computeSignature(
  */
 export function safeCompare(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
+  if (!/^[0-9a-f]+$/i.test(a) || !/^[0-9a-f]+$/i.test(b)) return false;
   return crypto.timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
 }
 
@@ -46,6 +47,7 @@ export function safeCompare(a: string, b: string): boolean {
  * Expects:
  *   - `req.webhookSecret` (string)  attached upstream (e.g. by the route handler after
  *     looking up the developer's stored secret).
+ *   - or `req.webhookSecrets` (string[]) containing current and unexpired previous secrets.
  *   - `x-callora-signature-256` header  — `sha256=<hex>`
  *   - `x-callora-timestamp`      header  — ISO-8601 string
  *   - `req.rawBody` (Buffer)             — populated by the `captureRawBody` middleware.
@@ -59,14 +61,14 @@ export function safeCompare(a: string, b: string): boolean {
  *   - Signature does not match
  */
 export function verifyWebhookSignature(
-  req: Request & { webhookSecret?: string; rawBody?: Buffer },
+  req: Request & { webhookSecret?: string; webhookSecrets?: string[]; rawBody?: Buffer },
   _res: Response,
   next: NextFunction
 ): void {
-  const secret = req.webhookSecret;
+  const secrets = req.webhookSecrets ?? (req.webhookSecret ? [req.webhookSecret] : []);
 
   // No secret configured → skip verification (opt-in feature)
-  if (!secret) {
+  if (secrets.length === 0) {
     return next();
   }
 
@@ -111,9 +113,12 @@ export function verifyWebhookSignature(
   const receivedHex = parts[1];
 
   const rawBody = req.rawBody ?? Buffer.alloc(0);
-  const expectedHex = computeSignature(secret, tsHeader, rawBody);
+  const hasValidSignature = secrets.some((secret) => {
+    const expectedHex = computeSignature(secret, tsHeader, rawBody);
+    return safeCompare(expectedHex, receivedHex);
+  });
 
-  if (!safeCompare(expectedHex, receivedHex)) {
+  if (!hasValidSignature) {
     next(new UnauthorizedError(
       'Webhook signature verification failed.',
       'INVALID_WEBHOOK_SIGNATURE'

--- a/src/webhooks/webhook.store.ts
+++ b/src/webhooks/webhook.store.ts
@@ -3,13 +3,63 @@ import { WebhookConfig, WebhookEventType, DeadLetterEntry } from './webhook.type
 const store = new Map<string, WebhookConfig>();
 const deadLetterStore = new Map<string, DeadLetterEntry>();
 
+function normalizeConfig(config: WebhookConfig): WebhookConfig {
+    const secret_current = config.secret_current ?? config.secret;
+
+    return {
+        ...config,
+        secret: secret_current,
+        secret_current,
+    };
+}
+
 export const WebhookStore = {
     register(config: WebhookConfig): void {
-        store.set(config.developerId, config);
+        store.set(config.developerId, normalizeConfig(config));
     },
 
     get(developerId: string): WebhookConfig | undefined {
         return store.get(developerId);
+    },
+
+    rotateSecret(
+        developerId: string,
+        newSecret: string,
+        previousExpiresAt: Date,
+    ): WebhookConfig | undefined {
+        const currentConfig = store.get(developerId);
+        if (!currentConfig) return undefined;
+
+        const currentSecret = currentConfig.secret_current ?? currentConfig.secret;
+        const nextConfig = normalizeConfig({
+            ...currentConfig,
+            secret: newSecret,
+            secret_current: newSecret,
+            secret_previous: currentSecret,
+            previous_expires_at: currentSecret ? previousExpiresAt : undefined,
+        });
+
+        store.set(developerId, nextConfig);
+        return nextConfig;
+    },
+
+    getActiveSecrets(config: WebhookConfig, now: Date = new Date()): string[] {
+        const secrets = new Set<string>();
+        const currentSecret = config.secret_current ?? config.secret;
+
+        if (currentSecret) {
+            secrets.add(currentSecret);
+        }
+
+        if (
+            config.secret_previous &&
+            config.previous_expires_at &&
+            config.previous_expires_at.getTime() >= now.getTime()
+        ) {
+            secrets.add(config.secret_previous);
+        }
+
+        return [...secrets];
     },
 
     delete(developerId: string): void {

--- a/src/webhooks/webhook.types.ts
+++ b/src/webhooks/webhook.types.ts
@@ -7,7 +7,10 @@ export interface WebhookConfig {
     developerId: string;
     url: string;
     events: string[];
-    secret?: string; // for HMAC signature (optional but recommended)
+    secret?: string; // legacy alias for secret_current
+    secret_current?: string; // for HMAC signature (optional but recommended)
+    secret_previous?: string;
+    previous_expires_at?: Date;
     createdAt: Date;
 }
 

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -19,10 +19,17 @@ var mockLogger = {
   warn: jest.fn(),
   info: jest.fn(),
   debug: jest.fn(),
+  audit: jest.fn(),
 };
 
 jest.mock('../../src/logger.js', () => ({
-  logger: mockLogger,
+  logger: {
+    error: (...args: unknown[]) => mockLogger.error(...args),
+    warn: (...args: unknown[]) => mockLogger.warn(...args),
+    info: (...args: unknown[]) => mockLogger.info(...args),
+    debug: (...args: unknown[]) => mockLogger.debug(...args),
+    audit: (...args: unknown[]) => mockLogger.audit(...args),
+  },
   runWithRequestContext: <T>(_ctx: unknown, callback: () => T): T => callback(),
 }));
 
@@ -234,6 +241,84 @@ describe('Webhook Routes Security Tests', () => {
 
       expect(response.body.message).toBe('No webhook registered for this developer.');
       expect(response.body.code).toBe('WEBHOOK_NOT_FOUND');
+    });
+  });
+
+  describe('POST /api/webhooks/:developerId/rotate-secret', () => {
+    beforeEach(() => {
+      WebhookStore.register({
+        developerId: 'dev-rotate',
+        url: 'https://example.com/webhook',
+        events: ['new_api_call'],
+        secret: 'old-secret',
+        createdAt: new Date(),
+      });
+    });
+
+    it('returns the new secret exactly once, stores previous secret metadata, and audits rotation', async () => {
+      const response = await request(app)
+        .post('/api/webhooks/dev-rotate/rotate-secret')
+        .expect(200);
+
+      expect(response.body.message).toBe('Webhook secret rotated successfully.');
+      expect(response.body.developerId).toBe('dev-rotate');
+      expect(response.body.secret).toMatch(/^[a-f0-9]{64}$/);
+      expect(response.body.previous_expires_at).toBeDefined();
+
+      const serialized = JSON.stringify(response.body);
+      expect(serialized.match(/[a-f0-9]{64}/g)).toHaveLength(1);
+      expect(serialized).not.toContain('old-secret');
+
+      const stored = WebhookStore.get('dev-rotate');
+      expect(stored?.secret_current).toBe(response.body.secret);
+      expect(stored?.secret_previous).toBe('old-secret');
+      expect(stored?.previous_expires_at).toBeInstanceOf(Date);
+
+      expect(mockLogger.audit).toHaveBeenCalledWith(
+        'WEBHOOK_SECRET_ROTATED',
+        'dev-rotate',
+        expect.objectContaining({
+          developerId: 'dev-rotate',
+          previousExpiresAt: response.body.previous_expires_at,
+          hadPreviousSecret: true,
+        }),
+      );
+    });
+
+    it('does not expose current or previous secrets on subsequent GET', async () => {
+      await request(app)
+        .post('/api/webhooks/dev-rotate/rotate-secret')
+        .expect(200);
+
+      const response = await request(app)
+        .get('/api/webhooks/dev-rotate')
+        .expect(200);
+
+      expect(response.body).not.toHaveProperty('secret');
+      expect(response.body).not.toHaveProperty('secret_current');
+      expect(response.body).not.toHaveProperty('secret_previous');
+    });
+
+    it('returns 404 when rotating a missing webhook', async () => {
+      const response = await request(app)
+        .post('/api/webhooks/missing-dev/rotate-secret')
+        .expect(404);
+
+      expect(response.body.code).toBe('WEBHOOK_NOT_FOUND');
+    });
+
+    it('keeps only the immediately previous secret after a double rotation', async () => {
+      const first = await request(app)
+        .post('/api/webhooks/dev-rotate/rotate-secret')
+        .expect(200);
+      const second = await request(app)
+        .post('/api/webhooks/dev-rotate/rotate-secret')
+        .expect(200);
+
+      const stored = WebhookStore.get('dev-rotate');
+      expect(stored?.secret_current).toBe(second.body.secret);
+      expect(stored?.secret_previous).toBe(first.body.secret);
+      expect(stored?.secret_previous).not.toBe('old-secret');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add webhook signing secret rotation via `POST /api/webhooks/:developerId/rotate-secret`
- Store `secret_current`, `secret_previous`, and `previous_expires_at`
- Accept signatures from current and unexpired previous secrets during the grace window
- Add audit logging for secret rotation without exposing secret values
- Reject fractional/scientific/hex pagination strings through existing validation error envelope
- Document rotation behavior, grace-window config, and pagination validation behavior

## Tests

- `npm test -- webhook.signature`
- `npm test -- pagination`
- `npm test -- tests/integration/webhooks.test.ts -t rotate-secret`

## Notes

Full webhook integration and repo typecheck still have pre-existing unrelated failures outside this change.

Closes #396
Closes #410