### PR TITLE
## feat(idempotency): Add periodic idempotency sweeper with advisory lock and observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,15 @@ BILLING_MAX_CONCURRENCY_PER_DEV=1
 BILLING_SEMAPHORE_TTL_MS=300000
 
 # -----------------------------------------------------------------------------
+# Idempotency cleanup
+# -----------------------------------------------------------------------------
+# How long idempotency cache entries are kept before they become eligible
+# for periodic cleanup (seconds).
+IDEMPOTENCY_RETENTION_WINDOW_SECONDS=86400
+# How often the idempotency sweeper job runs (milliseconds).
+IDEMPOTENCY_SWEEPER_INTERVAL_MS=60000
+
+# -----------------------------------------------------------------------------
 # CORS — comma-separated list of allowed origins
 # -----------------------------------------------------------------------------
 CORS_ALLOWED_ORIGINS=http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ callora-backend/
 | `STELLAR_TRANSACTION_TIMEOUT` | Transaction timeout (seconds) | `30` |
 | `BILLING_MAX_CONCURRENCY_PER_DEV` | Max concurrent deducts per developer | `1` |
 | `BILLING_SEMAPHORE_TTL_MS` | Idle semaphore state TTL in ms | `300000` |
+| `IDEMPOTENCY_SWEEPER_INTERVAL_MS` | Interval for periodic idempotency cleanup in milliseconds | `60000` |
 | `CIRCUIT_BREAKER_THRESHOLD` | Failures before opening circuit | `5` |
 | `CIRCUIT_BREAKER_COOLDOWN_MS` | Cooldown period (ms) | `30000` |
 | `RETRY_MAX_ATTEMPTS` | Maximum retry attempts | `3` |

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -136,6 +136,7 @@ export const envSchema = z
 
     // Idempotency
     IDEMPOTENCY_RETENTION_WINDOW_SECONDS: z.coerce.number().int().positive().default(86400),
+    IDEMPOTENCY_SWEEPER_INTERVAL_MS: z.coerce.number().int().positive().default(60_000),
   })
   .superRefine((values, ctx) => {
     if (values.SOROBAN_RPC_ENABLED && !values.SOROBAN_RPC_URL) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -199,6 +199,7 @@ export const config = {
   },
   idempotency: {
     retentionWindowSeconds: env.IDEMPOTENCY_RETENTION_WINDOW_SECONDS,
+    sweeperIntervalMs: env.IDEMPOTENCY_SWEEPER_INTERVAL_MS,
   },
   listingsCache: {
     warmupTimeoutMs: env.LISTINGS_CACHE_WARMUP_TIMEOUT_MS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { PgUsageEventsRepository } from './repositories/usageEventsRepository.pg
 import { createRevenueLedgerIndexerJob } from './services/revenueLedgerIndexer.js';
 import { RevenueSettlementService } from './services/revenueSettlementService.js';
 import { createSettlementStatusSyncJob } from './services/settlementStatusSyncJob.js';
+import { createIdempotencySweeperJob } from './services/idempotencySweeper.js';
 import { createPostgresUsageStore } from './services/usageStore.js';
 import { createPostgresSettlementStore } from './services/settlementStore.js';
 import { createApiRegistry } from './data/apiRegistry.js';
@@ -269,6 +270,10 @@ if (isDirectExecution) {
     intervalMs: config.settlementSync.intervalMs,
   });
 
+  const idempotencySweeperJob = createIdempotencySweeperJob(pool, {
+    intervalMs: config.idempotency.sweeperIntervalMs,
+  });
+
   const apiKeys = new Map<string, ApiKey>([
     ['test-key-1', { key: 'test-key-1', developerId: 'dev_001', apiId: 'api_001' }],
     ['test-key-2', { key: 'test-key-2', developerId: 'dev_002', apiId: 'api_002' }],
@@ -313,6 +318,11 @@ if (isDirectExecution) {
       awaitIdle: () => revenueLedgerIndexerJob.awaitIdle(),
     },
     {
+      name: 'idempotency-sweeper',
+      beginShutdown: () => idempotencySweeperJob.beginShutdown(),
+      awaitIdle: () => idempotencySweeperJob.awaitIdle(),
+    },
+    {
       name: 'webhook-dispatcher',
       beginShutdown: stopWebhookDispatching,
       awaitIdle: awaitWebhookDispatcherIdle,
@@ -332,6 +342,7 @@ if (isDirectExecution) {
   const closeAllDataResources = async () => {
     revenueLedgerIndexerJob.stop();
     settlementStatusSyncJob.stop();
+    idempotencySweeperJob.stop();
     await closeDb();
     await Promise.allSettled([
       closePgPool(),
@@ -362,6 +373,7 @@ if (isDirectExecution) {
 
       revenueLedgerIndexerJob.start();
       settlementStatusSyncJob.start();
+      idempotencySweeperJob.start();
       
       const server = app.listen(PORT, () => {
         console.log(`Callora backend listening on http://localhost:${PORT}`);

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -464,12 +464,23 @@ const proxyPrematureAbortsTotal = new client.Counter({
   help: 'Total number of proxy responses where the client connection closed before the response finished (premature abort)',
 });
 
+const idempotencyStoreRows = new client.Gauge({
+  name: 'idempotency_store_rows',
+  help: 'Current number of rows in the idempotency_store table',
+});
+
 register.registerMetric(proxyPrematureAbortsTotal);
+register.registerMetric(idempotencyStoreRows);
 
 /** Increment the premature-abort counter. Called by proxyRoutes when a response
  *  emits `close` without a preceding `finish` event. */
 export function recordProxyPrematureAbort(): void {
   proxyPrematureAbortsTotal.inc();
+}
+
+/** Update the current number of active idempotency rows for monitoring. */
+export function setIdempotencyStoreRows(value: number): void {
+  idempotencyStoreRows.set(value);
 }
 
 /** Exposed for testing — reset all metrics including upstream and HTTP. */
@@ -484,5 +495,6 @@ export function resetAllMetrics(): void {
   apisListingCacheHits.reset();
   apisListingCacheMisses.reset();
   proxyPrematureAbortsTotal.reset();
+  idempotencyStoreRows.reset();
   gatewayUpstreamBreakerState.reset();
 }

--- a/src/services/idempotencySweeper.test.ts
+++ b/src/services/idempotencySweeper.test.ts
@@ -1,0 +1,102 @@
+import { resetAllMetrics, register } from '../metrics.js';
+import {
+  createIdempotencySweeperJob,
+  sweepIdempotencyStoreRows,
+} from './idempotencySweeper.js';
+
+describe('idempotency sweeper', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    resetAllMetrics();
+  });
+
+  it('acquires the advisory lock, deletes expired rows, and updates the gauge', async () => {
+    const mockPool = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockResolvedValueOnce({ rowCount: 2 })
+        .mockResolvedValueOnce({ rows: [{ row_count: '5' }] })
+        .mockResolvedValueOnce({}),
+    } as any;
+
+    const rowCount = await sweepIdempotencyStoreRows(mockPool);
+
+    expect(rowCount).toBe(5);
+    expect(mockPool.query).toHaveBeenNthCalledWith(
+      1,
+      'SELECT pg_try_advisory_lock($1) AS acquired',
+      [0x4a5b6c7d],
+    );
+    expect(mockPool.query).toHaveBeenNthCalledWith(
+      2,
+      'DELETE FROM idempotency_store WHERE expires_at < NOW()::timestamp',
+    );
+    expect(mockPool.query).toHaveBeenNthCalledWith(
+      3,
+      'SELECT COUNT(*)::bigint AS row_count FROM idempotency_store',
+    );
+
+    const metrics = await register.getMetricsAsJSON();
+    const gauge = metrics.find((m: any) => m.name === 'idempotency_store_rows');
+    expect(gauge).toBeDefined();
+    expect(gauge.values.some((value: any) => Number(value.value) === 5)).toBe(true);
+  });
+
+  it('skips delete when lock is held by another instance and still updates the gauge', async () => {
+    const mockPool = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: false }] })
+        .mockResolvedValueOnce({ rows: [{ row_count: '3' }] }),
+    } as any;
+
+    const rowCount = await sweepIdempotencyStoreRows(mockPool);
+
+    expect(rowCount).toBe(3);
+    expect(mockPool.query).toHaveBeenNthCalledWith(
+      1,
+      'SELECT pg_try_advisory_lock($1) AS acquired',
+      [0x4a5b6c7d],
+    );
+    expect(mockPool.query).toHaveBeenNthCalledWith(
+      2,
+      'SELECT COUNT(*)::bigint AS row_count FROM idempotency_store',
+    );
+  });
+
+  it('respects shutdown and waits for the current sweep to complete', async () => {
+    jest.useFakeTimers();
+
+    let firstQueryReleased = false;
+    const mockPool = {
+      query: jest.fn().mockImplementation(async (text: string) => {
+        if (text.includes('pg_try_advisory_lock')) {
+          return { rows: [{ acquired: true }] };
+        }
+        if (text.includes('DELETE FROM idempotency_store')) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          firstQueryReleased = true;
+          return { rowCount: 1 };
+        }
+        if (text.includes('SELECT COUNT')) {
+          return { rows: [{ row_count: '1' }] };
+        }
+        return { rows: [] };
+      }),
+    } as any;
+
+    const job = createIdempotencySweeperJob(mockPool, { intervalMs: 1000 });
+    job.start();
+
+    await Promise.resolve();
+    expect(mockPool.query).toHaveBeenCalledWith('SELECT pg_try_advisory_lock($1) AS acquired', [0x4a5b6c7d]);
+
+    job.beginShutdown();
+    await job.awaitIdle();
+
+    expect(firstQueryReleased).toBe(true);
+    jest.runOnlyPendingTimers();
+    expect(mockPool.query).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/services/idempotencySweeper.ts
+++ b/src/services/idempotencySweeper.ts
@@ -1,0 +1,131 @@
+import type { Pool } from 'pg';
+import { setIdempotencyStoreRows } from '../metrics.js';
+
+const IDEMPOTENCY_SWEEPER_ADVISORY_LOCK_KEY = 0x4a5b6c7d;
+
+export interface IdempotencySweeperJobOptions {
+  intervalMs: number;
+  logger?: Pick<typeof console, 'error' | 'info'>;
+}
+
+export interface IdempotencySweeperJob {
+  start(): void;
+  stop(): void;
+  beginShutdown(): void;
+  awaitIdle(): Promise<void>;
+}
+
+export async function sweepIdempotencyStoreRows(
+  pool: Pool,
+  logger: Pick<typeof console, 'error' | 'info'> = console,
+): Promise<number> {
+  let lockAcquired = false;
+  let deletedRows = 0;
+
+  try {
+    const lockResult = await pool.query<{ acquired: boolean }>(
+      'SELECT pg_try_advisory_lock($1) AS acquired',
+      [IDEMPOTENCY_SWEEPER_ADVISORY_LOCK_KEY],
+    );
+
+    if (lockResult.rows[0]?.acquired) {
+      lockAcquired = true;
+      const deleteResult = await pool.query(
+        'DELETE FROM idempotency_store WHERE expires_at < NOW()::timestamp',
+      );
+      deletedRows = deleteResult.rowCount ?? 0;
+      logger.info(
+        `[idempotencySweeper] Removed ${deletedRows} expired idempotency rows.`,
+      );
+    } else {
+      logger.info(
+        '[idempotencySweeper] Another instance owns the sweeper lock; skipping cleanup for this run.',
+      );
+    }
+
+    const countResult = await pool.query<{ row_count: string }>(
+      'SELECT COUNT(*)::bigint AS row_count FROM idempotency_store',
+    );
+    const rowCount = Number(countResult.rows[0]?.row_count ?? 0);
+
+    setIdempotencyStoreRows(rowCount);
+    logger.info(
+      `[idempotencySweeper] idempotency_store_rows=${rowCount} (deleted ${deletedRows}).`,
+    );
+
+    return rowCount;
+  } catch (error) {
+    logger.error('[idempotencySweeper] Sweep failed:', error);
+    throw error;
+  } finally {
+    if (lockAcquired) {
+      try {
+        await pool.query('SELECT pg_advisory_unlock($1)', [IDEMPOTENCY_SWEEPER_ADVISORY_LOCK_KEY]);
+      } catch (unlockError) {
+        logger.error('[idempotencySweeper] Failed to release advisory lock:', unlockError);
+      }
+    }
+  }
+}
+
+export function createIdempotencySweeperJob(
+  pool: Pool,
+  options: IdempotencySweeperJobOptions,
+): IdempotencySweeperJob {
+  const logger = options.logger ?? console;
+  if (!Number.isInteger(options.intervalMs) || options.intervalMs <= 0) {
+    throw new Error('intervalMs must be a positive integer.');
+  }
+
+  let timer: NodeJS.Timeout | null = null;
+  let accepting = true;
+  let running: Promise<void> | null = null;
+
+  const tick = async (): Promise<void> => {
+    if (!accepting || running) {
+      return;
+    }
+
+    running = (async () => {
+      try {
+        await sweepIdempotencyStoreRows(pool, logger);
+      } catch (error) {
+        logger.error('[idempotencySweeper] Job failed:', error);
+      } finally {
+        running = null;
+      }
+    })();
+
+    await running;
+  };
+
+  return {
+    start() {
+      if (timer || !accepting) {
+        return;
+      }
+
+      void tick();
+      timer = setInterval(() => {
+        void tick();
+      }, options.intervalMs);
+    },
+    stop() {
+      if (!timer) {
+        return;
+      }
+      clearInterval(timer);
+      timer = null;
+    },
+    beginShutdown() {
+      accepting = false;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+    async awaitIdle() {
+      await (running ?? Promise.resolve());
+    },
+  };
+}


### PR DESCRIPTION
This PR introduces a periodic cleanup job for `idempotency_store` along with Prometheus metrics to improve cache maintenance and operational visibility.

### What's included

- Added `idempotencySweeper.ts` with:
  - Periodic cleanup of expired `idempotency_store` rows.
  - Advisory lock protection using `pg_try_advisory_lock` to ensure only one instance performs cleanup.
  - Prometheus gauge updates for the current `idempotency_store` row count.

- Added `idempotencySweeper.test.ts` covering:
  - Successful lock acquisition, expired row deletion, and gauge updates.
  - Lock contention scenarios where cleanup is skipped.
  - Graceful shutdown and idle waiting behavior.

- Added Prometheus metric:
  - `idempotency_store_rows` in `metrics.ts`.

- Added environment configuration:
  - `IDEMPOTENCY_SWEEPER_INTERVAL_MS`.

- Integrated the sweeper into application lifecycle:
  - Startup.
  - Graceful shutdown.
  - Stop handling in `index.ts`.

- Updated:
  - `.env.example`
  - `README.md`

### Purpose

- Prevent stale idempotency cache entries from accumulating.
- Provide operational visibility into `idempotency_store` size through Prometheus metrics.
- Ensure cleanup is performed safely in multi-instance deployments using advisory locks.
- Support graceful shutdown without abandoning in-progress sweep operations.

Closes #408