### PR TITLE
feat: admin endpoints to inspect and reset usage aggregates

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -197,6 +197,158 @@
         }
       }
     },
+    "/api/admin/usage/{developerId}": {
+      "get": {
+        "summary": "Inspect a developer usage aggregate",
+        "description": "Returns a redacted aggregate snapshot for a developer's live usageStore state. Requires admin authentication and the admin IP allowlist.",
+        "security": [
+          {
+            "adminApiKey": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "developerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage aggregate snapshot retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUsageSnapshotResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized admin request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden by admin IP allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Usage aggregate not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/usage/{developerId}/reset": {
+      "post": {
+        "summary": "Reset a developer usage aggregate",
+        "description": "Resets a developer's live usageStore aggregate and writes an audit log with the prior aggregate values. Requires admin authentication and the admin IP allowlist.",
+        "security": [
+          {
+            "adminApiKey": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "developerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage aggregate reset successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUsageResetResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized admin request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden by admin IP allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Usage aggregate not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/apis": {
       "get": {
         "summary": "List public APIs",
@@ -468,6 +620,11 @@
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT"
+      },
+      "adminApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-admin-api-key"
       }
     },
     "schemas": {
@@ -637,6 +794,110 @@
               "to": {
                 "type": "string",
                 "format": "date-time"
+              }
+            }
+          }
+        }
+      },
+      "AdminUsageSnapshot": {
+        "type": "object",
+        "required": [
+          "developerId",
+          "totalEvents",
+          "settledEvents",
+          "unsettledEvents",
+          "totalAmountUsdc",
+          "settledAmountUsdc",
+          "unsettledAmountUsdc",
+          "apiCount",
+          "endpointCount",
+          "firstEventAt",
+          "lastEventAt",
+          "statusCodes"
+        ],
+        "properties": {
+          "developerId": {
+            "type": "string"
+          },
+          "totalEvents": {
+            "type": "integer"
+          },
+          "settledEvents": {
+            "type": "integer"
+          },
+          "unsettledEvents": {
+            "type": "integer"
+          },
+          "totalAmountUsdc": {
+            "type": "number"
+          },
+          "settledAmountUsdc": {
+            "type": "number"
+          },
+          "unsettledAmountUsdc": {
+            "type": "number"
+          },
+          "apiCount": {
+            "type": "integer"
+          },
+          "endpointCount": {
+            "type": "integer"
+          },
+          "firstEventAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "lastEventAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "statusCodes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "AdminUsageSnapshotResponse": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/AdminUsageSnapshot"
+          }
+        }
+      },
+      "AdminUsageResetResponse": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "developerId",
+              "reset",
+              "priorValues"
+            ],
+            "properties": {
+              "developerId": {
+                "type": "string"
+              },
+              "reset": {
+                "type": "boolean"
+              },
+              "priorValues": {
+                "$ref": "#/components/schemas/AdminUsageSnapshot"
               }
             }
           }

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import { z } from 'zod';
-import adminRouter from './routes/admin.js';
+import { createAdminRouter } from './routes/admin.js';
 import { createApiRouter } from './routes/index.js';
 import { createApisRouter } from './routes/apis.js';
 import { pool } from './db.js';
@@ -52,6 +52,7 @@ import {
 import { apiKeyRepository } from './repositories/apiKeyRepository.js';
 import { apiRegistrationSchema } from './validators/apiRegistration.js';
 import { stellarNetworkQuerySchema } from './validators/networkSchema.js';
+import { createUsageStore, type UsageAdminStore } from './services/usageStore.js';
 
 interface AppDependencies {
   usageEventsRepository?: UsageEventsRepository;
@@ -59,6 +60,7 @@ interface AppDependencies {
   vaultRepository?: VaultRepository;
   apiRepository?: ApiRepository;
   developerRepository?: DeveloperRepository;
+  usageStore?: UsageAdminStore;
   findDeveloperByUserId?: (userId: string) => Promise<Developer | undefined>;
   createApiWithEndpoints?: (input: CreateApiInput) => Promise<ApiWithEndpoints>;
 }
@@ -103,6 +105,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
   const vaultController = new VaultController(vaultRepository);
   const apiRepository = dependencies?.apiRepository ?? defaultApiRepository;
   const developerRepository = dependencies?.developerRepository ?? defaultDeveloperRepository;
+  const usageStore = dependencies?.usageStore ?? createUsageStore();
 
   // Production-safe security headers with environment-based configuration
   const isProduction = process.env.NODE_ENV === 'production';
@@ -250,7 +253,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     }
   });
 
-  app.use('/api/admin', adminRouter);
+  app.use('/api/admin', createAdminRouter({ usageStore }));
 
   // Prometheus metrics endpoint — auth-gated in production
   app.get('/api/metrics', metricsEndpoint);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import type { RequestHandler } from 'express';
 import { createDeveloperRouter } from './routes/developerRoutes.js';
 import { createGatewayRouter } from './routes/gatewayRoutes.js';
 import { createProxyRouter } from './routes/proxyRoutes.js';
+import { createAdminRouter } from './routes/admin.js';
 import { defaultDeveloperRepository } from './repositories/developerRepository.js';
 import { createBillingService } from './services/billingService.js';
 import { createRateLimiter } from './services/rateLimiter.js';
@@ -277,6 +278,7 @@ if (isDirectExecution) {
     developerRepository: defaultDeveloperRepository,
   });
   app.use('/api/developers', developerRouter);
+  app.use('/api/admin', createAdminRouter({ usageStore }));
 
   // Legacy gateway route (existing)
   const gatewayRouter = createGatewayRouter({

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,31 +3,102 @@ import { adminAuth } from '../middleware/adminAuth.js';
 import { createAdminIpAllowlist } from '../middleware/ipAllowlist.js';
 import { findUsers } from '../repositories/userRepository.js';
 import { parsePagination, paginatedResponse } from '../lib/pagination.js';
-import { AppError, InternalServerError } from '../errors/index.js';
+import { AppError, InternalServerError, NotFoundError } from '../errors/index.js';
 import { logger } from '../logger.js';
+import { createUsageStore, type UsageAdminStore } from '../services/usageStore.js';
 
-const router = Router();
+export interface AdminRouterDeps {
+  usageStore: UsageAdminStore;
+}
 
-// Apply IP allowlist check before authentication
-router.use(createAdminIpAllowlist());
-router.use(adminAuth);
-
-router.get('/users', async (req, res, next) => {
-  try {
-    const { limit, offset } = parsePagination(req.query as Record<string, string>);
-    const { users, total } = await findUsers({ limit, offset });
-
-    logger.audit('LIST_USERS', res.locals.adminActor, { limit, offset, count: users.length, total });
-
-    res.json(paginatedResponse(users, { total, limit, offset }));
-  } catch (error) {
-    if (error instanceof AppError) {
-      next(error);
-      return;
-    }
-    logger.error('Failed to list users:', error);
-    next(new InternalServerError());
-  }
+const buildUsageAuditDetails = (developerId: string, priorValues: unknown) => ({
+  developerId,
+  priorValues,
 });
+
+export function createAdminRouter(deps: AdminRouterDeps) {
+  const router = Router();
+
+  // Apply IP allowlist check before authentication.
+  router.use(createAdminIpAllowlist());
+  router.use(adminAuth);
+
+  router.get('/users', async (req, res, next) => {
+    try {
+      const { limit, offset } = parsePagination(req.query as Record<string, string>);
+      const { users, total } = await findUsers({ limit, offset });
+
+      logger.audit('LIST_USERS', res.locals.adminActor, { limit, offset, count: users.length, total });
+
+      res.json(paginatedResponse(users, { total, limit, offset }));
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error('Failed to list users:', error);
+      next(new InternalServerError());
+    }
+  });
+
+  router.get('/usage/:developerId', async (req, res, next) => {
+    try {
+      const snapshot = await deps.usageStore.getDeveloperUsageSnapshot(req.params.developerId);
+      if (!snapshot) {
+        next(new NotFoundError('Usage aggregate not found', 'USAGE_AGGREGATE_NOT_FOUND'));
+        return;
+      }
+
+      logger.audit('READ_USAGE_AGGREGATE', res.locals.adminActor, {
+        developerId: req.params.developerId,
+        totalEvents: snapshot.totalEvents,
+      });
+
+      res.json({ data: snapshot });
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error('Failed to read usage aggregate:', error);
+      next(new InternalServerError());
+    }
+  });
+
+  router.post('/usage/:developerId/reset', async (req, res, next) => {
+    try {
+      const priorValues = await deps.usageStore.resetDeveloperUsage(req.params.developerId);
+      if (!priorValues) {
+        next(new NotFoundError('Usage aggregate not found', 'USAGE_AGGREGATE_NOT_FOUND'));
+        return;
+      }
+
+      logger.audit(
+        'RESET_USAGE_AGGREGATE',
+        res.locals.adminActor,
+        buildUsageAuditDetails(req.params.developerId, priorValues),
+      );
+
+      res.json({
+        data: {
+          developerId: req.params.developerId,
+          reset: true,
+          priorValues,
+        },
+      });
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error('Failed to reset usage aggregate:', error);
+      next(new InternalServerError());
+    }
+  });
+
+  return router;
+}
+
+const router = createAdminRouter({ usageStore: createUsageStore() });
 
 export default router;

--- a/src/services/usageStore.ts
+++ b/src/services/usageStore.ts
@@ -1,10 +1,42 @@
 import { UsageStore, UsageEvent } from '../types/gateway.js';
 
+export interface UsageAggregateSnapshot {
+  developerId: string;
+  totalEvents: number;
+  settledEvents: number;
+  unsettledEvents: number;
+  totalAmountUsdc: number;
+  settledAmountUsdc: number;
+  unsettledAmountUsdc: number;
+  apiCount: number;
+  endpointCount: number;
+  firstEventAt: string | null;
+  lastEventAt: string | null;
+  statusCodes: Record<string, number>;
+}
+
+export interface UsageAdminStore extends UsageStore {
+  getDeveloperUsageSnapshot(developerId: string): Promise<UsageAggregateSnapshot | undefined> | UsageAggregateSnapshot | undefined;
+  resetDeveloperUsage(developerId: string): Promise<UsageAggregateSnapshot | undefined> | UsageAggregateSnapshot | undefined;
+}
+
+const emptyStatusCounts = (): Record<string, number> => ({});
+
+const sumAmounts = (events: UsageEvent[]): number =>
+  events.reduce((total, event) => total + event.amountUsdc, 0);
+
+const toIsoOrNull = (value: Date | string | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+};
+
 /**
  * In-memory usage event store with idempotency.
  * In production this would write to a database table.
  */
-export class InMemoryUsageStore implements UsageStore {
+export class InMemoryUsageStore implements UsageAdminStore {
   private events: UsageEvent[] = [];
   private requestIds = new Set<string>();
 
@@ -31,6 +63,52 @@ export class InMemoryUsageStore implements UsageStore {
       return this.events.filter((e) => e.apiKey === apiKey);
     }
     return [...this.events];
+  }
+
+  getDeveloperUsageSnapshot(developerId: string): UsageAggregateSnapshot | undefined {
+    const events = this.events.filter((event) => event.userId === developerId);
+    if (events.length === 0) {
+      return undefined;
+    }
+
+    const settledEvents = events.filter((event) => event.settlementId);
+    const unsettledEvents = events.filter((event) => !event.settlementId);
+    const sortedTimestamps = events
+      .map((event) => event.timestamp)
+      .sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
+    const statusCodes = emptyStatusCounts();
+
+    for (const event of events) {
+      const statusCode = String(event.statusCode);
+      statusCodes[statusCode] = (statusCodes[statusCode] ?? 0) + 1;
+    }
+
+    return {
+      developerId,
+      totalEvents: events.length,
+      settledEvents: settledEvents.length,
+      unsettledEvents: unsettledEvents.length,
+      totalAmountUsdc: sumAmounts(events),
+      settledAmountUsdc: sumAmounts(settledEvents),
+      unsettledAmountUsdc: sumAmounts(unsettledEvents),
+      apiCount: new Set(events.map((event) => event.apiId)).size,
+      endpointCount: new Set(events.map((event) => event.endpointId)).size,
+      firstEventAt: sortedTimestamps[0] ?? null,
+      lastEventAt: sortedTimestamps[sortedTimestamps.length - 1] ?? null,
+      statusCodes,
+    };
+  }
+
+  resetDeveloperUsage(developerId: string): UsageAggregateSnapshot | undefined {
+    const priorSnapshot = this.getDeveloperUsageSnapshot(developerId);
+    if (!priorSnapshot) {
+      return undefined;
+    }
+
+    const retainedEvents = this.events.filter((event) => event.userId !== developerId);
+    this.events = retainedEvents;
+    this.requestIds = new Set(retainedEvents.map((event) => event.requestId));
+    return priorSnapshot;
   }
 
   /** Retrieve all usage events that haven't been settled yet and have a non-zero price. */
@@ -83,8 +161,29 @@ interface UsageEventRow {
   settlement_external_id: string | null;
 }
 
+interface UsageAggregateRow {
+  total_events: string | number;
+  settled_events: string | number;
+  unsettled_events: string | number;
+  total_amount_usdc: string | number | null;
+  settled_amount_usdc: string | number | null;
+  unsettled_amount_usdc: string | number | null;
+  api_count: string | number;
+  endpoint_count: string | number;
+  first_event_at: Date | string | null;
+  last_event_at: Date | string | null;
+}
+
+interface StatusCodeCountRow {
+  status_code: number;
+  count: string | number;
+}
+
 const toNumber = (value: string | number): number =>
   typeof value === 'number' ? value : Number(value);
+
+const nullableNumber = (value: string | number | null): number =>
+  value === null ? 0 : toNumber(value);
 
 const mapUsageEventRow = (row: UsageEventRow): UsageEvent => ({
   id: String(row.id),
@@ -120,7 +219,7 @@ const usageEventSelect = `
     ON s.id = rl.settlement_id
 `;
 
-export class PostgresUsageStore implements UsageStore {
+export class PostgresUsageStore implements UsageAdminStore {
   constructor(private readonly db: UsageStoreQueryable) {}
 
   async record(event: UsageEvent): Promise<boolean> {
@@ -244,6 +343,122 @@ export class PostgresUsageStore implements UsageStore {
     );
 
     return result.rows.map(mapUsageEventRow);
+  }
+
+  async getDeveloperUsageSnapshot(developerId: string): Promise<UsageAggregateSnapshot | undefined> {
+    const [aggregateResult, statusResult] = await Promise.all([
+      this.db.query<UsageAggregateRow>(
+        `
+          SELECT
+            COUNT(*) AS total_events,
+            COUNT(*) FILTER (WHERE rl.settlement_id IS NOT NULL) AS settled_events,
+            COUNT(*) FILTER (WHERE rl.settlement_id IS NULL) AS unsettled_events,
+            COALESCE(SUM(ue.amount_usdc), 0) AS total_amount_usdc,
+            COALESCE(SUM(ue.amount_usdc) FILTER (WHERE rl.settlement_id IS NOT NULL), 0) AS settled_amount_usdc,
+            COALESCE(SUM(ue.amount_usdc) FILTER (WHERE rl.settlement_id IS NULL), 0) AS unsettled_amount_usdc,
+            COUNT(DISTINCT ue.api_id) AS api_count,
+            COUNT(DISTINCT ue.endpoint_id) AS endpoint_count,
+            MIN(ue.created_at) AS first_event_at,
+            MAX(ue.created_at) AS last_event_at
+          FROM revenue_ledger rl
+          INNER JOIN usage_events ue
+            ON ue.id = rl.usage_event_id
+          WHERE rl.developer_id = $1
+        `,
+        [developerId],
+      ),
+      this.db.query<StatusCodeCountRow>(
+        `
+          SELECT ue.status_code, COUNT(*) AS count
+          FROM revenue_ledger rl
+          INNER JOIN usage_events ue
+            ON ue.id = rl.usage_event_id
+          WHERE rl.developer_id = $1
+          GROUP BY ue.status_code
+          ORDER BY ue.status_code ASC
+        `,
+        [developerId],
+      ),
+    ]);
+
+    const aggregate = aggregateResult.rows[0];
+    if (!aggregate || toNumber(aggregate.total_events) === 0) {
+      return undefined;
+    }
+
+    const statusCodes = emptyStatusCounts();
+    for (const row of statusResult.rows) {
+      statusCodes[String(row.status_code)] = toNumber(row.count);
+    }
+
+    return {
+      developerId,
+      totalEvents: toNumber(aggregate.total_events),
+      settledEvents: toNumber(aggregate.settled_events),
+      unsettledEvents: toNumber(aggregate.unsettled_events),
+      totalAmountUsdc: nullableNumber(aggregate.total_amount_usdc),
+      settledAmountUsdc: nullableNumber(aggregate.settled_amount_usdc),
+      unsettledAmountUsdc: nullableNumber(aggregate.unsettled_amount_usdc),
+      apiCount: toNumber(aggregate.api_count),
+      endpointCount: toNumber(aggregate.endpoint_count),
+      firstEventAt: toIsoOrNull(aggregate.first_event_at),
+      lastEventAt: toIsoOrNull(aggregate.last_event_at),
+      statusCodes,
+    };
+  }
+
+  async resetDeveloperUsage(developerId: string): Promise<UsageAggregateSnapshot | undefined> {
+    const client = await this.db.connect();
+
+    try {
+      await client.query('BEGIN');
+
+      const snapshotStore = new PostgresUsageStore({
+        query: client.query.bind(client),
+        connect: this.db.connect.bind(this.db),
+      });
+      const priorSnapshot = await snapshotStore.getDeveloperUsageSnapshot(developerId);
+      if (!priorSnapshot) {
+        await client.query('ROLLBACK');
+        return undefined;
+      }
+
+      const deletedLedger = await client.query<{ usage_event_id: string | number | null }>(
+        `
+          DELETE FROM revenue_ledger
+          WHERE developer_id = $1
+          RETURNING usage_event_id
+        `,
+        [developerId],
+      );
+
+      const usageEventIds = deletedLedger.rows
+        .map((row) => row.usage_event_id)
+        .filter((id): id is string | number => id !== null && id !== undefined);
+
+      if (usageEventIds.length > 0) {
+        await client.query(
+          `
+            DELETE FROM usage_events ue
+            WHERE ue.id = ANY($1::bigint[])
+              AND NOT EXISTS (
+                SELECT 1
+                FROM revenue_ledger rl
+                WHERE rl.usage_event_id = ue.id
+              )
+          `,
+          [usageEventIds.map((id) => Number(id))],
+        );
+      }
+
+      await client.query('COMMIT');
+      return priorSnapshot;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   async markAsSettled(eventIds: string[], settlementId: string): Promise<void> {

--- a/tests/integration/adminUsage.test.ts
+++ b/tests/integration/adminUsage.test.ts
@@ -1,0 +1,198 @@
+import express from 'express';
+import request from 'supertest';
+import { createAdminRouter } from '../../src/routes/admin.js';
+import { errorHandler } from '../../src/middleware/errorHandler.js';
+import { createUsageStore } from '../../src/services/usageStore.js';
+import { logger } from '../../src/logger.js';
+
+jest.mock('../../src/logger', () => {
+  const actual = jest.requireActual('../../src/logger');
+  return {
+    ...actual,
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      audit: jest.fn(),
+    },
+  };
+});
+
+jest.mock('../../src/repositories/userRepository', () => ({
+  findUsers: jest.fn().mockResolvedValue({ users: [], total: 0 }),
+}));
+
+const TEST_ADMIN_API_KEY = 'test-admin-api-key';
+const originalAdminApiKey = process.env.ADMIN_API_KEY;
+const originalIpRanges = process.env.ADMIN_IP_ALLOWED_RANGES;
+const originalIpAllowlistEnabled = process.env.ADMIN_IP_ALLOWLIST_ENABLED;
+
+const buildApp = (usageStore = createUsageStore()) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin', createAdminRouter({ usageStore }));
+  app.use(errorHandler);
+  return { app, usageStore };
+};
+
+const seedUsage = (usageStore: ReturnType<typeof createUsageStore>) => {
+  usageStore.record({
+    id: 'evt_1',
+    requestId: 'req_1',
+    apiKey: 'secret-api-key',
+    apiKeyId: 'key_1',
+    apiId: 'api_1',
+    endpointId: 'endpoint_1',
+    userId: 'dev_001',
+    amountUsdc: 1.5,
+    statusCode: 200,
+    timestamp: '2026-06-25T10:00:00.000Z',
+  });
+  usageStore.record({
+    id: 'evt_2',
+    requestId: 'req_2',
+    apiKey: 'another-secret-api-key',
+    apiKeyId: 'key_2',
+    apiId: 'api_2',
+    endpointId: 'endpoint_2',
+    userId: 'dev_001',
+    amountUsdc: 2,
+    statusCode: 500,
+    timestamp: '2026-06-25T10:05:00.000Z',
+    settlementId: 'stl_1',
+  });
+};
+
+describe('admin usage inspection and reset endpoints', () => {
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = TEST_ADMIN_API_KEY;
+    delete process.env.ADMIN_IP_ALLOWED_RANGES;
+    delete process.env.ADMIN_IP_ALLOWLIST_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalAdminApiKey === undefined) {
+      delete process.env.ADMIN_API_KEY;
+    } else {
+      process.env.ADMIN_API_KEY = originalAdminApiKey;
+    }
+
+    if (originalIpRanges === undefined) {
+      delete process.env.ADMIN_IP_ALLOWED_RANGES;
+    } else {
+      process.env.ADMIN_IP_ALLOWED_RANGES = originalIpRanges;
+    }
+
+    if (originalIpAllowlistEnabled === undefined) {
+      delete process.env.ADMIN_IP_ALLOWLIST_ENABLED;
+    } else {
+      process.env.ADMIN_IP_ALLOWLIST_ENABLED = originalIpAllowlistEnabled;
+    }
+
+    jest.clearAllMocks();
+  });
+
+  it('rejects usage reads without admin credentials', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app).get('/api/admin/usage/dev_001');
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('applies the admin IP allowlist before usage reads', async () => {
+    process.env.ADMIN_IP_ALLOWED_RANGES = '203.0.113.0/24';
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .get('/api/admin/usage/dev_001')
+      .set('x-admin-api-key', TEST_ADMIN_API_KEY);
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('IP_NOT_ALLOWED');
+  });
+
+  it('returns 404 for unknown developer usage aggregates', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .get('/api/admin/usage/missing_dev')
+      .set('x-admin-api-key', TEST_ADMIN_API_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('USAGE_AGGREGATE_NOT_FOUND');
+  });
+
+  it('returns a redacted current usage aggregate snapshot', async () => {
+    const { app, usageStore } = buildApp();
+    seedUsage(usageStore);
+
+    const res = await request(app)
+      .get('/api/admin/usage/dev_001')
+      .set('x-admin-api-key', TEST_ADMIN_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      developerId: 'dev_001',
+      totalEvents: 2,
+      settledEvents: 1,
+      unsettledEvents: 1,
+      totalAmountUsdc: 3.5,
+      settledAmountUsdc: 2,
+      unsettledAmountUsdc: 1.5,
+      apiCount: 2,
+      endpointCount: 2,
+      firstEventAt: '2026-06-25T10:00:00.000Z',
+      lastEventAt: '2026-06-25T10:05:00.000Z',
+      statusCodes: { '200': 1, '500': 1 },
+    });
+    expect(JSON.stringify(res.body)).not.toContain('secret-api-key');
+    expect(logger.audit).toHaveBeenCalledWith(
+      'READ_USAGE_AGGREGATE',
+      'admin-api-key',
+      expect.objectContaining({ developerId: 'dev_001', totalEvents: 2 }),
+    );
+  });
+
+  it('resets usage and audits prior aggregate values', async () => {
+    const { app, usageStore } = buildApp();
+    seedUsage(usageStore);
+
+    const resetRes = await request(app)
+      .post('/api/admin/usage/dev_001/reset')
+      .set('x-admin-api-key', TEST_ADMIN_API_KEY);
+
+    expect(resetRes.status).toBe(200);
+    expect(resetRes.body.data.reset).toBe(true);
+    expect(resetRes.body.data.priorValues).toEqual(expect.objectContaining({
+      developerId: 'dev_001',
+      totalEvents: 2,
+      totalAmountUsdc: 3.5,
+    }));
+    expect(logger.audit).toHaveBeenCalledWith(
+      'RESET_USAGE_AGGREGATE',
+      'admin-api-key',
+      expect.objectContaining({
+        developerId: 'dev_001',
+        priorValues: expect.objectContaining({ totalEvents: 2 }),
+      }),
+    );
+
+    const readAfterReset = await request(app)
+      .get('/api/admin/usage/dev_001')
+      .set('x-admin-api-key', TEST_ADMIN_API_KEY);
+
+    expect(readAfterReset.status).toBe(404);
+    expect(usageStore.getEvents()).toHaveLength(0);
+  });
+
+  it('rejects usage resets without admin credentials', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app).post('/api/admin/usage/dev_001/reset');
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+});


### PR DESCRIPTION
## Summary

Adds admin-only usage inspection and reset endpoints for live `usageStore` aggregates.

## Changes

- Added `GET /api/admin/usage/:developerId`
- Added `POST /api/admin/usage/:developerId/reset`
- Guarded both endpoints behind the existing admin IP allowlist and `adminAuth`
- Added usage aggregate snapshot and reset operations to both in-memory and Postgres usage stores
- Reset returns and audits prior aggregate values before clearing records
- Wired the admin router to the live usage store in both `createApp()` and runtime startup
- Updated OpenAPI docs for the new endpoints and admin API-key auth scheme
- Added integration tests for:
  - Missing admin credentials
  - Admin IP allowlist denial
  - Unknown developer aggregate
  - Redacted aggregate read
  - Reset behavior and audit logging

## Security Notes

- The read endpoint returns aggregate values only, not raw usage events.
- API keys and request-level details are not exposed in the response.
- Reset operations emit a strong audit log entry containing the prior aggregate snapshot.

## Testing

Attempted:

```bash
npm test -- admin
npm run typecheck

## Closes #402 