### PR TITLE
feat(db): route read-only queries to PostgreSQL replicas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,20 @@ DB_IDLE_TIMEOUT_MS=30000
 DB_CONN_TIMEOUT_MS=2000
 
 # -----------------------------------------------------------------------------
+# Database — read replicas (optional)
+# -----------------------------------------------------------------------------
+# Comma-separated list of PostgreSQL read-replica connection strings.
+# When set, SELECT queries are round-robin routed to the listed replicas;
+# INSERT / UPDATE / DELETE always use DATABASE_URL (primary).
+# On any replica error the query is automatically retried against the primary.
+# Leave blank (or omit) to route all queries to the primary.
+#
+# Format:
+#   REPLICA_URLS=postgresql://user:pass@replica1:5432/db,postgresql://user:pass@replica2:5432/db
+#
+# REPLICA_URLS=
+
+# -----------------------------------------------------------------------------
 # Auth — REQUIRED, app will not start without these
 # -----------------------------------------------------------------------------
 JWT_SECRET=your-jwt-secret-here

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,6 +4,12 @@ module.exports = {
   testEnvironment: "node",
   testMatch: ["**/?(*.)+(spec|test).ts"],
   testPathIgnorePatterns: ["/node_modules/"],
+  // Strip .js extensions from imports so Jest's CommonJS resolver can find
+  // the TypeScript source files (ESM-style imports end with .js but Jest
+  // needs the extensionless path to locate the .ts file via ts-jest).
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   transform: {
     "^.+\\.ts$": [
       "ts-jest",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -23,6 +23,48 @@ export const envSchema = z
     DB_IDLE_TIMEOUT_MS: z.coerce.number().default(30_000),
     DB_CONN_TIMEOUT_MS: z.coerce.number().default(2_000),
 
+    /**
+     * REPLICA_URLS — optional comma-separated list of PostgreSQL read-replica
+     * connection strings.
+     *
+     * Format:
+     *   REPLICA_URLS=postgresql://user:pass@replica1:5432/db,postgresql://user:pass@replica2:5432/db
+     *
+     * Behaviour:
+     *   - When set, read-only repository queries are routed round-robin to the
+     *     listed replicas. Write queries always use DATABASE_URL (primary).
+     *   - On replica failure the query is automatically retried against the
+     *     primary; see src/db/replicaPool.ts for details.
+     *   - When absent or empty, all queries continue to use the primary pool.
+     *
+     * Each URL must use the postgresql:// or postgres:// scheme. Individual
+     * URL validation (scheme, format) is performed at application startup by
+     * the replica pool initialisation code in src/db/replicaPool.ts.
+     */
+    REPLICA_URLS: z
+      .string()
+      .optional()
+      .refine(
+        (val) => {
+          if (!val || val.trim() === '') return true;
+          // Validate that each entry is a parseable postgresql:// URL
+          return val.split(',').every((raw) => {
+            const url = raw.trim();
+            if (!url) return false;
+            try {
+              const parsed = new URL(url);
+              return parsed.protocol === 'postgresql:' || parsed.protocol === 'postgres:';
+            } catch {
+              return false;
+            }
+          });
+        },
+        {
+          message:
+            'REPLICA_URLS must be a comma-separated list of valid postgresql:// or postgres:// connection strings.',
+        },
+      ),
+
     // Database (individual fields for health checks)
     DB_HOST: z.string().default("localhost"),
     DB_PORT: z.coerce.number().default(5432),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -97,6 +97,7 @@ export const config = {
   version: env.APP_VERSION,
 
   databaseUrl: env.DATABASE_URL,
+  replicaUrls: env.REPLICA_URLS,
   database: {
     pool: {
       host: env.DB_HOST,

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,7 @@
 import { Pool } from 'pg';
 import { config } from './config/index.js';
 import { logger } from './logger.js';
+import { getReplicaPool, type Queryable } from './db/replicaPool.js';
 
 function createTimeoutPromise(timeoutMs: number, message: string): {
   promise: Promise<never>;
@@ -21,7 +22,7 @@ function createTimeoutPromise(timeoutMs: number, message: string): {
 }
 
 /**
- * Shared PostgreSQL connection pool for the application.
+ * Shared PostgreSQL connection pool for the application (primary).
  *
  * Pool configuration:
  * - connectionString: taken from config.databaseUrl (DATABASE_URL env var)
@@ -40,11 +41,61 @@ let poolClosed = false;
 
 /**
  * Convenience helper that proxies to pool.query for simple one-off queries.
+ * Always routes to the primary database.
  */
 export const query = (
   text: string,
   params?: unknown[],
 ): Promise<import('pg').QueryResult> => pool.query(text, params);
+
+// ── Replica-aware query routing ───────────────────────────────────────────────
+//
+// Repositories should prefer `readQuery()` for SELECT statements and
+// `writeQuery()` for INSERT / UPDATE / DELETE.  This allows read-replica
+// routing to be enabled transparently by setting REPLICA_URLS.
+//
+// Both helpers are intentionally thin wrappers — they add zero overhead when
+// no replicas are configured (all calls fall through to `pool`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Execute a **read-only** query.
+ *
+ * Routes to a replica when REPLICA_URLS is configured; automatically falls
+ * back to the primary on replica errors.  Pass-through to the primary when
+ * no replicas are configured.
+ *
+ * @example
+ * const { rows } = await readQuery<UserRow>('SELECT id FROM users WHERE id = $1', [id]);
+ */
+export function readQuery<T = unknown>(
+  text: string,
+  params?: unknown[],
+): Promise<{ rows: T[] }> {
+  return getReplicaPool(pool).read<T>(text, params);
+}
+
+/**
+ * Execute a **write** query (INSERT / UPDATE / DELETE / DDL).
+ *
+ * Always routed to the primary database. Replicas are never used for writes.
+ *
+ * @example
+ * const { rows } = await writeQuery<UserRow>(
+ *   'INSERT INTO users (stellar_address) VALUES ($1) RETURNING id',
+ *   [address],
+ * );
+ */
+export function writeQuery<T = unknown>(
+  text: string,
+  params?: unknown[],
+): Promise<{ rows: T[] }> {
+  return getReplicaPool(pool).write<T>(text, params);
+}
+
+// Re-export the Queryable interface so repositories can type-check without
+// importing from the internal db/replicaPool module directly.
+export type { Queryable };
 
 /**
  * Lightweight database health check used by the /api/health endpoint.
@@ -75,6 +126,9 @@ export async function closePgPool(): Promise<void> {
   if (poolClosed) {
     return;
   }
+  // Close replica pools before the primary so no in-flight replica queries
+  // attempt fallback to an already-closed primary.
+  await getReplicaPool(pool).closeAll();
   await pool.end();
   poolClosed = true;
 }

--- a/src/db/replicaPool.test.ts
+++ b/src/db/replicaPool.test.ts
@@ -1,0 +1,407 @@
+/**
+ * replicaPool.test.ts
+ *
+ * Comprehensive tests for the replica routing infrastructure.
+ * Covers:
+ *   - reads routed to replicas
+ *   - writes routed to primary
+ *   - no replicas configured (all → primary)
+ *   - replica failure → primary fallback
+ *   - round-robin distribution
+ *   - metrics emitted for each scenario
+ *   - invalid REPLICA_URLS configuration
+ *   - concurrent read routing
+ *
+ * NOTE: env, logger, and metrics are mocked so this suite runs without a
+ * real database connection or complete .env file.
+ */
+
+// ── Mocks (must be hoisted before any imports that pull those modules) ─────────
+
+// Mock the env module so we don't need all required env vars set in CI.
+jest.mock('../config/env', () => ({
+  env: {
+    REPLICA_URLS: undefined,
+    DB_POOL_MAX: 10,
+    DB_IDLE_TIMEOUT_MS: 30_000,
+    DB_CONN_TIMEOUT_MS: 2_000,
+  },
+}));
+
+// Mock logger — prevents pino setup from failing and keeps output clean.
+jest.mock('../logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  getRequestId: jest.fn(() => undefined),
+}));
+
+// Track metric call counts manually so we can assert without Prometheus.
+const mockMetrics = {
+  recordReplicaQuery: jest.fn(),
+  recordPrimaryQuery: jest.fn(),
+  recordReplicaFallback: jest.fn(),
+  recordReplicaFailure: jest.fn(),
+};
+
+jest.mock('../metrics', () => ({
+  ...mockMetrics,
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import {
+  ReplicaPool,
+  parseReplicaUrls,
+  _resetReplicaPool,
+  getReplicaPool,
+} from '../db/replicaPool.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Minimal pg.Pool stub. */
+function makePoolStub(rows: unknown[] = [], shouldReject = false) {
+  const calls: Array<{ text: string; params?: unknown[] }> = [];
+  return {
+    query: jest.fn(async (text: string, params?: unknown[]) => {
+      calls.push({ text, params });
+      if (shouldReject) throw new Error('Pool connection error');
+      return { rows };
+    }),
+    end: jest.fn().mockResolvedValue(undefined),
+    _calls: calls,
+  };
+}
+
+// Reset mock call counts before each test.
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── parseReplicaUrls ──────────────────────────────────────────────────────────
+
+describe('parseReplicaUrls', () => {
+  test('returns empty array for undefined', () => {
+    expect(parseReplicaUrls(undefined)).toEqual([]);
+  });
+
+  test('returns empty array for empty string', () => {
+    expect(parseReplicaUrls('')).toEqual([]);
+  });
+
+  test('returns empty array for whitespace-only string', () => {
+    expect(parseReplicaUrls('   ')).toEqual([]);
+  });
+
+  test('parses a single postgresql:// URL', () => {
+    expect(parseReplicaUrls('postgresql://user:pass@host:5432/db')).toEqual([
+      'postgresql://user:pass@host:5432/db',
+    ]);
+  });
+
+  test('parses multiple comma-separated URLs', () => {
+    const urls = parseReplicaUrls(
+      'postgresql://a:b@r1:5432/db,postgresql://a:b@r2:5432/db',
+    );
+    expect(urls).toHaveLength(2);
+    expect(urls[0]).toBe('postgresql://a:b@r1:5432/db');
+    expect(urls[1]).toBe('postgresql://a:b@r2:5432/db');
+  });
+
+  test('trims whitespace around individual URLs', () => {
+    const urls = parseReplicaUrls(
+      ' postgresql://a:b@r1:5432/db , postgresql://a:b@r2:5432/db ',
+    );
+    expect(urls).toHaveLength(2);
+    expect(urls[0]).toBe('postgresql://a:b@r1:5432/db');
+    expect(urls[1]).toBe('postgresql://a:b@r2:5432/db');
+  });
+
+  test('accepts postgres:// scheme', () => {
+    expect(() => parseReplicaUrls('postgres://user:pass@host:5432/db')).not.toThrow();
+  });
+
+  test('throws on non-URL string', () => {
+    expect(() => parseReplicaUrls('not-a-url')).toThrow(/not a valid URL/i);
+  });
+
+  test('throws on non-postgresql scheme', () => {
+    expect(() => parseReplicaUrls('mysql://user:pass@host:3306/db')).toThrow(
+      /postgresql:\/\/ or postgres:\/\/ scheme/i,
+    );
+  });
+
+  test('throws on empty segment between commas', () => {
+    expect(() =>
+      parseReplicaUrls('postgresql://a:b@r1:5432/db,,postgresql://a:b@r2:5432/db'),
+    ).toThrow(/empty after trimming/i);
+  });
+});
+
+// ── TestableReplicaPool (injects stub pg pools) ───────────────────────────────
+
+/**
+ * Build a ReplicaPool instance with stubbed replica arrays injected directly,
+ * bypassing the real pg.Pool constructor (which would need real DB URLs).
+ */
+function buildTestablePool(
+  primary: ReturnType<typeof makePoolStub>,
+  replicaStubs: Array<ReturnType<typeof makePoolStub>>,
+): ReplicaPool {
+  const instance = Object.create(ReplicaPool.prototype) as ReplicaPool;
+  Object.defineProperty(instance, 'primary', { value: primary, writable: true });
+  Object.defineProperty(instance, 'replicaPools', { value: replicaStubs, writable: true });
+  Object.defineProperty(instance, 'roundRobinIndex', { value: 0, writable: true });
+  return instance;
+}
+
+// ── No replicas configured ────────────────────────────────────────────────────
+
+describe('ReplicaPool — no replicas configured', () => {
+  let primary: ReturnType<typeof makePoolStub>;
+  let rp: ReplicaPool;
+
+  beforeEach(() => {
+    primary = makePoolStub([{ id: 1 }]);
+    rp = buildTestablePool(primary, []);
+  });
+
+  test('hasReplicas is false', () => {
+    expect(rp.hasReplicas).toBe(false);
+  });
+
+  test('replicaCount is 0', () => {
+    expect(rp.replicaCount).toBe(0);
+  });
+
+  test('read() routes to primary', async () => {
+    const result = await rp.read('SELECT 1');
+    expect(primary.query).toHaveBeenCalledTimes(1);
+    expect(result.rows).toEqual([{ id: 1 }]);
+  });
+
+  test('write() routes to primary', async () => {
+    await rp.write('INSERT INTO foo VALUES ($1)', [42]);
+    expect(primary.query).toHaveBeenCalledWith('INSERT INTO foo VALUES ($1)', [42]);
+  });
+
+  test('read() calls recordPrimaryQuery metric', async () => {
+    await rp.read('SELECT 1');
+    expect(mockMetrics.recordPrimaryQuery).toHaveBeenCalledTimes(1);
+    expect(mockMetrics.recordReplicaQuery).not.toHaveBeenCalled();
+  });
+
+  test('write() calls recordPrimaryQuery metric', async () => {
+    await rp.write('INSERT 1');
+    expect(mockMetrics.recordPrimaryQuery).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Reads routed to replicas ──────────────────────────────────────────────────
+
+describe('ReplicaPool — reads routed to replicas', () => {
+  let primary: ReturnType<typeof makePoolStub>;
+  let replica1: ReturnType<typeof makePoolStub>;
+  let replica2: ReturnType<typeof makePoolStub>;
+  let rp: ReplicaPool;
+
+  beforeEach(() => {
+    primary = makePoolStub([{ primary: true }]);
+    replica1 = makePoolStub([{ replica: 1 }]);
+    replica2 = makePoolStub([{ replica: 2 }]);
+    rp = buildTestablePool(primary, [replica1, replica2]);
+  });
+
+  test('hasReplicas is true', () => {
+    expect(rp.hasReplicas).toBe(true);
+  });
+
+  test('replicaCount equals number of stubs', () => {
+    expect(rp.replicaCount).toBe(2);
+  });
+
+  test('read() routes to first replica on first call', async () => {
+    const result = await rp.read('SELECT 1');
+    expect(replica1.query).toHaveBeenCalledTimes(1);
+    expect(primary.query).not.toHaveBeenCalled();
+    expect(result.rows).toEqual([{ replica: 1 }]);
+  });
+
+  test('write() always routes to primary, never replicas', async () => {
+    await rp.write('INSERT INTO t VALUES ($1)', ['v']);
+    expect(primary.query).toHaveBeenCalledWith('INSERT INTO t VALUES ($1)', ['v']);
+    expect(replica1.query).not.toHaveBeenCalled();
+    expect(replica2.query).not.toHaveBeenCalled();
+  });
+
+  test('read() calls recordReplicaQuery metric', async () => {
+    await rp.read('SELECT 1');
+    expect(mockMetrics.recordReplicaQuery).toHaveBeenCalledTimes(1);
+    expect(mockMetrics.recordPrimaryQuery).not.toHaveBeenCalled();
+  });
+
+  test('write() calls recordPrimaryQuery, not recordReplicaQuery', async () => {
+    await rp.write('INSERT 1');
+    expect(mockMetrics.recordPrimaryQuery).toHaveBeenCalledTimes(1);
+    expect(mockMetrics.recordReplicaQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ── Round-robin distribution ──────────────────────────────────────────────────
+
+describe('ReplicaPool — round-robin distribution', () => {
+  let primary: ReturnType<typeof makePoolStub>;
+  let replica1: ReturnType<typeof makePoolStub>;
+  let replica2: ReturnType<typeof makePoolStub>;
+  let replica3: ReturnType<typeof makePoolStub>;
+  let rp: ReplicaPool;
+
+  beforeEach(() => {
+    primary = makePoolStub();
+    replica1 = makePoolStub([{ r: 1 }]);
+    replica2 = makePoolStub([{ r: 2 }]);
+    replica3 = makePoolStub([{ r: 3 }]);
+    rp = buildTestablePool(primary, [replica1, replica2, replica3]);
+  });
+
+  test('distributes reads across replicas in round-robin order', async () => {
+    await rp.read('S'); // → replica1
+    await rp.read('S'); // → replica2
+    await rp.read('S'); // → replica3
+    await rp.read('S'); // → replica1 again
+
+    expect(replica1.query).toHaveBeenCalledTimes(2);
+    expect(replica2.query).toHaveBeenCalledTimes(1);
+    expect(replica3.query).toHaveBeenCalledTimes(1);
+    expect(primary.query).not.toHaveBeenCalled();
+  });
+
+  test('wraps around evenly after a full cycle', async () => {
+    for (let i = 0; i < 6; i++) await rp.read('S');
+    expect(replica1.query).toHaveBeenCalledTimes(2);
+    expect(replica2.query).toHaveBeenCalledTimes(2);
+    expect(replica3.query).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Replica failure fallback ──────────────────────────────────────────────────
+
+describe('ReplicaPool — replica failure fallback', () => {
+  let primary: ReturnType<typeof makePoolStub>;
+  let failingReplica: ReturnType<typeof makePoolStub>;
+  let rp: ReplicaPool;
+
+  beforeEach(() => {
+    primary = makePoolStub([{ primary: true }]);
+    failingReplica = makePoolStub([], true); // always rejects
+    rp = buildTestablePool(primary, [failingReplica]);
+  });
+
+  test('read() falls back to primary when replica throws', async () => {
+    const result = await rp.read('SELECT 1');
+    expect(failingReplica.query).toHaveBeenCalledTimes(1);
+    expect(primary.query).toHaveBeenCalledTimes(1);
+    expect(result.rows).toEqual([{ primary: true }]);
+  });
+
+  test('calls recordReplicaFailure on replica error', async () => {
+    await rp.read('SELECT 1');
+    expect(mockMetrics.recordReplicaFailure).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls recordReplicaFallback when falling back to primary', async () => {
+    await rp.read('SELECT 1');
+    expect(mockMetrics.recordReplicaFallback).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls recordPrimaryQuery for the fallback query', async () => {
+    await rp.read('SELECT 1');
+    expect(mockMetrics.recordPrimaryQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT call recordReplicaQuery when replica fails', async () => {
+    await rp.read('SELECT 1');
+    expect(mockMetrics.recordReplicaQuery).not.toHaveBeenCalled();
+  });
+
+  test('throws when both replica AND primary fail', async () => {
+    const alsoFailing = makePoolStub([], true);
+    const brokenRp = buildTestablePool(alsoFailing, [failingReplica]);
+    await expect(brokenRp.read('SELECT 1')).rejects.toThrow('Pool connection error');
+  });
+
+  test('write() never touches replica even when primary fails', async () => {
+    const failingPrimary = makePoolStub([], true);
+    const rp2 = buildTestablePool(failingPrimary, [failingReplica]);
+
+    await expect(rp2.write('INSERT 1')).rejects.toThrow();
+    // Replica MUST NOT have been queried
+    expect(failingReplica.query).not.toHaveBeenCalled();
+  });
+});
+
+// ── Concurrent reads ──────────────────────────────────────────────────────────
+
+describe('ReplicaPool — concurrent reads', () => {
+  test('12 concurrent reads across 3 replicas — no races, all served', async () => {
+    const primary = makePoolStub([]);
+    const replicas = [
+      makePoolStub([{ r: 1 }]),
+      makePoolStub([{ r: 2 }]),
+      makePoolStub([{ r: 3 }]),
+    ];
+    const rp = buildTestablePool(primary, replicas);
+
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => rp.read('SELECT 1')),
+    );
+
+    expect(results).toHaveLength(12);
+
+    const total =
+      replicas[0].query.mock.calls.length +
+      replicas[1].query.mock.calls.length +
+      replicas[2].query.mock.calls.length;
+    expect(total).toBe(12);
+
+    expect(primary.query).not.toHaveBeenCalled();
+  });
+});
+
+// ── closeAll ──────────────────────────────────────────────────────────────────
+
+describe('ReplicaPool — closeAll', () => {
+  test('calls end() on every replica pool', async () => {
+    const primary = makePoolStub();
+    const r1 = makePoolStub();
+    const r2 = makePoolStub();
+    const rp = buildTestablePool(primary, [r1, r2]);
+
+    await rp.closeAll();
+
+    expect(r1.end).toHaveBeenCalledTimes(1);
+    expect(r2.end).toHaveBeenCalledTimes(1);
+    // Primary is NOT closed by closeAll — that's the caller's responsibility
+    expect(primary.end).not.toHaveBeenCalled();
+  });
+});
+
+// ── getReplicaPool singleton ──────────────────────────────────────────────────
+
+describe('getReplicaPool singleton', () => {
+  beforeEach(() => _resetReplicaPool());
+  afterEach(() => _resetReplicaPool());
+
+  test('returns the same instance on repeated calls', () => {
+    const primary = makePoolStub() as unknown as import('pg').Pool;
+    expect(getReplicaPool(primary)).toBe(getReplicaPool(primary));
+  });
+
+  test('returns a ReplicaPool instance', () => {
+    const primary = makePoolStub() as unknown as import('pg').Pool;
+    expect(getReplicaPool(primary)).toBeInstanceOf(ReplicaPool);
+  });
+});

--- a/src/db/replicaPool.ts
+++ b/src/db/replicaPool.ts
@@ -1,0 +1,281 @@
+/**
+ * replicaPool.ts
+ *
+ * Manages PostgreSQL read-replica connection pools and provides a simple
+ * query-routing API that sends read-only queries to replicas when configured,
+ * and always routes write queries to the primary pool.
+ *
+ * Routing rules:
+ *   - read()  → next replica (round-robin), falls back to primary on error
+ *   - write() → primary only, never replicated
+ *
+ * When no REPLICA_URLS are configured every call is transparently forwarded to
+ * the primary pool so callers require no conditional logic.
+ */
+
+import { Pool, type QueryResult } from 'pg';
+import { env } from '../config/env.js';
+import { logger } from '../logger.js';
+import { getRequestId } from '../logger.js';
+import {
+  recordReplicaQuery,
+  recordPrimaryQuery,
+  recordReplicaFallback,
+  recordReplicaFailure,
+} from '../metrics.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal queryable interface shared between pg.Pool and the replica pool.
+ * Repositories already depend on this shape via UserRepositoryQueryable /
+ * UsageEventsRepositoryQueryable — no new coupling is introduced.
+ */
+export interface Queryable {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+/** Result type identical to pg.QueryResult for compatibility. */
+export type { QueryResult };
+
+// ── Replica URL parsing ───────────────────────────────────────────────────────
+
+/**
+ * Parse REPLICA_URLS from the environment.
+ *
+ * Expected format (comma-separated connection strings):
+ *   REPLICA_URLS=postgresql://user:pass@replica1:5432/db,postgresql://user:pass@replica2:5432/db
+ *
+ * Returns an empty array when the variable is absent or blank.
+ * Throws a descriptive error when any URL is syntactically invalid.
+ */
+function parseReplicaUrls(raw: string | undefined): string[] {
+  if (!raw || raw.trim() === '') {
+    return [];
+  }
+
+  return raw.split(',').map((rawUrl, index) => {
+    const url = rawUrl.trim();
+    if (url === '') {
+      throw new Error(
+        `REPLICA_URLS[${index}] is empty after trimming. ` +
+          'Each entry must be a valid postgresql:// connection string.',
+      );
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      throw new Error(
+        `REPLICA_URLS[${index}] is not a valid URL: "${url}". ` +
+          'Each entry must be a valid postgresql:// connection string.',
+      );
+    }
+
+    if (parsedUrl.protocol !== 'postgresql:' && parsedUrl.protocol !== 'postgres:') {
+      throw new Error(
+        `REPLICA_URLS[${index}] must use the postgresql:// or postgres:// scheme. Got: "${parsedUrl.protocol}"`,
+      );
+    }
+
+    return url;
+  });
+}
+
+// ── Pool factory ──────────────────────────────────────────────────────────────
+
+function createReplicaPool(connectionString: string): Pool {
+  return new Pool({
+    connectionString,
+    max: env.DB_POOL_MAX,
+    idleTimeoutMillis: env.DB_IDLE_TIMEOUT_MS,
+    connectionTimeoutMillis: env.DB_CONN_TIMEOUT_MS,
+  });
+}
+
+// ── ReplicaPool class ─────────────────────────────────────────────────────────
+
+/**
+ * Manages a set of read-replica pools and a reference to the primary pool.
+ *
+ * Usage:
+ *   const router = new ReplicaPool(primaryPool);
+ *   const result = await router.read<MyRow>('SELECT ...', [param]);
+ *   const result = await router.write<MyRow>('INSERT ...', [param]);
+ */
+export class ReplicaPool {
+  private readonly replicaPools: Pool[];
+  private roundRobinIndex = 0;
+
+  /**
+   * @param primary - The primary PostgreSQL pool (always used for writes).
+   * @param replicaUrls - Parsed replica connection strings. When empty all
+   *   reads are forwarded to the primary without replica overhead.
+   */
+  constructor(
+    private readonly primary: Pool,
+    replicaUrls: string[],
+  ) {
+    this.replicaPools = replicaUrls.map(createReplicaPool);
+  }
+
+  /**
+   * Whether at least one replica is configured.
+   */
+  get hasReplicas(): boolean {
+    return this.replicaPools.length > 0;
+  }
+
+  /**
+   * The number of configured replica pools.
+   */
+  get replicaCount(): number {
+    return this.replicaPools.length;
+  }
+
+  /**
+   * Execute a **read-only** query.
+   *
+   * Routing:
+   *   - With replicas → round-robin across replica pools; on failure retries
+   *     once against the primary and emits a fallback metric.
+   *   - Without replicas → forwarded directly to the primary.
+   *
+   * Never use this method for INSERT / UPDATE / DELETE / DDL statements.
+   * Those must go through `write()`.
+   */
+  async read<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }> {
+    if (!this.hasReplicas) {
+      recordPrimaryQuery();
+      // Cast via unknown to avoid pg's QueryResultRow constraint on the generic.
+      return (this.primary.query(text, params as never) as unknown) as Promise<{ rows: T[] }>;
+    }
+
+    const replica = this.nextReplica();
+    const replicaIndex = this.currentReplicaIndex();
+    const requestId = getRequestId();
+
+    logger.info({
+      msg: '[db] routing read to replica',
+      replicaIndex,
+      ...(requestId ? { requestId } : {}),
+    });
+
+    try {
+      const result = await (replica.query(text, params as never) as unknown) as { rows: T[] };
+      recordReplicaQuery();
+      return result;
+    } catch (err) {
+      recordReplicaFailure();
+
+      logger.warn({
+        msg: '[db] replica query failed, falling back to primary',
+        replicaIndex,
+        error: err instanceof Error ? err.message : String(err),
+        ...(requestId ? { requestId } : {}),
+      });
+
+      try {
+        const fallbackResult = await (this.primary.query(text, params as never) as unknown) as { rows: T[] };
+        recordReplicaFallback();
+        recordPrimaryQuery();
+        return fallbackResult;
+      } catch (primaryErr) {
+        logger.error({
+          msg: '[db] primary fallback also failed after replica error',
+          error:
+            primaryErr instanceof Error ? primaryErr.message : String(primaryErr),
+          ...(requestId ? { requestId } : {}),
+        });
+        throw primaryErr;
+      }
+    }
+  }
+
+  /**
+   * Execute a **write** query (INSERT, UPDATE, DELETE, DDL).
+   *
+   * Always routed to the primary database.
+   * Replicas are never used for writes.
+   */
+  async write<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }> {
+    recordPrimaryQuery();
+    return (this.primary.query(text, params as never) as unknown) as Promise<{ rows: T[] }>;
+  }
+
+  /**
+   * Gracefully close all replica pools.
+   * Call this during application shutdown alongside closing the primary pool.
+   */
+  async closeAll(): Promise<void> {
+    await Promise.all(this.replicaPools.map((p) => p.end()));
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────
+
+  /**
+   * Select the next replica pool using round-robin.
+   * Advances the internal counter atomically (single-threaded Node.js event loop).
+   */
+  private nextReplica(): Pool {
+    const pool = this.replicaPools[this.roundRobinIndex]!;
+    this.roundRobinIndex = (this.roundRobinIndex + 1) % this.replicaPools.length;
+    return pool;
+  }
+
+  /**
+   * Return the replica index that was last selected by nextReplica().
+   * Only meaningful immediately after a nextReplica() call.
+   */
+  private currentReplicaIndex(): number {
+    const len = this.replicaPools.length;
+    // After nextReplica() advances the index, the one we just used is at
+    // (roundRobinIndex - 1 + len) % len.
+    return (this.roundRobinIndex - 1 + len) % len;
+  }
+}
+
+// ── Singleton instance ────────────────────────────────────────────────────────
+
+/**
+ * Lazily-initialised singleton replica pool.
+ * Exported as a getter so the primary pool (from db.ts) can be imported
+ * without creating a circular dependency at module-load time.
+ */
+let _replicaPool: ReplicaPool | undefined;
+
+/**
+ * Initialise (or return the already-initialised) application-level ReplicaPool.
+ *
+ * @param primaryPool - The primary pg.Pool from db.ts.
+ */
+export function getReplicaPool(primaryPool: Pool): ReplicaPool {
+  if (_replicaPool) {
+    return _replicaPool;
+  }
+
+  const replicaUrls = parseReplicaUrls(env.REPLICA_URLS);
+
+  if (replicaUrls.length > 0) {
+    logger.info({
+      msg: '[db] replica routing enabled',
+      replicaCount: replicaUrls.length,
+    });
+  } else {
+    logger.info({ msg: '[db] no replicas configured, all queries routed to primary' });
+  }
+
+  _replicaPool = new ReplicaPool(primaryPool, replicaUrls);
+  return _replicaPool;
+}
+
+/**
+ * Reset the singleton (test helper — do not use in production code).
+ */
+export function _resetReplicaPool(): void {
+  _replicaPool = undefined;
+}
+
+// ── Re-export parse helper for tests ─────────────────────────────────────────
+export { parseReplicaUrls };

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -497,4 +497,79 @@ export function resetAllMetrics(): void {
   proxyPrematureAbortsTotal.reset();
   idempotencyStoreRows.reset();
   gatewayUpstreamBreakerState.reset();
+  resetReplicaMetrics();
+}
+
+// ── Replica routing metrics ───────────────────────────────────────────────────
+//
+// Metric: db_replica_queries_total
+//   Type:    Counter
+//   Purpose: Count read queries successfully served by a replica.
+//
+// Metric: db_primary_queries_total
+//   Type:    Counter
+//   Purpose: Count all queries routed to the primary (writes + no-replica reads
+//            + fallbacks after replica failure).
+//
+// Metric: db_replica_fallbacks_total
+//   Type:    Counter
+//   Purpose: Count replica queries that failed and were retried on the primary.
+//            A rising value warrants investigation of replica health.
+//
+// Metric: db_replica_failures_total
+//   Type:    Counter
+//   Purpose: Count individual replica connection/query errors (before fallback).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const dbReplicaQueriesTotal = new client.Counter({
+  name: 'db_replica_queries_total',
+  help: 'Total number of read queries served by a PostgreSQL replica',
+});
+
+const dbPrimaryQueriesTotal = new client.Counter({
+  name: 'db_primary_queries_total',
+  help: 'Total number of queries routed to the primary PostgreSQL database (writes, fallbacks, and no-replica reads)',
+});
+
+const dbReplicaFallbacksTotal = new client.Counter({
+  name: 'db_replica_fallbacks_total',
+  help: 'Total number of replica queries that failed and were retried against the primary database',
+});
+
+const dbReplicaFailuresTotal = new client.Counter({
+  name: 'db_replica_failures_total',
+  help: 'Total number of individual replica connection or query errors',
+});
+
+register.registerMetric(dbReplicaQueriesTotal);
+register.registerMetric(dbPrimaryQueriesTotal);
+register.registerMetric(dbReplicaFallbacksTotal);
+register.registerMetric(dbReplicaFailuresTotal);
+
+/** Increment the replica query counter. Called by ReplicaPool on successful replica reads. */
+export function recordReplicaQuery(): void {
+  dbReplicaQueriesTotal.inc();
+}
+
+/** Increment the primary query counter. Called by ReplicaPool on primary reads and all writes. */
+export function recordPrimaryQuery(): void {
+  dbPrimaryQueriesTotal.inc();
+}
+
+/** Increment the fallback counter. Called by ReplicaPool when a replica error causes a primary retry. */
+export function recordReplicaFallback(): void {
+  dbReplicaFallbacksTotal.inc();
+}
+
+/** Increment the replica failure counter. Called by ReplicaPool on each replica-level error. */
+export function recordReplicaFailure(): void {
+  dbReplicaFailuresTotal.inc();
+}
+
+/** Reset all replica routing metrics. Used in tests to isolate metric state. */
+export function resetReplicaMetrics(): void {
+  dbReplicaQueriesTotal.reset();
+  dbPrimaryQueriesTotal.reset();
+  dbReplicaFallbacksTotal.reset();
+  dbReplicaFailuresTotal.reset();
 }

--- a/src/repositories/refreshTokenRepository.ts
+++ b/src/repositories/refreshTokenRepository.ts
@@ -1,6 +1,12 @@
 import crypto from 'crypto';
 import type { RefreshToken } from '../types/auth.js';
 import { logger } from '../logger.js';
+import { readQuery, writeQuery } from '../db.js';
+
+/** Injectable queryable for tests. */
+export interface RefreshTokenRepositoryQueryable {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[]; rowCount?: number | null }>;
+}
 
 export interface RefreshTokenRepository {
   /**
@@ -54,7 +60,22 @@ export interface RefreshTokenRepository {
  * This should be adapted to your specific database setup
  */
 export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
-  constructor(private readonly db: any) {}
+  private readonly readDb: RefreshTokenRepositoryQueryable;
+  private readonly writeDb: RefreshTokenRepositoryQueryable;
+
+  /**
+   * @param db - Optional injectable queryable (test helper).
+   *   When omitted, reads route to replicas and writes route to the primary.
+   */
+  constructor(db?: RefreshTokenRepositoryQueryable) {
+    if (db) {
+      this.readDb = db;
+      this.writeDb = db;
+    } else {
+      this.readDb = { query: readQuery };
+      this.writeDb = { query: writeQuery };
+    }
+  }
 
   async createRefreshToken(token: Omit<RefreshToken, 'id'> & { id?: string }): Promise<RefreshToken> {
     const id = token.id || crypto.randomUUID();
@@ -63,7 +84,7 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
       ...token
     };
 
-    await this.db.query(
+    await this.writeDb.query(
       `INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at, created_at, last_used_at, is_revoked, family_id)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        RETURNING id, user_id, token_hash, expires_at, created_at, last_used_at, is_revoked, family_id`,
@@ -83,7 +104,7 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
   }
 
   async findRefreshTokenById(tokenId: string, userId: string): Promise<RefreshToken | null> {
-    const result = await this.db.query(
+    const result = await this.readDb.query(
       `SELECT id, user_id, token_hash, expires_at, created_at, last_used_at, is_revoked, family_id
        FROM refresh_tokens
        WHERE id = $1 AND user_id = $2`,
@@ -94,21 +115,21 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
       return null;
     }
 
-    const row = result.rows[0];
+    const row = result.rows[0] as Record<string, unknown>;
     return {
-      id: row.id,
-      userId: row.user_id,
-      tokenHash: row.token_hash,
-      expiresAt: new Date(row.expires_at),
-      createdAt: new Date(row.created_at),
-      lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : undefined,
-      isRevoked: row.is_revoked,
-      familyId: row.family_id
+      id: row['id'] as string,
+      userId: row['user_id'] as string,
+      tokenHash: row['token_hash'] as string,
+      expiresAt: new Date(row['expires_at'] as string),
+      createdAt: new Date(row['created_at'] as string),
+      lastUsedAt: row['last_used_at'] ? new Date(row['last_used_at'] as string) : undefined,
+      isRevoked: row['is_revoked'] as boolean,
+      familyId: row['family_id'] as string,
     };
   }
 
   async findRefreshTokenByHash(tokenHash: string, userId: string): Promise<RefreshToken | null> {
-    const result = await this.db.query(
+    const result = await this.readDb.query(
       `SELECT id, user_id, token_hash, expires_at, created_at, last_used_at, is_revoked, family_id
        FROM refresh_tokens
        WHERE token_hash = $1 AND user_id = $2`,
@@ -119,21 +140,21 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
       return null;
     }
 
-    const row = result.rows[0];
+    const row = result.rows[0] as Record<string, unknown>;
     return {
-      id: row.id,
-      userId: row.user_id,
-      tokenHash: row.token_hash,
-      expiresAt: new Date(row.expires_at),
-      createdAt: new Date(row.created_at),
-      lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : undefined,
-      isRevoked: row.is_revoked,
-      familyId: row.family_id
+      id: row['id'] as string,
+      userId: row['user_id'] as string,
+      tokenHash: row['token_hash'] as string,
+      expiresAt: new Date(row['expires_at'] as string),
+      createdAt: new Date(row['created_at'] as string),
+      lastUsedAt: row['last_used_at'] ? new Date(row['last_used_at'] as string) : undefined,
+      isRevoked: row['is_revoked'] as boolean,
+      familyId: row['family_id'] as string,
     };
   }
 
   async updateLastUsed(tokenId: string, userId: string): Promise<void> {
-    await this.db.query(
+    await this.writeDb.query(
       `UPDATE refresh_tokens
        SET last_used_at = CURRENT_TIMESTAMP
        WHERE id = $1 AND user_id = $2`,
@@ -142,7 +163,7 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
   }
 
   async revokeRefreshToken(tokenId: string, userId: string): Promise<void> {
-    await this.db.query(
+    await this.writeDb.query(
       `UPDATE refresh_tokens
        SET is_revoked = true
        WHERE id = $1 AND user_id = $2`,
@@ -151,7 +172,7 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
   }
 
   async revokeFamily(familyId: string, userId: string): Promise<void> {
-    await this.db.query(
+    await this.writeDb.query(
       `UPDATE refresh_tokens
        SET is_revoked = true
        WHERE family_id = $1 AND user_id = $2`,
@@ -160,7 +181,7 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
   }
 
   async revokeAllUserTokens(userId: string): Promise<void> {
-    await this.db.query(
+    await this.writeDb.query(
       `UPDATE refresh_tokens
        SET is_revoked = true
        WHERE user_id = $1`,
@@ -169,20 +190,21 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
   }
 
   async cleanupExpiredTokens(): Promise<number> {
-    const result = await this.db.query(
+    const result = await this.writeDb.query(
       `DELETE FROM refresh_tokens
        WHERE (expires_at < CURRENT_TIMESTAMP OR is_revoked = true)`
     );
-    return result.rowCount || 0;
+    return (result as { rowCount?: number | null }).rowCount ?? 0;
   }
 
   async countActiveTokens(userId: string): Promise<number> {
-    const result = await this.db.query(
+    const result = await this.readDb.query(
       `SELECT COUNT(*) as count
        FROM refresh_tokens
        WHERE user_id = $1 AND expires_at > CURRENT_TIMESTAMP AND is_revoked = false`,
       [userId]
     );
-    return parseInt(result.rows[0].count, 10);
+    const row = result.rows[0] as Record<string, unknown> | undefined;
+    return parseInt(String(row?.['count'] ?? '0'), 10);
   }
 }

--- a/src/repositories/usageEventsRepository.pg.ts
+++ b/src/repositories/usageEventsRepository.pg.ts
@@ -7,6 +7,7 @@ import {
   type UsageBucket,
   type GroupBy,
 } from './usageEventsRepository.js';
+import { readQuery, writeQuery } from '../db.js';
 
 export interface CreateUsageEventInput {
   userId: string;
@@ -207,7 +208,26 @@ const appendDateFilters = (params: unknown[], clauses: string[], from?: Date, to
 };
 
 export class PgUsageEventsRepository implements UsageEventsPgRepository {
-  constructor(private readonly db: UsageEventsRepositoryQueryable) { }
+  private readonly readDb: UsageEventsRepositoryQueryable;
+  private readonly writeDb: UsageEventsRepositoryQueryable;
+
+  /**
+   * @param db - Optional injectable queryable used in tests.
+   *   When omitted the module-level routing helpers are used:
+   *   - reads  → readQuery()  (replica-aware)
+   *   - writes → writeQuery() (primary only)
+   */
+  constructor(db?: UsageEventsRepositoryQueryable) {
+    if (db) {
+      // In tests both read and write use the same injected queryable.
+      this.readDb = db;
+      this.writeDb = db;
+    } else {
+      // Production: route reads to replicas and writes to primary.
+      this.readDb = { query: readQuery };
+      this.writeDb = { query: writeQuery };
+    }
+  }
 
   async create(event: CreateUsageEventInput): Promise<BillingUsageEvent> {
     const userId = assertNonEmpty(event.userId, 'userId');
@@ -218,7 +238,7 @@ export class PgUsageEventsRepository implements UsageEventsPgRepository {
     const requestId = assertNonEmpty(event.requestId, 'requestId');
     const amount = assertAmount(event.amount).toString();
 
-    const result = await this.db.query<UsageEventRow>(
+    const result = await this.writeDb.query<UsageEventRow>(
       `
       INSERT INTO usage_events (
         user_id,
@@ -348,7 +368,7 @@ export class PgUsageEventsRepository implements UsageEventsPgRepository {
       return [];
     }
 
-    const result = await this.db.query<RevenueLedgerUsageEventRow>(
+    const result = await this.readDb.query<RevenueLedgerUsageEventRow>(
       `
         SELECT
           ue.id AS usage_event_id,
@@ -370,7 +390,7 @@ export class PgUsageEventsRepository implements UsageEventsPgRepository {
   }
 
   async indexRevenueLedgerEvent(event: RevenueLedgerUsageEvent, developerId: string): Promise<boolean> {
-    const result = await this.db.query<{ inserted: number }>(
+    const result = await this.writeDb.query<{ inserted: number }>(
       `
         INSERT INTO revenue_ledger (
           api_id,
@@ -452,7 +472,7 @@ export class PgUsageEventsRepository implements UsageEventsPgRepository {
       sql += ` OFFSET $${params.length}`;
     }
 
-    const result = await this.db.query<UsageEventRow>(sql, params);
+    const result = await this.readDb.query<UsageEventRow>(sql, params);
     return result.rows.map(mapUsageEventRow);
   }
 
@@ -468,7 +488,7 @@ export class PgUsageEventsRepository implements UsageEventsPgRepository {
     const clauses = [`${column} = $1`];
     appendDateFilters(params, clauses, from, to);
 
-    const result = await this.db.query<TotalRow>(
+    const result = await this.readDb.query<TotalRow>(
       `
         SELECT COALESCE(SUM(amount_usdc), 0)::text AS total
         FROM usage_events

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -1,6 +1,6 @@
 import type { Pool } from 'pg';
 import { NotFoundError } from '../errors/index.js';
-import { pool } from '../db.js';
+import { pool, readQuery, writeQuery } from '../db.js';
 import type { PaginationParams } from '../lib/pagination.js';
 
 export interface UserDto {
@@ -72,11 +72,16 @@ const assertNonEmpty = (value: string, fieldName: string): string => {
 };
 
 export class PgUserRepository implements UserRepository {
-  constructor(private readonly db: UserRepositoryQueryable = pool as Pool) {}
+  /**
+   * @param db - Optional injectable queryable used in tests. When omitted the
+   *   module-level routing helpers (readQuery / writeQuery) are used so that
+   *   reads can be served from replicas when REPLICA_URLS is configured.
+   */
+  constructor(private readonly db?: UserRepositoryQueryable) {}
 
   async create(user: CreateUserInput): Promise<UserDto> {
     const stellarAddress = assertNonEmpty(user.stellarAddress, 'stellarAddress');
-    const result = await this.db.query<UserRow>(
+    const result = await this.write<UserRow>(
       `
         INSERT INTO users (stellar_address)
         VALUES ($1)
@@ -90,7 +95,7 @@ export class PgUserRepository implements UserRepository {
 
   async findByStellarAddress(address: string): Promise<UserDto | null> {
     const stellarAddress = assertNonEmpty(address, 'stellarAddress');
-    const result = await this.db.query<UserRow>(
+    const result = await this.read<UserRow>(
       `
         SELECT id, stellar_address, created_at
         FROM users
@@ -105,7 +110,7 @@ export class PgUserRepository implements UserRepository {
 
   async findById(id: string): Promise<UserDto | null> {
     const userId = assertNonEmpty(id, 'id');
-    const result = await this.db.query<UserRow>(
+    const result = await this.read<UserRow>(
       `
         SELECT id, stellar_address, created_at
         FROM users
@@ -125,7 +130,7 @@ export class PgUserRepository implements UserRepository {
 
     if (data.stellarAddress !== undefined) {
       values.push(assertNonEmpty(data.stellarAddress, 'stellarAddress'));
-      updates.push(`stellar_address = $${values.length}`);
+      updates.push(`stellar_address = ${values.length}`);
     }
 
     if (updates.length === 0) {
@@ -138,7 +143,7 @@ export class PgUserRepository implements UserRepository {
     }
 
     values.push(userId);
-    const result = await this.db.query<UserRow>(
+    const result = await this.write<UserRow>(
       `
         UPDATE users
         SET ${updates.join(', ')}
@@ -157,7 +162,7 @@ export class PgUserRepository implements UserRepository {
 
   async list(params: PaginationParams): Promise<FindUsersResult> {
     const [usersResult, totalResult] = await Promise.all([
-      this.db.query<UserRow>(
+      this.read<UserRow>(
         `
         SELECT id, stellar_address, created_at
         FROM users
@@ -167,13 +172,39 @@ export class PgUserRepository implements UserRepository {
       `,
         [params.offset, params.limit],
       ),
-      this.db.query<CountRow>('SELECT COUNT(*)::text AS count FROM users'),
+      this.read<CountRow>('SELECT COUNT(*)::text AS count FROM users'),
     ]);
 
     return {
       users: usersResult.rows.map(mapUserListRow),
       total: Number(totalResult.rows[0]?.count ?? 0),
     };
+  }
+
+  // ── Private routing helpers ─────────────────────────────────────────────
+
+  /**
+   * Route a read query.
+   * When a custom `db` was injected (e.g. in tests) it is used directly.
+   * Otherwise the module-level `readQuery` helper routes to replica/primary.
+   */
+  private read<T>(text: string, params?: unknown[]): Promise<{ rows: T[] }> {
+    if (this.db) {
+      return this.db.query<T>(text, params);
+    }
+    return readQuery<T>(text, params);
+  }
+
+  /**
+   * Route a write query.
+   * When a custom `db` was injected (e.g. in tests) it is used directly.
+   * Otherwise the module-level `writeQuery` helper always routes to the primary.
+   */
+  private write<T>(text: string, params?: unknown[]): Promise<{ rows: T[] }> {
+    if (this.db) {
+      return this.db.query<T>(text, params);
+    }
+    return writeQuery<T>(text, params);
   }
 }
 


### PR DESCRIPTION
##closed #465 
Summary

Adds replica-aware database routing so read-only queries can be served by PostgreSQL replicas when configured, while ensuring all write operations continue to execute against the primary database.

Changes

* Added a replica connection pool with support for REPLICA_URLS.
* Implemented read/write routing abstraction for repositories.
* Configured automatic fallback to the primary database on replica failures.
* Added metrics for replica usage, fallback events, and failures.
* Updated environment configuration to support replica connection strings.
* Added documentation describing routing behavior and configuration.

Testing

Covered:

* Read queries routed to replicas.
* Write queries routed to the primary database.
* Operation when no replicas are configured.
* Replica failure fallback to primary.
* Routing strategy behavior.
* Metrics emission.
* Invalid configuration handling.
* Concurrent read routing.

Validation

npm test
npm run lint
npm run build

Security

* Writes are never executed against replicas.
* Configuration is validated at startup.
* Structured logs avoid exposing sensitive query information.
* Replica failures degrade safely by retrying against the primary database.