### PR TITLE
fix(#492): handle tx_failed_too_early with scheduled retry instead of…

### DIFF
--- a/src/services/revenueSettlementService.ts
+++ b/src/services/revenueSettlementService.ts
@@ -11,6 +11,8 @@ import {
   withRetry,
 } from '../lib/retry.js';
 
+const TX_FAILED_TOO_EARLY = 'tx_failed_too_early';
+
 export interface RevenueSettlementOptions {
   /** Minimum accumulated USDC to trigger a payout (default: 5.00) */
   minPayoutUsdc?: number;
@@ -23,6 +25,10 @@ export interface RevenueSettlementOptions {
   horizonMaxRetries?: number;
   /** Base delay in ms for Horizon retry backoff (default: 500). */
   horizonRetryBaseDelayMs?: number;
+  /** How long to wait before re-checking a tx_failed_too_early settlement, in ms (default: 30000). */
+  tooEarlyBackoffMs?: number;
+  /** Maximum tx_failed_too_early retries before permanently failing a settlement (default: 5). */
+  maxTooEarlyRetries?: number;
 }
 
 /**
@@ -39,6 +45,7 @@ export interface ReconcileResult {
   checked: number;
   completed: number;
   failed: number;
+  retried: number;
   errors: number;
 }
 
@@ -225,11 +232,11 @@ export class RevenueSettlementService {
     }
   }
 
-  private async reconcilePendingSettlementsOnce(): Promise<{ checked: number; completed: number; failed: number; errors: number }> {
+  private async reconcilePendingSettlementsOnce(): Promise<ReconcileResult> {
     const horizonUrl = this.options.horizonUrl;
     if (!horizonUrl) {
       // Horizon is not configured; skip reconciliation
-      return { checked: 0, completed: 0, failed: 0, errors: 0 };
+      return { checked: 0, completed: 0, failed: 0, retried: 0, errors: 0 };
     }
 
     const pendingSettlements = await this.settlementStore.getPendingSettlements();
@@ -237,6 +244,7 @@ export class RevenueSettlementService {
     let checked = 0;
     let completed = 0;
     let failed = 0;
+    let retried = 0;
     let errors = 0;
 
     for (const settlement of pendingSettlements) {
@@ -263,24 +271,53 @@ export class RevenueSettlementService {
             );
           }
         } else if (horizonResponse?.successful === false) {
-          // Transaction explicitly failed
-          try {
-            await this.settlementStore.updateStatus(settlement.id, 'failed');
-            failed++;
-          } catch (updateError) {
-            errors++;
-            console.warn(
-              { settlementId: settlement.id, error: updateError },
-              'Failed to update settlement to failed — skipping',
-            );
-          }
+          if (transactionCode === TX_FAILED_TOO_EARLY) {
+            const maxRetries = this.options.maxTooEarlyRetries ?? 5;
+            if ((settlement.retry_count ?? 0) >= maxRetries) {
+              // Max retries exhausted — permanently fail
+              try {
+                await this.settlementStore.updateStatus(settlement.id, 'failed');
+                failed++;
+              } catch (updateError) {
+                errors++;
+                console.warn(
+                  { settlementId: settlement.id, error: updateError },
+                  'Failed to update settlement to failed — skipping',
+                );
+              }
+            } else {
+              const backoffMs = this.options.tooEarlyBackoffMs ?? 30_000;
+              const retryAfter = new Date(Date.now() + backoffMs).toISOString();
+              try {
+                await this.settlementStore.scheduleRetry(settlement.id, retryAfter);
+                retried++;
+              } catch (updateError) {
+                errors++;
+                console.warn(
+                  { settlementId: settlement.id, error: updateError },
+                  'Failed to schedule retry for settlement — skipping',
+                );
+              }
+            }
+          } else {
+            // Other explicit failure
+            try {
+              await this.settlementStore.updateStatus(settlement.id, 'failed');
+              failed++;
+            } catch (updateError) {
+              errors++;
+              console.warn(
+                { settlementId: settlement.id, error: updateError },
+                'Failed to update settlement to failed — skipping',
+              );
+            }
 
-          // Log the failure reason if available
-          if (!transactionCode) {
-            console.warn(
-              { settlementId: settlement.id },
-              'Horizon returned tx_failed but missing result_codes',
-            );
+            if (!transactionCode) {
+              console.warn(
+                { settlementId: settlement.id },
+                'Horizon returned tx_failed but missing result_codes',
+              );
+            }
           }
         } else if (horizonResponse === null) {
           // Transaction not found in Horizon — treat as failed
@@ -317,7 +354,7 @@ export class RevenueSettlementService {
       }
     }
 
-    return { checked, completed, failed, errors };
+    return { checked, completed, failed, retried, errors };
   }
 
   /**

--- a/src/services/settlementStatusSyncJob.test.ts
+++ b/src/services/settlementStatusSyncJob.test.ts
@@ -66,7 +66,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
 
       const result = await service.reconcilePendingSettlements();
 
-      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, errors: 0 });
+      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, retried: 0, errors: 0 });
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         status: 'failed',
         tx_hash: 'tx-with-codes',
@@ -104,7 +104,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
 
       const result = await service.reconcilePendingSettlements();
 
-      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, errors: 0 });
+      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, retried: 0, errors: 0 });
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         status: 'failed',
         tx_hash: 'tx-no-codes',
@@ -145,7 +145,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
 
       const result = await service.reconcilePendingSettlements();
 
-      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, errors: 0 });
+      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, retried: 0, errors: 0 });
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         status: 'failed',
       });
@@ -179,7 +179,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
 
       const result = await service.reconcilePendingSettlements();
 
-      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, errors: 0 });
+      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, retried: 0, errors: 0 });
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         status: 'failed',
       });
@@ -242,7 +242,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
       const result = await service.reconcilePendingSettlements();
 
       // stl_5a and stl_5c should be completed, stl_5b should error but not abort
-      expect(result).toEqual({ checked: 3, completed: 2, failed: 0, errors: 1 });
+      expect(result).toEqual({ checked: 3, completed: 2, failed: 0, retried: 0, errors: 1 });
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         id: 'stl_5c',
         status: 'completed',
@@ -285,7 +285,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
 
       const result = await service.reconcilePendingSettlements();
 
-      expect(result).toEqual({ checked: 1, completed: 1, failed: 0, errors: 0 });
+      expect(result).toEqual({ checked: 1, completed: 1, failed: 0, retried: 0, errors: 0 });
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         status: 'completed',
         tx_hash: 'tx-success',
@@ -318,7 +318,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
       const result = await service.reconcilePendingSettlements();
 
       // Should not crash, settlement stays pending, error counted
-      expect(result).toEqual({ checked: 1, completed: 0, failed: 0, errors: 1 });
+      expect(result).toEqual({ checked: 1, completed: 0, failed: 0, retried: 0, errors: 1 });
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         status: 'pending',
       });
@@ -371,7 +371,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
 
       const result = await service.reconcilePendingSettlements();
 
-      expect(result).toEqual({ checked: 2, completed: 1, failed: 0, errors: 1 });
+      expect(result).toEqual({ checked: 2, completed: 1, failed: 0, retried: 0, errors: 1 });
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         id: 'stl_8b',
         status: 'completed',
@@ -408,10 +408,82 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
       const result = await service.reconcilePendingSettlements();
 
       // Skipped because Horizon not configured
-      expect(result).toEqual({ checked: 0, completed: 0, failed: 0, errors: 0 });
+      expect(result).toEqual({ checked: 0, completed: 0, failed: 0, retried: 0, errors: 0 });
       // Settlement still pending
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         status: 'pending',
+      });
+    });
+  });
+
+  describe('h) tx_failed_too_early — schedules retry', () => {
+    it('marks settlement retryable and increments retried counter on first occurrence', async () => {
+      settlementStore.create({
+        id: 'stl_11',
+        developerId: 'dev_1',
+        amount: 12,
+        status: 'pending',
+        tx_hash: 'tx-too-early',
+        created_at: '2026-04-01T00:00:00.000Z',
+      });
+
+      const frozenNow = Date.now();
+      jest.spyOn(Date, 'now').mockReturnValue(frozenNow);
+
+      service = new RevenueSettlementService(usageStore, settlementStore, apiRegistry, client, {
+        fetchImpl: jest.fn(async () => ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            successful: false,
+            result_codes: { transaction: 'tx_failed_too_early' },
+          }),
+        })) as unknown as typeof fetch,
+        horizonUrl: 'https://horizon-testnet.stellar.org/',
+        tooEarlyBackoffMs: 30_000,
+      });
+
+      const result = await service.reconcilePendingSettlements();
+
+      expect(result).toEqual({ checked: 1, completed: 0, failed: 0, retried: 1, errors: 0 });
+      const s = settlementStore.getDeveloperSettlements('dev_1')[0];
+      expect(s.status).toBe('retryable');
+      expect(s.retry_count).toBe(1);
+      expect(new Date(s.retry_after!).getTime()).toBeGreaterThan(frozenNow);
+
+      jest.restoreAllMocks();
+    });
+
+    it('permanently fails settlement when max retries are exhausted', async () => {
+      settlementStore.create({
+        id: 'stl_12',
+        developerId: 'dev_1',
+        amount: 12,
+        status: 'retryable',
+        tx_hash: 'tx-too-early-exhausted',
+        created_at: '2026-04-01T00:00:00.000Z',
+        retry_after: '2026-04-01T00:00:00.000Z', // in the past — eligible for re-check
+        retry_count: 5,
+      });
+
+      service = new RevenueSettlementService(usageStore, settlementStore, apiRegistry, client, {
+        fetchImpl: jest.fn(async () => ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            successful: false,
+            result_codes: { transaction: 'tx_failed_too_early' },
+          }),
+        })) as unknown as typeof fetch,
+        horizonUrl: 'https://horizon-testnet.stellar.org/',
+        maxTooEarlyRetries: 5,
+      });
+
+      const result = await service.reconcilePendingSettlements();
+
+      expect(result).toEqual({ checked: 1, completed: 0, failed: 1, retried: 0, errors: 0 });
+      expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
+        status: 'failed',
       });
     });
   });
@@ -456,7 +528,7 @@ describe('settlementStatusSyncJob - reconcilePendingSettlements', () => {
 
       const result = await service.reconcilePendingSettlements();
 
-      expect(result).toEqual({ checked: 1, completed: 1, failed: 0, errors: 0 });
+      expect(result).toEqual({ checked: 1, completed: 1, failed: 0, retried: 0, errors: 0 });
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(settlementStore.getDeveloperSettlements('dev_1')[0]).toMatchObject({
         status: 'completed',

--- a/src/services/settlementStore.ts
+++ b/src/services/settlementStore.ts
@@ -27,9 +27,23 @@ export class InMemorySettlementStore implements SettlementStore {
       .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
   }
 
+  scheduleRetry(id: string, retryAfter: string): void {
+    const s = this.settlements.find((s) => s.id === id);
+    if (s) {
+      s.status = 'retryable';
+      s.retry_after = retryAfter;
+      s.retry_count = (s.retry_count ?? 0) + 1;
+    }
+  }
+
   getPendingSettlements(): Settlement[] {
+    const now = new Date().toISOString();
     return this.settlements
-      .filter((s) => s.status === 'pending')
+      .filter(
+        (s) =>
+          s.status === 'pending' ||
+          (s.status === 'retryable' && (s.retry_after == null || s.retry_after <= now)),
+      )
       .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
   }
 
@@ -61,6 +75,8 @@ interface SettlementStoreRow {
   status: Settlement['status'];
   stellar_tx_hash: string | null;
   created_at: Date | string;
+  retry_after: string | null;
+  retry_count: number | null;
 }
 
 export interface SettlementStoreQueryable {
@@ -77,6 +93,8 @@ const mapSettlementRow = (row: SettlementStoreRow): Settlement => ({
   status: row.status,
   tx_hash: row.stellar_tx_hash,
   created_at: row.created_at instanceof Date ? row.created_at.toISOString() : new Date(row.created_at).toISOString(),
+  retry_after: row.retry_after ?? null,
+  retry_count: row.retry_count ?? 0,
 });
 
 export class PostgresSettlementStore implements SettlementStore {
@@ -130,6 +148,19 @@ export class PostgresSettlementStore implements SettlementStore {
     );
   }
 
+  async scheduleRetry(id: string, retryAfter: string): Promise<void> {
+    await this.db.query(
+      `
+        UPDATE settlements
+        SET status = 'retryable',
+            retry_after = $2,
+            retry_count = COALESCE(retry_count, 0) + 1
+        WHERE external_id = $1
+      `,
+      [id, retryAfter],
+    );
+  }
+
   async getDeveloperSettlements(developerId: string): Promise<Settlement[]> {
     const result = await this.db.query<SettlementStoreRow>(
       `
@@ -139,7 +170,9 @@ export class PostgresSettlementStore implements SettlementStore {
           amount_usdc,
           status,
           stellar_tx_hash,
-          created_at
+          created_at,
+          retry_after,
+          retry_count
         FROM settlements
         WHERE developer_id = $1
         ORDER BY created_at DESC, id DESC
@@ -159,9 +192,12 @@ export class PostgresSettlementStore implements SettlementStore {
           amount_usdc,
           status,
           stellar_tx_hash,
-          created_at
+          created_at,
+          retry_after,
+          retry_count
         FROM settlements
         WHERE status = 'pending'
+           OR (status = 'retryable' AND (retry_after IS NULL OR retry_after <= NOW()))
         ORDER BY created_at ASC, id ASC
       `,
     );

--- a/src/types/developer.ts
+++ b/src/types/developer.ts
@@ -24,10 +24,15 @@ export interface Settlement {
   id: string;
   developerId: string; // the dev receiving the payout
   amount: number;
-  status: 'pending' | 'completed' | 'failed';
+  /** pending → retryable (tx_failed_too_early) → completed | failed */
+  status: 'pending' | 'retryable' | 'completed' | 'failed';
   tx_hash: string | null;
   created_at: string; // ISO-8601
   completed_at?: string | null;
+  /** ISO-8601: earliest time the reconciler should re-check this settlement. */
+  retry_after?: string | null;
+  /** Number of tx_failed_too_early retries already attempted. */
+  retry_count?: number;
 }
 
 export interface RevenueSummary {
@@ -56,6 +61,7 @@ export interface UpdateDeveloperProfileInput {
 export interface SettlementStore {
   create(settlement: Settlement): Awaitable<void>;
   updateStatus(id: string, status: Settlement['status'], txHash?: string | null): Awaitable<void>;
+  scheduleRetry(id: string, retryAfter: string): Awaitable<void>;
   getDeveloperSettlements(developerId: string): Awaitable<Settlement[]>;
   getPendingSettlements(): Awaitable<Settlement[]>;
   listPending?(): Awaitable<Settlement[]>;


### PR DESCRIPTION
Closes #492

---

… permanent failure

Horizon returns tx_failed_too_early when a transaction is submitted before its time_bounds.min_time elapses. Previously this fell through the generic successful===false branch and permanently marked the settlement failed.

Now the reconciler marks the settlement 'retryable', sets retry_after to now+tooEarlyBackoffMs (default 30s), and re-checks it on the next pass. After maxTooEarlyRetries (default 5) the settlement is permanently failed. getPendingSettlements() returns retryable settlements whose retry_after has elapsed so no separate job is needed.