### PR TITLE
feat: API quota notification webhooks at 80/95/100 thresholds

### DIFF
--- a/PR_DESCRIPTION_QUOTA_NOTIFICATIONS.md
+++ b/PR_DESCRIPTION_QUOTA_NOTIFICATIONS.md
@@ -1,0 +1,188 @@
+# feat: API quota notification webhooks at 80/95/100 thresholds
+
+## Summary
+
+Implements the quota notification dispatcher described in issue #392. Developers now receive `quota.threshold.reached` webhook events at **80%**, **95%**, and **100%** of their monthly API call quota, giving them actionable signals before they hit rate limits.
+
+---
+
+## What changed
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `src/services/quotaNotifier.ts` | Core service: interval job, threshold scan, at-most-once idempotency |
+| `src/services/quotaNotifier.test.ts` | 34 unit tests — all passing |
+| `migrations/0009_quota_notifications_sent.sql` | PostgreSQL table to record sent notifications |
+| `migrations/0009_quota_notifications_sent.down.sql` | Rollback migration |
+| `docs/quota-notifications.md` | Operator guide: schema, wiring, error handling |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `src/webhooks/webhook.types.ts` | Added `quota.threshold.reached` to `WebhookEventType`; added `QuotaThresholdReachedData` interface; added missing `DeadLetterEntry` and `WebhookDeliveryStatus` types |
+
+---
+
+## Design decisions
+
+### Idempotency: at-most-once delivery
+
+The `(developer_id, period, threshold)` triple is written to `quota_notifications_sent` **before** the webhook is dispatched. This means:
+
+- A crash between `markSent` and delivery skips that delivery — the next tick won't retry. This is the safer choice; a missed alert is less harmful than a flood of duplicates.
+- A crash before `markSent` will retry on the next tick.
+- The `quota_notifications_sent` table has a composite primary key on `(developer_id, period, threshold)`, so concurrent processes cannot double-insert.
+
+### Month boundary derivation
+
+The period (`YYYY-MM`) and the `from`/`to` query window are both derived from the injected `now()` clock on every tick. This means:
+
+- There is no mutable state that can drift between ticks.
+- Tests can inject a fake clock and advance it across month boundaries without restarting the job.
+
+### Separation of concerns
+
+`runQuotaCheck` is exported as a pure async function that takes all its dependencies as arguments. The interval machinery in `createQuotaNotifierJob` is a thin wrapper. This makes the core logic directly unit-testable without fake timers.
+
+### Quota source
+
+Developer quotas are provided via an injected `getDeveloperQuotas()` callback rather than hard-coding a repository interface. This keeps the notifier decoupled from whatever storage mechanism the operator uses (a Postgres table, a config file, a feature-flag system, etc.). See `docs/quota-notifications.md` for a concrete wiring example.
+
+---
+
+## Webhook payload
+
+```json
+{
+  "event": "quota.threshold.reached",
+  "timestamp": "2026-06-25T16:00:00.000Z",
+  "developerId": "dev_abc123",
+  "data": {
+    "period": "2026-06",
+    "threshold": 80,
+    "currentUsage": 800,
+    "quotaLimit": 1000,
+    "usagePercent": 80.00
+  }
+}
+```
+
+---
+
+## Database migration
+
+```sql
+-- up
+CREATE TABLE quota_notifications_sent (
+  developer_id  VARCHAR(255) NOT NULL,
+  period        CHAR(7)      NOT NULL,  -- 'YYYY-MM'
+  threshold     SMALLINT     NOT NULL,  -- 80 | 95 | 100
+  created_at    TIMESTAMP    NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (developer_id, period, threshold)
+);
+CREATE INDEX idx_quota_notifications_developer_period
+  ON quota_notifications_sent (developer_id, period);
+
+-- down
+DROP INDEX IF EXISTS idx_quota_notifications_developer_period;
+DROP TABLE IF EXISTS quota_notifications_sent;
+```
+
+Apply with:
+```bash
+psql -U <user> -d callora -f migrations/0009_quota_notifications_sent.sql
+```
+
+---
+
+## Test output
+
+```
+PASS src/services/quotaNotifier.test.ts
+
+  periodOf
+    ✓ returns YYYY-MM for mid-month
+    ✓ returns YYYY-MM for first day of month
+    ✓ returns YYYY-MM for last day of month
+    ✓ pads single-digit months
+
+  monthBoundaries
+    ✓ sets from to the start of the month (UTC)
+    ✓ sets to to the last millisecond of the month (UTC)
+    ✓ handles December correctly (no month 13)
+    ✓ handles February in a leap year
+
+  InMemoryQuotaNotificationStore
+    ✓ returns false before a notification is marked
+    ✓ returns true after markSent
+    ✓ is keyed by (developerId, period, threshold) — different keys are independent
+    ✓ markSent is idempotent
+    ✓ clear() resets all state
+
+  runQuotaCheck — threshold detection
+    ✓ fires no notifications when usage is below 80%
+    ✓ fires the 80% notification at exactly 80 calls / 100 limit
+    ✓ fires 80% and 95% when usage is at 95%
+    ✓ fires all three thresholds when usage is at 100%
+    ✓ fires all three when usage exceeds 100%
+
+  runQuotaCheck — idempotency
+    ✓ does not re-fire a threshold already marked in the store
+    ✓ fires each threshold exactly once across repeated runs in the same period
+
+  runQuotaCheck — month boundary
+    ✓ events from a previous month are not counted in the current period
+    ✓ sends June notifications for June and July notifications for July independently
+    ✓ uses now() on each tick so clock-skew does not use stale period
+
+  runQuotaCheck — guard conditions
+    ✓ skips developers with monthlyLimit <= 0
+    ✓ handles multiple developers independently
+    ✓ returns 0 and logs error when getDeveloperQuotas throws
+    ✓ continues to next developer when usage repo throws for one
+    ✓ continues when notificationStore.hasBeenSent throws
+    ✓ continues when notificationStore.markSent throws
+
+  runQuotaCheck — webhook payload shape
+    ✓ builds the correct QuotaThresholdReachedData payload
+
+  createQuotaNotifierJob
+    ✓ does not run before start() is called
+    ✓ runs on each interval tick after start()
+    ✓ stops firing after stop() is called
+    ✓ calling start() twice is a no-op (no duplicate intervals)
+
+Tests: 34 passed, 34 total
+```
+
+---
+
+## Acceptance criteria checklist
+
+- [x] Threshold events fire exactly once per developer per period per threshold
+- [x] Webhook payload conforms to the `QuotaThresholdReachedData` schema (documented in `webhook.types.ts` and `docs/quota-notifications.md`)
+- [x] Unit tests with fake clock cover boundary transitions (month rollover, clock-skew, prior-month events excluded)
+- [x] Operator docs added under `docs/quota-notifications.md`
+- [x] Reuses existing `dispatchToAll` / `WebhookStore` infrastructure
+- [x] Migration ships with a matching `.down.sql` rollback file
+
+---
+
+## How to wire into production
+
+See [`docs/quota-notifications.md`](docs/quota-notifications.md) for the full operator guide. Short version:
+
+```ts
+const job = createQuotaNotifierJob(usageEventsRepository, new PgQuotaNotificationStore(pool), {
+  intervalMs: 60_000,
+  getDeveloperQuotas: () => pool.query('SELECT developer_id, monthly_limit FROM developer_quotas'),
+});
+job.start();
+// on shutdown:
+job.stop();
+```
+
+closes #392

--- a/docs/quota-notifications.md
+++ b/docs/quota-notifications.md
@@ -1,0 +1,216 @@
+# Quota Notifications
+
+Callora automatically notifies developers when their API usage crosses critical
+thresholds within a calendar month. This document explains the event schema,
+delivery mechanics, idempotency guarantees, and how to wire the notifier into a
+production deployment.
+
+## Overview
+
+The `QuotaNotifier` service runs on a configurable interval and:
+
+1. Loads the current list of developer quotas via an injected `getDeveloperQuotas` callback.
+2. Counts each developer's API calls in the current UTC calendar month by querying `usage_events`.
+3. For each configured threshold (80%, 95%, 100%), fires a `quota.threshold.reached` webhook
+   event if the developer has crossed that threshold **and the notification has not already been sent**.
+
+## Event schema
+
+### `quota.threshold.reached`
+
+Delivered as a standard `WebhookPayload`:
+
+```json
+{
+  "event": "quota.threshold.reached",
+  "timestamp": "2026-06-25T16:00:00.000Z",
+  "developerId": "dev_abc123",
+  "data": {
+    "period": "2026-06",
+    "threshold": 80,
+    "currentUsage": 800,
+    "quotaLimit": 1000,
+    "usagePercent": 80.00
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `period` | `string` | Billing month in `YYYY-MM` format |
+| `threshold` | `80 \| 95 \| 100` | Percentage milestone that was crossed |
+| `currentUsage` | `number` | Total calls made this month |
+| `quotaLimit` | `number` | Configured monthly call limit |
+| `usagePercent` | `number` | Actual usage percentage, rounded to 2 decimal places |
+
+### Signature verification
+
+All webhook deliveries are signed with `X-Callora-Signature: sha256=<hmac>` when
+the developer has configured a webhook secret. See
+[WEBHOOK_SIGNATURE_VERIFICATION.md](../WEBHOOK_SIGNATURE_VERIFICATION.md) for
+verification details.
+
+## Idempotency guarantee
+
+Each `(developerId, period, threshold)` triple is persisted in
+`quota_notifications_sent` **before** the webhook is dispatched. This means:
+
+- Repeated ticks within the same month never re-fire the same alert.
+- A process restart or crash after `markSent` but before delivery will not
+  produce a duplicate — the next tick will skip the already-recorded entry.
+- A crash before `markSent` will retry on the next tick (at-most-once delivery).
+
+## Database migration
+
+Apply the migration before starting the service:
+
+```bash
+psql -U <user> -d <database> -f migrations/0009_quota_notifications_sent.sql
+```
+
+To roll back:
+
+```bash
+psql -U <user> -d <database> -f migrations/0009_quota_notifications_sent.down.sql
+```
+
+### Table schema
+
+```sql
+CREATE TABLE quota_notifications_sent (
+  developer_id  VARCHAR(255) NOT NULL,
+  period        CHAR(7)      NOT NULL,  -- 'YYYY-MM'
+  threshold     SMALLINT     NOT NULL,  -- 80 | 95 | 100
+  created_at    TIMESTAMP    NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (developer_id, period, threshold)
+);
+```
+
+## Wiring into production (`src/index.ts`)
+
+```typescript
+import { createQuotaNotifierJob, PgQuotaNotificationStore } from './services/quotaNotifier.js';
+import { InMemoryUsageEventsRepository } from './repositories/usageEventsRepository.js';
+
+// 1. Build the notification store backed by PostgreSQL
+const notificationStore = new PgQuotaNotificationStore(pool);
+
+// 2. Provide a function that returns current developer quotas.
+//    This can query a `developer_quotas` table, a config file, etc.
+async function getDeveloperQuotas() {
+  const result = await pool.query<{ developer_id: string; monthly_limit: number }>(
+    'SELECT developer_id, monthly_limit FROM developer_quotas WHERE monthly_limit > 0',
+  );
+  return result.rows.map((r) => ({
+    developerId: r.developer_id,
+    monthlyLimit: r.monthly_limit,
+  }));
+}
+
+// 3. Create and start the job
+const quotaNotifierJob = createQuotaNotifierJob(usageEventsRepository, notificationStore, {
+  intervalMs: 60_000,       // check every minute
+  getDeveloperQuotas,
+});
+
+quotaNotifierJob.start();
+
+// 4. Stop cleanly on shutdown
+process.once('SIGTERM', () => {
+  quotaNotifierJob.stop();
+});
+```
+
+### Choosing `intervalMs`
+
+| Scenario | Recommended interval |
+|---|---|
+| High-traffic, near-real-time alerts | `60_000` (1 minute) |
+| Standard production | `300_000` (5 minutes) |
+| Low-traffic / cost-sensitive | `900_000` (15 minutes) |
+
+A shorter interval reduces alert latency but increases database read load.
+The notifier skips a tick if a previous tick is still in progress, so there is
+no risk of overlapping runs.
+
+## Local / test setup
+
+For unit tests and local development without a PostgreSQL instance, use the
+provided in-memory implementations:
+
+```typescript
+import {
+  InMemoryQuotaNotificationStore,
+  createQuotaNotifierJob,
+} from './src/services/quotaNotifier.js';
+import { InMemoryUsageEventsRepository } from './src/repositories/usageEventsRepository.js';
+
+const store = new InMemoryQuotaNotificationStore();
+const repo  = new InMemoryUsageEventsRepository(myFixtureEvents);
+
+const job = createQuotaNotifierJob(repo, store, {
+  intervalMs: 1_000,
+  getDeveloperQuotas: async () => [
+    { developerId: 'dev_test', monthlyLimit: 1000 },
+  ],
+});
+```
+
+To inject a fake clock in tests:
+
+```typescript
+let fakeNow = new Date('2026-06-15T12:00:00Z');
+const job = createQuotaNotifierJob(repo, store, {
+  intervalMs: 1_000,
+  getDeveloperQuotas,
+  now: () => fakeNow,
+});
+```
+
+## Webhook registration
+
+Developers must register a webhook endpoint that subscribes to
+`quota.threshold.reached`:
+
+```typescript
+WebhookStore.register({
+  developerId: 'dev_abc123',
+  url: 'https://your-app.example.com/webhooks/callora',
+  events: ['quota.threshold.reached'],
+  secret: 'your-hmac-secret',
+  createdAt: new Date(),
+});
+```
+
+Developers not registered in the webhook store will have their thresholds
+checked and recorded, but no HTTP delivery will be attempted.
+
+## Monitoring
+
+The notifier logs structured messages at `info` level on each successful
+dispatch and `error` level on any failure:
+
+```
+[quotaNotifier] Fired quota.threshold.reached for dev=dev_abc123 period=2026-06 threshold=80% (usage=800/1000)
+[quotaNotifier] Failed to fetch usage for developer dev_xyz: Error: connection timeout
+```
+
+These can be scraped by any log aggregator (e.g., CloudWatch, Datadog, Loki).
+
+## Error handling
+
+| Failure point | Behaviour |
+|---|---|
+| `getDeveloperQuotas` throws | Entire tick is skipped; error is logged |
+| `usageRepo.findByDeveloper` throws for one developer | That developer is skipped; other developers proceed |
+| `notificationStore.hasBeenSent` throws | That threshold is skipped; error is logged |
+| `notificationStore.markSent` throws | Webhook is **not** dispatched (prevents duplicate if delivery succeeds later) |
+| Webhook delivery fails | Error is logged; `markSent` is already recorded so the next tick will not retry delivery |
+
+## Thresholds reference
+
+| Threshold | Meaning | Recommended action |
+|---|---|---|
+| **80%** | 800 out of 1000 calls used | Review usage, consider upgrading plan |
+| **95%** | 950 out of 1000 calls used | Imminent rate-limiting; consider request throttling |
+| **100%** | Quota exhausted | Requests will be rejected; upgrade or contact support |

--- a/migrations/0009_quota_notifications_sent.down.sql
+++ b/migrations/0009_quota_notifications_sent.down.sql
@@ -1,0 +1,3 @@
+-- Rollback: 0009_quota_notifications_sent
+DROP INDEX IF EXISTS idx_quota_notifications_developer_period;
+DROP TABLE IF EXISTS quota_notifications_sent;

--- a/migrations/0009_quota_notifications_sent.sql
+++ b/migrations/0009_quota_notifications_sent.sql
@@ -1,0 +1,20 @@
+-- Migration: 0009_quota_notifications_sent
+-- Purpose: Track which quota threshold notifications have been sent per developer
+--          per billing period, so each threshold fires exactly once per period.
+--
+-- Columns:
+--   developer_id  — the developer that owns the quota being monitored
+--   period        — YYYY-MM billing month (e.g. '2026-06')
+--   threshold     — percentage milestone: 80, 95, or 100
+--   created_at    — when the notification was first dispatched
+
+CREATE TABLE IF NOT EXISTS quota_notifications_sent (
+  developer_id  VARCHAR(255) NOT NULL,
+  period        CHAR(7)      NOT NULL,  -- 'YYYY-MM'
+  threshold     SMALLINT     NOT NULL,  -- 80 | 95 | 100
+  created_at    TIMESTAMP    NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (developer_id, period, threshold)
+);
+
+CREATE INDEX IF NOT EXISTS idx_quota_notifications_developer_period
+  ON quota_notifications_sent (developer_id, period);

--- a/src/services/quotaNotifier.test.ts
+++ b/src/services/quotaNotifier.test.ts
@@ -1,0 +1,653 @@
+/**
+ * Unit tests for src/services/quotaNotifier.ts
+ *
+ * Uses fake clocks and in-memory stubs so no database or network is required.
+ * Covers:
+ *   - threshold detection at 80 / 95 / 100 %
+ *   - idempotency (no re-fire for the same period/threshold)
+ *   - month-boundary transitions
+ *   - clock-skew safety (each tick re-derives the period from now())
+ *   - repeated runs within the same period
+ *   - zero / negative quota guard
+ *   - error resilience (bad usage repo, bad notification store)
+ *   - InMemoryQuotaNotificationStore behaviour
+ *   - periodOf and monthBoundaries helpers
+ *   - createQuotaNotifierJob start/stop lifecycle
+ */
+
+import {
+    runQuotaCheck,
+    periodOf,
+    monthBoundaries,
+    InMemoryQuotaNotificationStore,
+    QUOTA_THRESHOLDS,
+    createQuotaNotifierJob,
+    type QuotaNotifierDeps,
+    type DeveloperQuota,
+    type QuotaNotificationStore,
+} from './quotaNotifier.js';
+import type { UsageEventsRepository, UsageEvent, UsageEventQuery } from '../repositories/usageEventsRepository.js';
+import { WebhookStore } from '../webhooks/webhook.store.js';
+import { resetWebhookDispatcherForTests } from '../webhooks/webhook.dispatcher.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(developerId: string, occurredAt: Date): UsageEvent {
+    return {
+        id: Math.random().toString(36).slice(2),
+        developerId,
+        apiId: 'api_1',
+        endpoint: '/test',
+        userId: developerId,
+        occurredAt,
+        revenue: 0n,
+    };
+}
+
+/** Creates a UsageEventsRepository stub that returns `events` for findByDeveloper. */
+function makeUsageRepo(events: UsageEvent[]): UsageEventsRepository {
+    return {
+        async findByDeveloper(query: UsageEventQuery) {
+            return events.filter(
+                (e) =>
+                    e.developerId === query.developerId &&
+                    e.occurredAt >= query.from &&
+                    e.occurredAt <= query.to,
+            );
+        },
+        findByUser: jest.fn(),
+        developerOwnsApi: jest.fn(),
+        aggregateByDeveloper: jest.fn(),
+        aggregateByUser: jest.fn(),
+    } as unknown as UsageEventsRepository;
+}
+
+function makeDeps(
+    events: UsageEvent[],
+    quotas: DeveloperQuota[],
+    store: QuotaNotificationStore,
+    now: () => Date,
+): QuotaNotifierDeps {
+    return {
+        usageRepo: makeUsageRepo(events),
+        notificationStore: store,
+        getDeveloperQuotas: async () => quotas,
+        now,
+        logger: { error: jest.fn(), info: jest.fn() },
+    };
+}
+
+// A fixed "now" inside June 2026
+const JUNE_15 = new Date('2026-06-15T12:00:00Z');
+const JULY_1 = new Date('2026-07-01T00:00:00Z');
+
+// ---------------------------------------------------------------------------
+// periodOf
+// ---------------------------------------------------------------------------
+
+describe('periodOf', () => {
+    it('returns YYYY-MM for mid-month', () => {
+        expect(periodOf(new Date('2026-06-15T00:00:00Z'))).toBe('2026-06');
+    });
+
+    it('returns YYYY-MM for first day of month', () => {
+        expect(periodOf(new Date('2026-01-01T00:00:00Z'))).toBe('2026-01');
+    });
+
+    it('returns YYYY-MM for last day of month', () => {
+        expect(periodOf(new Date('2026-12-31T23:59:59Z'))).toBe('2026-12');
+    });
+
+    it('pads single-digit months', () => {
+        expect(periodOf(new Date('2026-03-10T00:00:00Z'))).toBe('2026-03');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// monthBoundaries
+// ---------------------------------------------------------------------------
+
+describe('monthBoundaries', () => {
+    it('sets from to the start of the month (UTC)', () => {
+        const { from } = monthBoundaries(JUNE_15);
+        expect(from.toISOString()).toBe('2026-06-01T00:00:00.000Z');
+    });
+
+    it('sets to to the last millisecond of the month (UTC)', () => {
+        const { to } = monthBoundaries(JUNE_15);
+        expect(to.toISOString()).toBe('2026-06-30T23:59:59.999Z');
+    });
+
+    it('handles December correctly (no month 13)', () => {
+        const dec = new Date('2026-12-15T00:00:00Z');
+        const { from, to } = monthBoundaries(dec);
+        expect(from.toISOString()).toBe('2026-12-01T00:00:00.000Z');
+        expect(to.toISOString()).toBe('2026-12-31T23:59:59.999Z');
+    });
+
+    it('handles February in a leap year', () => {
+        const feb = new Date('2024-02-15T00:00:00Z');
+        const { to } = monthBoundaries(feb);
+        expect(to.toISOString()).toBe('2024-02-29T23:59:59.999Z');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// InMemoryQuotaNotificationStore
+// ---------------------------------------------------------------------------
+
+describe('InMemoryQuotaNotificationStore', () => {
+    it('returns false before a notification is marked', async () => {
+        const store = new InMemoryQuotaNotificationStore();
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(false);
+    });
+
+    it('returns true after markSent', async () => {
+        const store = new InMemoryQuotaNotificationStore();
+        await store.markSent('dev_1', '2026-06', 80);
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(true);
+    });
+
+    it('is keyed by (developerId, period, threshold) — different keys are independent', async () => {
+        const store = new InMemoryQuotaNotificationStore();
+        await store.markSent('dev_1', '2026-06', 80);
+
+        expect(await store.hasBeenSent('dev_1', '2026-06', 95)).toBe(false);
+        expect(await store.hasBeenSent('dev_2', '2026-06', 80)).toBe(false);
+        expect(await store.hasBeenSent('dev_1', '2026-07', 80)).toBe(false);
+    });
+
+    it('markSent is idempotent', async () => {
+        const store = new InMemoryQuotaNotificationStore();
+        await store.markSent('dev_1', '2026-06', 80);
+        await store.markSent('dev_1', '2026-06', 80); // no throw
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(true);
+    });
+
+    it('clear() resets all state', async () => {
+        const store = new InMemoryQuotaNotificationStore();
+        await store.markSent('dev_1', '2026-06', 80);
+        store.clear();
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// runQuotaCheck — threshold detection
+// ---------------------------------------------------------------------------
+
+describe('runQuotaCheck — threshold detection', () => {
+    beforeEach(() => {
+        WebhookStore.clear();
+        resetWebhookDispatcherForTests();
+    });
+
+    it('fires no notifications when usage is below 80%', async () => {
+        // 79 / 100 = 79%
+        const events = Array.from({ length: 79 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 100 }], store, () => JUNE_15);
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(0);
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(false);
+    });
+
+    it('fires the 80% notification at exactly 80 calls / 100 limit', async () => {
+        const events = Array.from({ length: 80 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 100 }], store, () => JUNE_15);
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(1);
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(true);
+        expect(await store.hasBeenSent('dev_1', '2026-06', 95)).toBe(false);
+    });
+
+    it('fires 80% and 95% when usage is at 95%', async () => {
+        const events = Array.from({ length: 95 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 100 }], store, () => JUNE_15);
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(2);
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(true);
+        expect(await store.hasBeenSent('dev_1', '2026-06', 95)).toBe(true);
+        expect(await store.hasBeenSent('dev_1', '2026-06', 100)).toBe(false);
+    });
+
+    it('fires all three thresholds when usage is at 100%', async () => {
+        const events = Array.from({ length: 100 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 100 }], store, () => JUNE_15);
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(3);
+        for (const threshold of QUOTA_THRESHOLDS) {
+            expect(await store.hasBeenSent('dev_1', '2026-06', threshold)).toBe(true);
+        }
+    });
+
+    it('fires all three when usage exceeds 100%', async () => {
+        const events = Array.from({ length: 150 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 100 }], store, () => JUNE_15);
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// runQuotaCheck — idempotency
+// ---------------------------------------------------------------------------
+
+describe('runQuotaCheck — idempotency', () => {
+    beforeEach(() => {
+        WebhookStore.clear();
+        resetWebhookDispatcherForTests();
+    });
+
+    it('does not re-fire a threshold already marked in the store', async () => {
+        const events = Array.from({ length: 80 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        await store.markSent('dev_1', '2026-06', 80); // pre-seed
+
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 100 }], store, () => JUNE_15);
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(0);
+    });
+
+    it('fires each threshold exactly once across repeated runs in the same period', async () => {
+        const events = Array.from({ length: 100 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 100 }], store, () => JUNE_15);
+
+        const first = await runQuotaCheck(deps);
+        const second = await runQuotaCheck(deps);
+        const third = await runQuotaCheck(deps);
+
+        expect(first).toBe(3);
+        expect(second).toBe(0);
+        expect(third).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// runQuotaCheck — month boundary / clock-skew
+// ---------------------------------------------------------------------------
+
+describe('runQuotaCheck — month boundary', () => {
+    beforeEach(() => {
+        WebhookStore.clear();
+        resetWebhookDispatcherForTests();
+    });
+
+    it('events from a previous month are not counted in the current period', async () => {
+        const mayEvent = makeEvent('dev_1', new Date('2026-05-31T23:59:59Z'));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(
+            [mayEvent],
+            [{ developerId: 'dev_1', monthlyLimit: 1 }],
+            store,
+            () => JUNE_15,
+        );
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(0);
+    });
+
+    it('sends June notifications for June and July notifications for July independently', async () => {
+        // 1 event in June → 100% of quota=1 → fires threshold 80/95/100
+        const juneEvent = makeEvent('dev_1', JUNE_15);
+        const store = new InMemoryQuotaNotificationStore();
+        const juneEvents = [juneEvent];
+
+        // June run
+        const juneDeps = makeDeps(
+            juneEvents,
+            [{ developerId: 'dev_1', monthlyLimit: 1 }],
+            store,
+            () => JUNE_15,
+        );
+        await runQuotaCheck(juneDeps);
+
+        // July run (new event in July, same store)
+        const julyEvent = makeEvent('dev_1', JULY_1);
+        const julyDeps = makeDeps(
+            [juneEvent, julyEvent],
+            [{ developerId: 'dev_1', monthlyLimit: 1 }],
+            store,
+            () => JULY_1,
+        );
+        const julyFired = await runQuotaCheck(julyDeps);
+
+        // Should fire thresholds again because the period is now '2026-07'
+        expect(julyFired).toBe(3);
+        expect(await store.hasBeenSent('dev_1', '2026-07', 80)).toBe(true);
+    });
+
+    it('uses now() on each tick so clock-skew does not use stale period', async () => {
+        let currentTime = JUNE_15;
+        const juneEvent = makeEvent('dev_1', JUNE_15);
+        const store = new InMemoryQuotaNotificationStore();
+
+        const deps: QuotaNotifierDeps = {
+            usageRepo: makeUsageRepo([juneEvent]),
+            notificationStore: store,
+            getDeveloperQuotas: async () => [{ developerId: 'dev_1', monthlyLimit: 1 }],
+            now: () => currentTime,
+            logger: { error: jest.fn(), info: jest.fn() },
+        };
+
+        // First tick in June
+        await runQuotaCheck(deps);
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(true);
+
+        // Advance clock to July — even same events array, period should differ
+        currentTime = JULY_1;
+        const julyFired = await runQuotaCheck(deps);
+        // juneEvent is outside July boundary, so callCount = 0 → no thresholds crossed
+        expect(julyFired).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// runQuotaCheck — guard conditions
+// ---------------------------------------------------------------------------
+
+describe('runQuotaCheck — guard conditions', () => {
+    beforeEach(() => {
+        WebhookStore.clear();
+        resetWebhookDispatcherForTests();
+    });
+
+    it('skips developers with monthlyLimit <= 0', async () => {
+        const events = Array.from({ length: 100 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 0 }], store, () => JUNE_15);
+
+        const fired = await runQuotaCheck(deps);
+        expect(fired).toBe(0);
+    });
+
+    it('handles multiple developers independently', async () => {
+        const dev1Events = Array.from({ length: 80 }, () => makeEvent('dev_1', JUNE_15));
+        const dev2Events = Array.from({ length: 50 }, () => makeEvent('dev_2', JUNE_15));
+        const allEvents = [...dev1Events, ...dev2Events];
+
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(
+            allEvents,
+            [
+                { developerId: 'dev_1', monthlyLimit: 100 },
+                { developerId: 'dev_2', monthlyLimit: 100 },
+            ],
+            store,
+            () => JUNE_15,
+        );
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(1); // only dev_1 crossed 80%
+        expect(await store.hasBeenSent('dev_1', '2026-06', 80)).toBe(true);
+        expect(await store.hasBeenSent('dev_2', '2026-06', 80)).toBe(false);
+    });
+
+    it('returns 0 and logs error when getDeveloperQuotas throws', async () => {
+        const store = new InMemoryQuotaNotificationStore();
+        const logger = { error: jest.fn(), info: jest.fn() };
+        const deps: QuotaNotifierDeps = {
+            usageRepo: makeUsageRepo([]),
+            notificationStore: store,
+            getDeveloperQuotas: async () => { throw new Error('DB down'); },
+            now: () => JUNE_15,
+            logger,
+        };
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(0);
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to load developer quotas'),
+            expect.any(Error),
+        );
+    });
+
+    it('continues to next developer when usage repo throws for one', async () => {
+        const store = new InMemoryQuotaNotificationStore();
+        const logger = { error: jest.fn(), info: jest.fn() };
+
+        // dev_1's usage fetch will throw; dev_2 should still be processed
+        const usageRepo: UsageEventsRepository = {
+            async findByDeveloper(query: UsageEventQuery) {
+                if (query.developerId === 'dev_1') throw new Error('usage fetch failed');
+                // dev_2: 80 events
+                return Array.from({ length: 80 }, () => makeEvent('dev_2', JUNE_15));
+            },
+            findByUser: jest.fn(),
+            developerOwnsApi: jest.fn(),
+            aggregateByDeveloper: jest.fn(),
+            aggregateByUser: jest.fn(),
+        } as unknown as UsageEventsRepository;
+
+        const deps: QuotaNotifierDeps = {
+            usageRepo,
+            notificationStore: store,
+            getDeveloperQuotas: async () => [
+                { developerId: 'dev_1', monthlyLimit: 100 },
+                { developerId: 'dev_2', monthlyLimit: 100 },
+            ],
+            now: () => JUNE_15,
+            logger,
+        };
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(1); // dev_2 fired
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to fetch usage for developer dev_1'),
+            expect.any(Error),
+        );
+    });
+
+    it('continues when notificationStore.hasBeenSent throws', async () => {
+        const events = Array.from({ length: 80 }, () => makeEvent('dev_1', JUNE_15));
+        const logger = { error: jest.fn(), info: jest.fn() };
+
+        const faultyStore: QuotaNotificationStore = {
+            async hasBeenSent() { throw new Error('store unavailable'); },
+            async markSent() { /* no-op */ },
+        };
+
+        const deps: QuotaNotifierDeps = {
+            usageRepo: makeUsageRepo(events),
+            notificationStore: faultyStore,
+            getDeveloperQuotas: async () => [{ developerId: 'dev_1', monthlyLimit: 100 }],
+            now: () => JUNE_15,
+            logger,
+        };
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(0);
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to check notification state'),
+            expect.any(Error),
+        );
+    });
+
+    it('continues when notificationStore.markSent throws', async () => {
+        const events = Array.from({ length: 80 }, () => makeEvent('dev_1', JUNE_15));
+        const logger = { error: jest.fn(), info: jest.fn() };
+
+        const faultyStore: QuotaNotificationStore = {
+            async hasBeenSent() { return false; },
+            async markSent() { throw new Error('write failed'); },
+        };
+
+        const deps: QuotaNotifierDeps = {
+            usageRepo: makeUsageRepo(events),
+            notificationStore: faultyStore,
+            getDeveloperQuotas: async () => [{ developerId: 'dev_1', monthlyLimit: 100 }],
+            now: () => JUNE_15,
+            logger,
+        };
+
+        const fired = await runQuotaCheck(deps);
+
+        expect(fired).toBe(0);
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to persist notification state'),
+            expect.any(Error),
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Webhook payload shape
+// ---------------------------------------------------------------------------
+
+describe('runQuotaCheck — webhook payload shape', () => {
+    beforeEach(() => {
+        WebhookStore.clear();
+        resetWebhookDispatcherForTests();
+    });
+
+    it('builds the correct QuotaThresholdReachedData payload', async () => {
+        // Register a webhook config for dev_1 and capture the dispatched payload
+        const capturedPayloads: unknown[] = [];
+        const fakeFetch = jest.fn().mockImplementation(async (_url: string, init: { body: string }) => {
+            capturedPayloads.push(JSON.parse(init.body));
+            return { ok: true, status: 200 } as Response;
+        });
+        global.fetch = fakeFetch as unknown as typeof global.fetch;
+
+        WebhookStore.register({
+            developerId: 'dev_1',
+            url: 'https://example.com/webhook',
+            events: ['quota.threshold.reached'],
+            createdAt: new Date(),
+        });
+
+        const events = Array.from({ length: 80 }, () => makeEvent('dev_1', JUNE_15));
+        const store = new InMemoryQuotaNotificationStore();
+        const deps = makeDeps(events, [{ developerId: 'dev_1', monthlyLimit: 100 }], store, () => JUNE_15);
+
+        await runQuotaCheck(deps);
+
+        expect(capturedPayloads).toHaveLength(1);
+        const payload = capturedPayloads[0] as { event: string; developerId: string; data: Record<string, unknown> };
+        expect(payload.event).toBe('quota.threshold.reached');
+        expect(payload.developerId).toBe('dev_1');
+        expect(payload.data.threshold).toBe(80);
+        expect(payload.data.period).toBe('2026-06');
+        expect(payload.data.currentUsage).toBe(80);
+        expect(payload.data.quotaLimit).toBe(100);
+        expect(payload.data.usagePercent).toBe(80);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// createQuotaNotifierJob — lifecycle
+// ---------------------------------------------------------------------------
+
+describe('createQuotaNotifierJob', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        WebhookStore.clear();
+        resetWebhookDispatcherForTests();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('does not run before start() is called', () => {
+        const getDeveloperQuotas = jest.fn(async () => []);
+        const store = new InMemoryQuotaNotificationStore();
+
+        createQuotaNotifierJob(makeUsageRepo([]), store, {
+            intervalMs: 1000,
+            getDeveloperQuotas,
+        });
+
+        jest.advanceTimersByTime(5000);
+        expect(getDeveloperQuotas).not.toHaveBeenCalled();
+    });
+
+    it('runs on each interval tick after start()', async () => {
+        const getDeveloperQuotas = jest.fn(async () => []);
+        const store = new InMemoryQuotaNotificationStore();
+
+        const job = createQuotaNotifierJob(makeUsageRepo([]), store, {
+            intervalMs: 1000,
+            getDeveloperQuotas,
+        });
+
+        job.start();
+
+        // Advance one tick at a time, draining the microtask queue after each
+        for (let i = 0; i < 3; i++) {
+            jest.advanceTimersByTime(1000);
+            await Promise.resolve();
+            await Promise.resolve();
+        }
+
+        expect(getDeveloperQuotas).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops firing after stop() is called', async () => {
+        const getDeveloperQuotas = jest.fn(async () => []);
+        const store = new InMemoryQuotaNotificationStore();
+
+        const job = createQuotaNotifierJob(makeUsageRepo([]), store, {
+            intervalMs: 1000,
+            getDeveloperQuotas,
+        });
+
+        job.start();
+
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        job.stop();
+
+        jest.advanceTimersByTime(3000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(getDeveloperQuotas).toHaveBeenCalledTimes(2);
+    });
+
+    it('calling start() twice is a no-op (no duplicate intervals)', async () => {
+        const getDeveloperQuotas = jest.fn(async () => []);
+        const store = new InMemoryQuotaNotificationStore();
+
+        const job = createQuotaNotifierJob(makeUsageRepo([]), store, {
+            intervalMs: 1000,
+            getDeveloperQuotas,
+        });
+
+        job.start();
+        job.start(); // second call should be ignored
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+
+        expect(getDeveloperQuotas).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/services/quotaNotifier.ts
+++ b/src/services/quotaNotifier.ts
@@ -1,0 +1,308 @@
+/**
+ * quotaNotifier.ts
+ *
+ * Watches aggregated usage_events per developer and fires
+ * `quota.threshold.reached` webhook events at 80%, 95%, and 100% of the
+ * configured monthly call quota.
+ *
+ * Idempotency guarantee: each (developerId, period, threshold) triple is
+ * recorded in `quota_notifications_sent` before the webhook fires, so repeated
+ * ticks and process restarts never re-send the same alert.
+ */
+
+import type { UsageEventsRepository, UsageEventQuery } from '../repositories/usageEventsRepository.js';
+import { dispatchToAll } from '../webhooks/webhook.dispatcher.js';
+import { WebhookStore } from '../webhooks/webhook.store.js';
+import type { WebhookPayload, QuotaThresholdReachedData } from '../webhooks/webhook.types.js';
+
+// ---------------------------------------------------------------------------
+// Public contracts
+// ---------------------------------------------------------------------------
+
+export type QuotaThreshold = 80 | 95 | 100;
+
+export const QUOTA_THRESHOLDS: QuotaThreshold[] = [80, 95, 100];
+
+/** One row returned by getDeveloperQuotas. */
+export interface DeveloperQuota {
+    developerId: string;
+    /** Maximum API calls allowed per calendar month. */
+    monthlyLimit: number;
+}
+
+/**
+ * Minimal interface for the idempotency store backed by quota_notifications_sent.
+ * In production this wraps a PostgreSQL pool; in tests it is replaced with an
+ * in-memory stub.
+ */
+export interface QuotaNotificationStore {
+    /** Returns true if a notification has already been sent for this key. */
+    hasBeenSent(developerId: string, period: string, threshold: QuotaThreshold): Promise<boolean>;
+    /** Persists the fact that a notification was sent. Must be idempotent. */
+    markSent(developerId: string, period: string, threshold: QuotaThreshold): Promise<void>;
+}
+
+export interface QuotaNotifierOptions {
+    intervalMs: number;
+    /** Factory that provides the current list of developer quotas each tick. */
+    getDeveloperQuotas: () => Promise<DeveloperQuota[]>;
+    /** Overrideable clock — defaults to Date; injected in tests for fake time. */
+    now?: () => Date;
+    logger?: Pick<typeof console, 'error' | 'info'>;
+}
+
+export interface QuotaNotifierJob {
+    start(): void;
+    stop(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Period helper
+// ---------------------------------------------------------------------------
+
+/** Returns the billing period string "YYYY-MM" for a given date. */
+export function periodOf(date: Date): string {
+    const y = date.getUTCFullYear();
+    const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+    return `${y}-${m}`;
+}
+
+/** Returns the UTC start/end boundaries of the month that contains `date`. */
+export function monthBoundaries(date: Date): { from: Date; to: Date } {
+    const y = date.getUTCFullYear();
+    const m = date.getUTCMonth();
+    const from = new Date(Date.UTC(y, m, 1, 0, 0, 0, 0));
+    const to = new Date(Date.UTC(y, m + 1, 1, 0, 0, 0, 0) - 1); // last ms of last day
+    return { from, to };
+}
+
+// ---------------------------------------------------------------------------
+// Core scan logic (exported for direct unit-testing without the interval)
+// ---------------------------------------------------------------------------
+
+export interface QuotaNotifierDeps {
+    usageRepo: UsageEventsRepository;
+    notificationStore: QuotaNotificationStore;
+    getDeveloperQuotas: () => Promise<DeveloperQuota[]>;
+    now: () => Date;
+    logger: Pick<typeof console, 'error' | 'info'>;
+}
+
+/**
+ * Runs a single quota-check pass over all registered developer quotas.
+ * Returns the number of notifications fired.
+ */
+export async function runQuotaCheck(deps: QuotaNotifierDeps): Promise<number> {
+    const { usageRepo, notificationStore, getDeveloperQuotas, now, logger } = deps;
+
+    const today = now();
+    const period = periodOf(today);
+    const { from, to } = monthBoundaries(today);
+
+    let fired = 0;
+
+    let quotas: DeveloperQuota[];
+    try {
+        quotas = await getDeveloperQuotas();
+    } catch (err) {
+        logger.error('[quotaNotifier] Failed to load developer quotas:', err);
+        return 0;
+    }
+
+    for (const { developerId, monthlyLimit } of quotas) {
+        if (monthlyLimit <= 0) continue;
+
+        let callCount: number;
+        try {
+            const query: UsageEventQuery = { developerId, from, to };
+            const events = await usageRepo.findByDeveloper(query);
+            callCount = events.length;
+        } catch (err) {
+            logger.error(`[quotaNotifier] Failed to fetch usage for developer ${developerId}:`, err);
+            continue;
+        }
+
+        const usagePercent = (callCount / monthlyLimit) * 100;
+
+        for (const threshold of QUOTA_THRESHOLDS) {
+            if (usagePercent < threshold) continue;
+
+            let alreadySent: boolean;
+            try {
+                alreadySent = await notificationStore.hasBeenSent(developerId, period, threshold);
+            } catch (err) {
+                logger.error(
+                    `[quotaNotifier] Failed to check notification state for dev=${developerId} threshold=${threshold}:`,
+                    err,
+                );
+                continue;
+            }
+
+            if (alreadySent) continue;
+
+            // Mark as sent BEFORE dispatching so that a dispatcher crash does not
+            // cause a duplicate on the next tick (at-most-once delivery).
+            try {
+                await notificationStore.markSent(developerId, period, threshold);
+            } catch (err) {
+                logger.error(
+                    `[quotaNotifier] Failed to persist notification state for dev=${developerId} threshold=${threshold}:`,
+                    err,
+                );
+                continue;
+            }
+
+            const data: QuotaThresholdReachedData = {
+                period,
+                threshold,
+                currentUsage: callCount,
+                quotaLimit: monthlyLimit,
+                usagePercent: Math.round(usagePercent * 100) / 100,
+            };
+
+            const payload: WebhookPayload = {
+                event: 'quota.threshold.reached',
+                timestamp: today.toISOString(),
+                developerId,
+                data: data as unknown as Record<string, unknown>,
+            };
+
+            const configs = WebhookStore.getByEvent('quota.threshold.reached');
+            const developerConfigs = configs.filter((c) => c.developerId === developerId);
+
+            try {
+                await dispatchToAll(developerConfigs, payload);
+                logger.info(
+                    `[quotaNotifier] Fired quota.threshold.reached for dev=${developerId} period=${period} threshold=${threshold}% (usage=${callCount}/${monthlyLimit})`,
+                );
+                fired += 1;
+            } catch (err) {
+                logger.error(
+                    `[quotaNotifier] Webhook dispatch failed for dev=${developerId} threshold=${threshold}:`,
+                    err,
+                );
+            }
+        }
+    }
+
+    return fired;
+}
+
+// ---------------------------------------------------------------------------
+// Interval job (matches the pattern in settlementStatusSyncJob.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the quota notifier background job.
+ *
+ * @example
+ * ```ts
+ * const job = createQuotaNotifierJob(usageRepo, notificationStore, {
+ *   intervalMs: 60_000,
+ *   getDeveloperQuotas: () => db.query('SELECT id, monthly_limit FROM developer_quotas'),
+ * });
+ * job.start();
+ * // on shutdown:
+ * job.stop();
+ * ```
+ */
+export function createQuotaNotifierJob(
+    usageRepo: UsageEventsRepository,
+    notificationStore: QuotaNotificationStore,
+    options: QuotaNotifierOptions,
+): QuotaNotifierJob {
+    const logger = options.logger ?? console;
+    const now = options.now ?? (() => new Date());
+
+    const deps: QuotaNotifierDeps = {
+        usageRepo,
+        notificationStore,
+        getDeveloperQuotas: options.getDeveloperQuotas,
+        now,
+        logger,
+    };
+
+    let timer: NodeJS.Timeout | null = null;
+    let running = false;
+
+    const tick = async (): Promise<void> => {
+        if (running) return;
+        running = true;
+        try {
+            await runQuotaCheck(deps);
+        } catch (err) {
+            logger.error('[quotaNotifier] Unexpected error during quota check:', err);
+        } finally {
+            running = false;
+        }
+    };
+
+    return {
+        start() {
+            if (timer) return;
+            timer = setInterval(() => { void tick(); }, options.intervalMs);
+        },
+        stop() {
+            if (!timer) return;
+            clearInterval(timer);
+            timer = null;
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory notification store (for tests and local dev without PostgreSQL)
+// ---------------------------------------------------------------------------
+
+export class InMemoryQuotaNotificationStore implements QuotaNotificationStore {
+    private readonly sent = new Set<string>();
+
+    private key(developerId: string, period: string, threshold: QuotaThreshold): string {
+        return `${developerId}|${period}|${threshold}`;
+    }
+
+    async hasBeenSent(developerId: string, period: string, threshold: QuotaThreshold): Promise<boolean> {
+        return this.sent.has(this.key(developerId, period, threshold));
+    }
+
+    async markSent(developerId: string, period: string, threshold: QuotaThreshold): Promise<void> {
+        this.sent.add(this.key(developerId, period, threshold));
+    }
+
+    /** Resets all state — for use in tests only. */
+    clear(): void {
+        this.sent.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PostgreSQL-backed notification store
+// ---------------------------------------------------------------------------
+
+export interface QuotaNotificationDb {
+    query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+export class PgQuotaNotificationStore implements QuotaNotificationStore {
+    constructor(private readonly db: QuotaNotificationDb) {}
+
+    async hasBeenSent(developerId: string, period: string, threshold: QuotaThreshold): Promise<boolean> {
+        const result = await this.db.query<{ exists: boolean }>(
+            `SELECT EXISTS (
+               SELECT 1 FROM quota_notifications_sent
+               WHERE developer_id = $1 AND period = $2 AND threshold = $3
+             ) AS exists`,
+            [developerId, period, threshold],
+        );
+        return result.rows[0]?.exists ?? false;
+    }
+
+    async markSent(developerId: string, period: string, threshold: QuotaThreshold): Promise<void> {
+        await this.db.query(
+            `INSERT INTO quota_notifications_sent (developer_id, period, threshold)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (developer_id, period, threshold) DO NOTHING`,
+            [developerId, period, threshold],
+        );
+    }
+}

--- a/src/webhooks/webhook.types.ts
+++ b/src/webhooks/webhook.types.ts
@@ -1,7 +1,8 @@
 export type WebhookEventType =
     | 'new_api_call'
     | 'settlement_completed'
-    | 'low_balance_alert';
+    | 'low_balance_alert'
+    | 'quota.threshold.reached';
 
 export interface WebhookConfig {
     developerId: string;
@@ -18,7 +19,21 @@ export interface WebhookPayload {
     data: Record<string, unknown>;
 }
 
-// Payload shapes per event type (for documentation purposes)
+export type WebhookDeliveryStatus = 'pending' | 'delivered' | 'failed';
+
+export interface DeadLetterEntry {
+    deliveryId: string;
+    config: WebhookConfig;
+    payload: WebhookPayload;
+    failedAt: string;        // ISO 8601
+    lastError: string;
+    attempts: number;
+}
+
+// ---------------------------------------------------------------------------
+// Per-event payload shapes (for documentation and type-safe construction)
+// ---------------------------------------------------------------------------
+
 export interface NewApiCallData {
     apiId: string;
     endpoint: string;
@@ -40,4 +55,18 @@ export interface LowBalanceAlertData {
     currentBalance: string;
     thresholdBalance: string;
     asset: string;
+}
+
+/** Fired when a developer crosses 80%, 95%, or 100% of their monthly call quota. */
+export interface QuotaThresholdReachedData {
+    /** Billing period in YYYY-MM format, e.g. "2026-06". */
+    period: string;
+    /** Threshold percentage that was crossed: 80 | 95 | 100. */
+    threshold: 80 | 95 | 100;
+    /** Total API calls made by the developer this period. */
+    currentUsage: number;
+    /** Configured monthly call quota for this developer. */
+    quotaLimit: number;
+    /** Actual usage as a percentage of quota, rounded to two decimal places. */
+    usagePercent: number;
 }


### PR DESCRIPTION
# feat: API quota notification webhooks at 80/95/100 thresholds

## Summary

Implements the quota notification dispatcher described in issue #392. Developers now receive `quota.threshold.reached` webhook events at **80%**, **95%**, and **100%** of their monthly API call quota, giving them actionable signals before they hit rate limits.

---

## What changed

### New files

| File | Purpose |
|---|---|
| `src/services/quotaNotifier.ts` | Core service: interval job, threshold scan, at-most-once idempotency |
| `src/services/quotaNotifier.test.ts` | 34 unit tests — all passing |
| `migrations/0009_quota_notifications_sent.sql` | PostgreSQL table to record sent notifications |
| `migrations/0009_quota_notifications_sent.down.sql` | Rollback migration |
| `docs/quota-notifications.md` | Operator guide: schema, wiring, error handling |

### Modified files

| File | Change |
|---|---|
| `src/webhooks/webhook.types.ts` | Added `quota.threshold.reached` to `WebhookEventType`; added `QuotaThresholdReachedData` interface; added missing `DeadLetterEntry` and `WebhookDeliveryStatus` types |

---

## Design decisions

### Idempotency: at-most-once delivery

The `(developer_id, period, threshold)` triple is written to `quota_notifications_sent` **before** the webhook is dispatched. This means:

- A crash between `markSent` and delivery skips that delivery — the next tick won't retry. This is the safer choice; a missed alert is less harmful than a flood of duplicates.
- A crash before `markSent` will retry on the next tick.
- The `quota_notifications_sent` table has a composite primary key on `(developer_id, period, threshold)`, so concurrent processes cannot double-insert.

### Month boundary derivation

The period (`YYYY-MM`) and the `from`/`to` query window are both derived from the injected `now()` clock on every tick. This means:

- There is no mutable state that can drift between ticks.
- Tests can inject a fake clock and advance it across month boundaries without restarting the job.

### Separation of concerns

`runQuotaCheck` is exported as a pure async function that takes all its dependencies as arguments. The interval machinery in `createQuotaNotifierJob` is a thin wrapper. This makes the core logic directly unit-testable without fake timers.

### Quota source

Developer quotas are provided via an injected `getDeveloperQuotas()` callback rather than hard-coding a repository interface. This keeps the notifier decoupled from whatever storage mechanism the operator uses (a Postgres table, a config file, a feature-flag system, etc.). See `docs/quota-notifications.md` for a concrete wiring example.

---

## Webhook payload

```json
{
  "event": "quota.threshold.reached",
  "timestamp": "2026-06-25T16:00:00.000Z",
  "developerId": "dev_abc123",
  "data": {
    "period": "2026-06",
    "threshold": 80,
    "currentUsage": 800,
    "quotaLimit": 1000,
    "usagePercent": 80.00
  }
}
```

---

## Database migration

```sql
-- up
CREATE TABLE quota_notifications_sent (
  developer_id  VARCHAR(255) NOT NULL,
  period        CHAR(7)      NOT NULL,  -- 'YYYY-MM'
  threshold     SMALLINT     NOT NULL,  -- 80 | 95 | 100
  created_at    TIMESTAMP    NOT NULL DEFAULT NOW(),
  PRIMARY KEY (developer_id, period, threshold)
);
CREATE INDEX idx_quota_notifications_developer_period
  ON quota_notifications_sent (developer_id, period);

-- down
DROP INDEX IF EXISTS idx_quota_notifications_developer_period;
DROP TABLE IF EXISTS quota_notifications_sent;
```

Apply with:
```bash
psql -U <user> -d callora -f migrations/0009_quota_notifications_sent.sql
```

---

## Test output

```
PASS src/services/quotaNotifier.test.ts

  periodOf
    ✓ returns YYYY-MM for mid-month
    ✓ returns YYYY-MM for first day of month
    ✓ returns YYYY-MM for last day of month
    ✓ pads single-digit months

  monthBoundaries
    ✓ sets from to the start of the month (UTC)
    ✓ sets to to the last millisecond of the month (UTC)
    ✓ handles December correctly (no month 13)
    ✓ handles February in a leap year

  InMemoryQuotaNotificationStore
    ✓ returns false before a notification is marked
    ✓ returns true after markSent
    ✓ is keyed by (developerId, period, threshold) — different keys are independent
    ✓ markSent is idempotent
    ✓ clear() resets all state

  runQuotaCheck — threshold detection
    ✓ fires no notifications when usage is below 80%
    ✓ fires the 80% notification at exactly 80 calls / 100 limit
    ✓ fires 80% and 95% when usage is at 95%
    ✓ fires all three thresholds when usage is at 100%
    ✓ fires all three when usage exceeds 100%

  runQuotaCheck — idempotency
    ✓ does not re-fire a threshold already marked in the store
    ✓ fires each threshold exactly once across repeated runs in the same period

  runQuotaCheck — month boundary
    ✓ events from a previous month are not counted in the current period
    ✓ sends June notifications for June and July notifications for July independently
    ✓ uses now() on each tick so clock-skew does not use stale period

  runQuotaCheck — guard conditions
    ✓ skips developers with monthlyLimit <= 0
    ✓ handles multiple developers independently
    ✓ returns 0 and logs error when getDeveloperQuotas throws
    ✓ continues to next developer when usage repo throws for one
    ✓ continues when notificationStore.hasBeenSent throws
    ✓ continues when notificationStore.markSent throws

  runQuotaCheck — webhook payload shape
    ✓ builds the correct QuotaThresholdReachedData payload

  createQuotaNotifierJob
    ✓ does not run before start() is called
    ✓ runs on each interval tick after start()
    ✓ stops firing after stop() is called
    ✓ calling start() twice is a no-op (no duplicate intervals)

Tests: 34 passed, 34 total
```

---

## Acceptance criteria checklist

- [x] Threshold events fire exactly once per developer per period per threshold
- [x] Webhook payload conforms to the `QuotaThresholdReachedData` schema (documented in `webhook.types.ts` and `docs/quota-notifications.md`)
- [x] Unit tests with fake clock cover boundary transitions (month rollover, clock-skew, prior-month events excluded)
- [x] Operator docs added under `docs/quota-notifications.md`
- [x] Reuses existing `dispatchToAll` / `WebhookStore` infrastructure
- [x] Migration ships with a matching `.down.sql` rollback file

---

## How to wire into production

See [`docs/quota-notifications.md`](docs/quota-notifications.md) for the full operator guide. Short version:

```ts
const job = createQuotaNotifierJob(usageEventsRepository, new PgQuotaNotificationStore(pool), {
  intervalMs: 60_000,
  getDeveloperQuotas: () => pool.query('SELECT developer_id, monthly_limit FROM developer_quotas'),
});
job.start();
// on shutdown:
job.stop();
```

closes #392