### PR TITLE
feat: end-to-end request-id propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Application errors are returned through the shared Express `errorHandler` using 
 
 For the `POST /api/billing/deduct` idempotency contract, response envelope, and retry guidance for SDK authors, see [docs/sdk/billing-deduct.md](./docs/sdk/billing-deduct.md).  
 For the complete gateway/proxy and billing error-code reference, including `502`/`504` derivation and Soroban billing mappings, see [docs/error-codes.md](./docs/error-codes.md).
+For request-id validation, AsyncLocalStorage propagation, structured logging, and outbound `X-Request-Id` forwarding, see [docs/request-id-propagation.md](./docs/request-id-propagation.md).
 
 | Variable | Required | Default | Description |
 |---|---|---|---|

--- a/docs/request-id-propagation.md
+++ b/docs/request-id-propagation.md
@@ -1,0 +1,45 @@
+# Request-ID Propagation Policy
+
+Callora accepts one correlation id at the HTTP edge and carries it through the
+request lifecycle.
+
+## Edge Header
+
+- Incoming `X-Request-Id` is sanitized by `src/middleware/requestId.ts`.
+- ASCII control characters are stripped before the value is echoed.
+- Empty, whitespace-only, or oversized values are discarded and replaced with a
+  generated UUID.
+- Every HTTP response emits `X-Request-Id`.
+
+## Async Context
+
+`src/utils/asyncContext.ts` stores the request id in `AsyncLocalStorage`.
+Downstream async work reads from this context instead of parsing headers again.
+This keeps the same id available to service calls, structured logs, and webhook
+delivery code.
+
+## Structured Logs
+
+Both logger paths attach the active request id:
+
+- `src/logger.ts` prefixes console-style logs with `[request_id:<id>]`.
+- `src/middleware/logging.ts` injects `requestId` into Pino structured payloads.
+
+Sensitive values are still redacted before logging.
+
+## Outbound Propagation
+
+Outbound calls propagate the active request id as `X-Request-Id`:
+
+- Gateway/proxy upstream calls.
+- Soroban JSON-RPC billing and settlement calls.
+- Webhook delivery requests.
+
+For Soroban JSON-RPC, the JSON-RPC `id` is also aligned to the active request id
+unless a test or caller explicitly provides a `requestIdFactory`.
+
+## Worker Fallback
+
+Jobs or tests that run outside an HTTP request use `getOrCreateRequestId()` to
+generate a local id. This preserves observability without inventing fake inbound
+headers.

--- a/src/__tests__/proxy.integration.test.ts
+++ b/src/__tests__/proxy.integration.test.ts
@@ -259,6 +259,32 @@ describe('Proxy /v1/call', () => {
     );
   });
 
+  it('propagates a client-supplied request id to upstream, response, and usage', async () => {
+    const edgeRequestId = 'edge-proxy-request-123';
+    let upstreamRequestId: string | undefined;
+    setUpstreamHandler((req, res) => {
+      upstreamRequestId = req.headers['x-request-id'] as string | undefined;
+      res.status(200).json({ requestId: upstreamRequestId });
+    });
+
+    const res = await fetch(`${proxyUrl}/v1/call/${TEST_API_SLUG}/request-id`, {
+      method: 'GET',
+      headers: {
+        'x-api-key': TEST_API_KEY,
+        'x-request-id': edgeRequestId,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-request-id')).toBe(edgeRequestId);
+    expect(upstreamRequestId).toBe(edgeRequestId);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    const events = usageStore.getEvents(TEST_API_KEY);
+    expect(events).toHaveLength(1);
+    expect(events[0].requestId).toBe(edgeRequestId);
+  });
+
   it('strips internal headers from the upstream request', async () => {
     let receivedHeaders: Record<string, string | string[] | undefined> = {};
 

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -93,4 +93,16 @@ describe('logger redaction helpers', () => {
       jest.resetModules();
     }
   });
+
+  test('request context is available from the dedicated async context utility', async () => {
+    const {
+      getRequestId,
+      runWithRequestContext,
+    } = await import('./utils/asyncContext.js');
+
+    await runWithRequestContext({ requestId: 'req-from-utils' }, async () => {
+      await Promise.resolve();
+      assert.equal(getRequestId(), 'req-from-utils');
+    });
+  });
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,10 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
+import {
+  getRequestId,
+  runWithRequestContext,
+  type RequestContext,
+} from './utils/asyncContext.js';
 
-type RequestContext = { requestId: string };
-
-const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+export { getRequestId, runWithRequestContext, type RequestContext };
 
 export const REDACTED_LOG_VALUE = '[REDACTED]';
 
@@ -37,11 +39,6 @@ export const PINO_REDACT_PATHS = [
   'req.headers["x-admin-api-key"]',
   'req.headers["proxy-authorization"]',
 ];
-
-export const runWithRequestContext = <T>(context: RequestContext, callback: () => T): T =>
-  requestContextStorage.run(context, callback);
-
-export const getRequestId = (): string | undefined => requestContextStorage.getStore()?.requestId;
 
 const normalizeLogKey = (key: string): string => key.replace(/[^a-z0-9]/gi, '').toLowerCase();
 

--- a/src/middleware/logging.test.ts
+++ b/src/middleware/logging.test.ts
@@ -39,6 +39,25 @@ describe('structured logger options', () => {
       },
     });
   });
+
+  test('redaction hook injects active request id into structured logs', async () => {
+    const method = jest.fn();
+    const { runWithRequestContext } = await import('../utils/asyncContext.js');
+
+    runWithRequestContext({ requestId: 'req-structured-1' }, () => {
+      structuredLoggerOptions.hooks?.logMethod?.call(
+        {} as never,
+        [{ event: 'webhook_dispatch', requestId: 'wrong-id' }, 'delivered'],
+        method,
+        30,
+      );
+    });
+
+    expect(method).toHaveBeenCalledWith(
+      { event: 'webhook_dispatch', requestId: 'req-structured-1' },
+      'delivered',
+    );
+  });
 });
 
 describe('requestLogger', () => {

--- a/src/middleware/logging.ts
+++ b/src/middleware/logging.ts
@@ -3,6 +3,7 @@ import pino from 'pino';
 import { v4 as uuidv4 } from 'uuid';
 import { PINO_REDACT_PATHS, REDACTED_LOG_VALUE, redactLogArguments } from '../logger.js';
 import { getClientIp } from '../lib/clientIp.js';
+import { getRequestId } from '../utils/asyncContext.js';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const defaultLevel = isProduction ? 'info' : 'debug';
@@ -16,14 +17,40 @@ export const structuredLoggerOptions: Parameters<typeof pino>[0] = {
   },
   hooks: {
     logMethod(args, method) {
+      const activeRequestId = getRequestId();
+
       if (args.length === 0) {
+        if (activeRequestId) {
+          return method.apply(this, [{ requestId: activeRequestId }]);
+        }
         return method.apply(this, args as [obj: unknown, msg?: string | undefined, ...args: unknown[]]);
       }
 
-      return method.apply(
-        this,
-        redactLogArguments(args) as [obj: unknown, msg?: string | undefined, ...args: unknown[]],
-      );
+      const redactedArgs = redactLogArguments(args);
+      if (!activeRequestId) {
+        return method.apply(
+          this,
+          redactedArgs as [obj: unknown, msg?: string | undefined, ...args: unknown[]],
+        );
+      }
+
+      const [first, ...rest] = redactedArgs;
+      if (
+        first &&
+        typeof first === 'object' &&
+        !Array.isArray(first) &&
+        !(first instanceof Error)
+      ) {
+        return method.apply(this, [
+          { ...(first as Record<string, unknown>), requestId: activeRequestId },
+          ...rest,
+        ] as [obj: unknown, msg?: string | undefined, ...args: unknown[]]);
+      }
+
+      return method.apply(this, [
+        { requestId: activeRequestId },
+        ...redactedArgs,
+      ] as [obj: unknown, msg?: string | undefined, ...args: unknown[]]);
     },
   },
   ...(isProduction
@@ -44,9 +71,7 @@ export function requestLogger(req: Request, res: Response, next: NextFunction): 
   // Prefer the sanitized ID already set by requestIdMiddleware (req.id).
   // Fall back to the raw header value for contexts where requestIdMiddleware
   // hasn't run (e.g. isolated unit tests), and finally generate a UUID.
-  const reqWithId = req as Request & { id?: string };
-  const requestId =
-    req.id ||
+  const requestId = req.id || getRequestId() ||
     (Array.isArray(req.headers['x-request-id'])
       ? req.headers['x-request-id'][0]
       : req.headers['x-request-id']) ||

--- a/src/middleware/requestId.ts
+++ b/src/middleware/requestId.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { runWithRequestContext } from '../logger.js';
+import { runWithRequestContext } from '../utils/asyncContext.js';
 
 const REQUEST_ID_HEADER = 'x-request-id';
 

--- a/src/routes/gatewayRoutes.test.ts
+++ b/src/routes/gatewayRoutes.test.ts
@@ -200,6 +200,56 @@ describe("gateway route - body size limits", () => {
   });
 });
 
+describe("gateway route - request id propagation", () => {
+  test("reuses the edge request id for upstream calls and response headers", async () => {
+    const apiKey = "test-key";
+    const apiId = "my-api";
+    const edgeRequestId = "edge-request-123";
+    const apiKeys = new Map<string, any>();
+    apiKeys.set(apiKey, { key: "k1", apiId, developerId: "dev1" });
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      text: async () => JSON.stringify({ ok: true }),
+    } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const usageStore = { record: jest.fn() };
+      const deps = {
+        billing: { deductCredit: async () => ({ success: true, balance: 100 }) },
+        rateLimiter: { check: async () => ({ allowed: true }) },
+        usageStore,
+        upstreamUrl: "http://example.internal",
+        apiKeys,
+      } as any;
+
+      const app = express();
+      app.use(requestIdMiddleware);
+      app.use("/gateway", createGatewayRouter(deps));
+      app.use(errorHandler);
+
+      const res = await request(app)
+        .post(`/gateway/${apiId}`)
+        .set("x-api-key", apiKey)
+        .set("x-request-id", edgeRequestId)
+        .send({ hello: "world" });
+
+      expect(res.status).toBe(200);
+      expect(res.headers["x-request-id"]).toBe(edgeRequestId);
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)["x-request-id"]).toBe(edgeRequestId);
+      expect(usageStore.record).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: edgeRequestId }),
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Bug #421 — prefix-exists-but-hash-mismatch must return 401, not 500
 // ---------------------------------------------------------------------------

--- a/src/routes/gatewayRoutes.ts
+++ b/src/routes/gatewayRoutes.ts
@@ -15,6 +15,7 @@ import {
   TooManyRequestsError,
   UnauthorizedError,
 } from '../errors/index.js';
+import { getOrCreateRequestId } from '../utils/asyncContext.js';
 
 /** Length of the key prefix used for candidate pre-filtering (matches repository). */
 const API_KEY_PREFIX_LENGTH = 16;
@@ -196,7 +197,7 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
     async (req: Request, res: Response, next: NextFunction) => {
       try {
         const apiKeyHeader = req.headers['x-api-key'] as string | undefined;
-        const requestId = randomUUID();
+        const requestId = req.id || getOrCreateRequestId(randomUUID);
 
         if (!apiKeyHeader) {
           next(new UnauthorizedError('Unauthorized: missing x-api-key header'));

--- a/src/routes/proxyRoutes.ts
+++ b/src/routes/proxyRoutes.ts
@@ -20,6 +20,7 @@ import {
 import { CircuitBreakerOpenError } from '../lib/errors.js';
 import { CircuitBreaker, type CircuitBreakerStore } from '../lib/circuitBreaker.js';
 import { env } from '../config/env.js';
+import { getOrCreateRequestId } from '../utils/asyncContext.js';
 
 /**
  * Headers that must never be forwarded to the upstream server.
@@ -108,7 +109,7 @@ export function createProxyRouter(deps: ProxyDeps): Router {
 
   async function handleProxy(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const requestId = randomUUID();
+      const requestId = req.id || getOrCreateRequestId(randomUUID);
       const apiEntry = req.api as unknown as ApiRegistryEntry | undefined;
       const endpoint = req.endpoint as unknown as EndpointPricing | undefined;
       const apiKeyHeader = req.apiKeyValue;

--- a/src/services/sorobanBilling.test.ts
+++ b/src/services/sorobanBilling.test.ts
@@ -89,6 +89,7 @@ describe('SorobanRpcBillingClient', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     const firstCall = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const [, init] = firstCall;
+    assert.equal((init.headers as Record<string, string>)['x-request-id'], 'req-deduct');
     assert.deepEqual(JSON.parse(String(init.body)), {
       jsonrpc: '2.0',
       id: 'req-deduct',
@@ -107,6 +108,33 @@ describe('SorobanRpcBillingClient', () => {
         networkPassphrase: 'Test SDF Network ; September 2015',
       },
     });
+  });
+
+  test('uses active request context for JSON-RPC id and X-Request-Id header', async () => {
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        result: {
+          value: '42',
+        },
+      }),
+    }));
+    const { runWithRequestContext } = await import('../utils/asyncContext.js');
+
+    const client = createSorobanRpcBillingClient({
+      rpcUrl: 'http://soroban-rpc.internal',
+      contractId: 'contract_abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await runWithRequestContext({ requestId: 'req-billing-als' }, async () => {
+      await client.getBalance('user_123');
+    });
+
+    const [, requestInit] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    assert.equal((requestInit.headers as Record<string, string>)['x-request-id'], 'req-billing-als');
+    assert.equal(JSON.parse(String(requestInit.body)).id, 'req-billing-als');
   });
 
   test('normalizes simulation failures returned by Soroban RPC', async () => {

--- a/src/services/sorobanBilling.ts
+++ b/src/services/sorobanBilling.ts
@@ -4,6 +4,7 @@ import {
 } from '../lib/simulationDiagnostics.js';
 import { withSorobanLatencyWrapper } from '../../tests/chaos/sorobanLatency.js';
 import { env } from '../config/env.js';
+import { getOrCreateRequestId } from '../utils/asyncContext.js';
 
 export interface SorobanBillingInvocationArg {
   type: 'string' | 'i128';
@@ -297,9 +298,11 @@ export class SorobanRpcBillingClient {
   }
 
   private async invoke(invocation: SorobanBillingInvocation): Promise<Record<string, unknown>> {
+    const requestId = this.options.requestIdFactory?.() ??
+      getOrCreateRequestId(() => `billing-${Date.now()}`);
     const requestBody: SorobanBillingRpcRequest = {
       jsonrpc: '2.0',
-      id: this.options.requestIdFactory?.() ?? `billing-${Date.now()}`,
+      id: requestId,
       method: 'simulateTransaction',
       params: {
         invocation,
@@ -319,6 +322,7 @@ export class SorobanRpcBillingClient {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
+          'x-request-id': requestId,
         },
         body: JSON.stringify(requestBody),
         signal: controller.signal,

--- a/src/services/sorobanSettlement.test.ts
+++ b/src/services/sorobanSettlement.test.ts
@@ -82,6 +82,7 @@ describe('SorobanRpcSettlementClient', () => {
     assert.equal(url, 'http://soroban-rpc.internal');
     assert.equal(init.method, 'POST');
     assert.equal((init.headers as Record<string, string>)['content-type'], 'application/json');
+    assert.equal((init.headers as Record<string, string>)['x-request-id'], 'req-fixed');
 
     assert.deepEqual(JSON.parse(String(init.body)), {
       jsonrpc: '2.0',
@@ -100,6 +101,29 @@ describe('SorobanRpcSettlementClient', () => {
         networkPassphrase: 'Test SDF Network ; September 2015',
       },
     });
+  });
+
+  test('uses active request context for JSON-RPC id and X-Request-Id header', async () => {
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ result: { transactionHash: '0xctx' } }),
+    }));
+    const { runWithRequestContext } = await import('../utils/asyncContext.js');
+
+    const client = createSorobanRpcSettlementClient({
+      rpcUrl: 'http://soroban-rpc.internal',
+      contractId: 'contract_abc',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await runWithRequestContext({ requestId: 'req-settlement-als' }, async () => {
+      await client.distribute('G_DEVELOPER_ACCOUNT', 1);
+    });
+
+    const [, requestInit] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    assert.equal((requestInit.headers as Record<string, string>)['x-request-id'], 'req-settlement-als');
+    assert.equal(JSON.parse(String(requestInit.body)).id, 'req-settlement-als');
   });
 
   test('normalizes simulation failures returned by Soroban RPC', async () => {

--- a/src/services/sorobanSettlement.ts
+++ b/src/services/sorobanSettlement.ts
@@ -8,6 +8,7 @@ import {
   type RetryOptions,
 } from '../lib/retry.js';
 import { withSorobanLatencyWrapper } from '../../tests/chaos/sorobanLatency.js';
+import { getOrCreateRequestId } from '../utils/asyncContext.js';
 
 export interface PayoutResult {
   success: boolean;
@@ -205,9 +206,11 @@ export class SorobanRpcSettlementClient implements SorobanSettlementClient {
       };
     }
 
+    const requestId = this.options.requestIdFactory?.() ??
+      getOrCreateRequestId(() => `soroban-settlement-${Date.now()}`);
     const requestBody: SorobanSimulationRequest = {
       jsonrpc: '2.0',
-      id: this.options.requestIdFactory?.() ?? `soroban-settlement-${Date.now()}`,
+      id: requestId,
       method: 'simulateTransaction',
       params: {
         invocation,
@@ -235,6 +238,7 @@ export class SorobanRpcSettlementClient implements SorobanSettlementClient {
             method: 'POST',
             headers: {
               'content-type': 'application/json',
+              'x-request-id': requestId,
             },
             body: JSON.stringify(requestBody),
             signal: controller.signal,

--- a/src/utils/asyncContext.test.ts
+++ b/src/utils/asyncContext.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+
+import {
+  getOrCreateRequestId,
+  getRequestId,
+  runWithRequestContext,
+} from './asyncContext.js';
+
+describe('async request context', () => {
+  test('stores request id across awaited async work', async () => {
+    await runWithRequestContext({ requestId: 'req-als-123' }, async () => {
+      await Promise.resolve();
+      assert.equal(getRequestId(), 'req-als-123');
+    });
+  });
+
+  test('falls back outside an inbound request context', () => {
+    assert.equal(getRequestId(), undefined);
+    assert.equal(getOrCreateRequestId(() => 'generated-fallback'), 'generated-fallback');
+  });
+});

--- a/src/utils/asyncContext.ts
+++ b/src/utils/asyncContext.ts
@@ -1,0 +1,30 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface RequestContext {
+  requestId: string;
+}
+
+const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Run a callback inside the per-request async context.
+ *
+ * The request-id middleware initializes this at the HTTP edge so async work
+ * kicked off by downstream services can attach the same correlation id to
+ * logs, RPC calls, and webhooks.
+ */
+export const runWithRequestContext = <T>(
+  context: RequestContext,
+  callback: () => T
+): T => requestContextStorage.run(context, callback);
+
+/** Return the active request id for the current async execution chain. */
+export const getRequestId = (): string | undefined =>
+  requestContextStorage.getStore()?.requestId;
+
+/**
+ * Return the active request id, or create a local fallback for work that runs
+ * outside an inbound HTTP request such as jobs and isolated unit tests.
+ */
+export const getOrCreateRequestId = (fallbackFactory: () => string): string =>
+  getRequestId() ?? fallbackFactory();

--- a/src/webhooks/webhook.dispatcher.test.ts
+++ b/src/webhooks/webhook.dispatcher.test.ts
@@ -54,6 +54,23 @@ describe('Webhook Dispatcher', () => {
         expect(headers['X-Callora-Delivery']).toBeDefined();
     });
 
+    it('propagates the active request id to outbound webhook headers', async () => {
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+        } as Response);
+        global.fetch = fetchMock as any;
+        const { runWithRequestContext } = await import('../utils/asyncContext.js');
+
+        await runWithRequestContext({ requestId: 'req-webhook-als' }, async () => {
+            await dispatchWebhook(config, payload);
+        });
+
+        const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+        expect(headers['X-Request-Id']).toBe('req-webhook-als');
+    });
+
     it('retries on non-2xx response and uses same idempotency key', async () => {
         const fetchMock = jest.fn()
             .mockResolvedValueOnce({

--- a/src/webhooks/webhook.dispatcher.ts
+++ b/src/webhooks/webhook.dispatcher.ts
@@ -1,26 +1,15 @@
 import crypto from 'crypto';
-import { WebhookConfig, WebhookPayload, DeadLetterEntry, WebhookDeliveryStatus } from './webhook.types.js';
-import { WebhookStore } from './webhook.store.js';
+import { WebhookConfig, WebhookPayload } from './webhook.types.js';
 import { logger } from '../logger.js';
+import { getRequestId } from '../utils/asyncContext.js';
 
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 1000;
-const MAX_DELAY_MS = 30_000;
 let acceptingDispatches = true;
 const inFlightDispatches = new Set<Promise<void>>();
 
 function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// Calculate exponential backoff with jitter to avoid thundering herd
-function calculateBackoff(attempt: number): number {
-    const exponentialDelay = BASE_DELAY_MS * Math.pow(2, attempt);
-    // Add jitter: random value between 0-25% of the exponential delay
-    const jitter = Math.random() * 0.25 * exponentialDelay;
-    const delayWithJitter = exponentialDelay + jitter;
-    // Cap at maximum delay
-    return Math.min(delayWithJitter, MAX_DELAY_MS);
 }
 
 function signPayload(secret: string, body: string): string {
@@ -72,6 +61,7 @@ export async function dispatchWebhook(
     return trackDispatch((async () => {
         const body = JSON.stringify(payload);
         const deliveryId = crypto.randomUUID();
+        const requestId = getRequestId();
         const headers: Record<string, string> = {
             'Content-Type': 'application/json',
             'User-Agent': 'Callora-Webhook/1.0',
@@ -79,6 +69,9 @@ export async function dispatchWebhook(
             'X-Callora-Timestamp': payload.timestamp,
             'X-Callora-Delivery': deliveryId,
         };
+        if (requestId) {
+            headers['X-Request-Id'] = requestId;
+        }
 
         if (config.secret) {
             headers['X-Callora-Signature'] = `sha256=${signPayload(config.secret, body)}`;
@@ -96,19 +89,21 @@ export async function dispatchWebhook(
                 });
 
                 if (response.ok) {
-                    console.log(
-                        `[webhook] ✓ Delivered ${payload.event} to ${config.url} (attempt ${attempt + 1})`
+                    logger.info(
+                        `[webhook] ✓ Delivered ${payload.event} to ${config.url}`,
+                        `attempt ${attempt + 1}`
                     );
                     return;
                 }
 
                 lastError = new Error(`HTTP ${response.status} ${response.statusText}`);
-                console.warn(
-                    `[webhook] Non-2xx response (${response.status}) for ${config.url}, attempt ${attempt + 1}`
+                logger.warn(
+                    `[webhook] Non-2xx response (${response.status}) for ${config.url}`,
+                    `attempt ${attempt + 1}`
                 );
             } catch (err) {
                 lastError = err;
-                console.warn(
+                logger.warn(
                     `[webhook] Error delivering to ${config.url}, attempt ${attempt + 1}:`,
                     (err as Error).message
                 );
@@ -116,7 +111,7 @@ export async function dispatchWebhook(
 
             if (attempt < MAX_RETRIES - 1) {
                 const delay = BASE_DELAY_MS * Math.pow(2, attempt);
-                console.log(`[webhook] Retrying in ${delay}ms...`);
+                logger.info(`[webhook] Retrying in ${delay}ms...`);
                 await sleep(delay);
             }
         }

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -400,13 +400,13 @@ describe('Webhook Signature Verification Tests', () => {
     expect(mockFetch).toHaveBeenCalledWith(testConfig.url, {
       method: 'POST',
       body: JSON.stringify(testPayload),
-      headers: {
+      headers: expect.objectContaining({
         'Content-Type': 'application/json',
         'User-Agent': 'Callora-Webhook/1.0',
         'X-Callora-Event': testPayload.event,
         'X-Callora-Timestamp': testPayload.timestamp,
         'X-Callora-Signature': `sha256=${expectedSignature}`,
-      },
+      }),
       signal: expect.any(AbortSignal),
     });
   });
@@ -570,13 +570,13 @@ describe('Webhook Logging Security Tests', () => {
 
     await dispatchWebhook(testConfig, testPayload);
 
-    expect(consoleSpy.log).toHaveBeenCalledWith(
+    expect(mockLogger.info).toHaveBeenCalledWith(
       expect.stringContaining('[webhook] ✓ Delivered new_api_call to https://example.com/webhook'),
       expect.stringContaining('attempt 1')
     );
 
     // Verify that sensitive data is not logged
-    const logCalls = consoleSpy.log.mock.calls.flat();
+    const logCalls = mockLogger.info.mock.calls.flat();
     const allLoggedText = logCalls.join(' ');
     expect(allLoggedText).not.toContain('sensitive-secret-key');
     expect(allLoggedText).not.toContain('this-should-not-be-logged');
@@ -585,11 +585,16 @@ describe('Webhook Logging Security Tests', () => {
   it('should not log sensitive payload data in error cases', async () => {
     mockFetch.mockRejectedValue(new Error('Network error'));
 
-    await dispatchWebhook(testConfig, testPayload);
+    jest.useFakeTimers();
+    const dispatchPromise = dispatchWebhook(testConfig, testPayload);
+    for (let attempt = 0; attempt < 5; attempt++) {
+      await jest.advanceTimersByTimeAsync(1000 * Math.pow(2, attempt));
+    }
+    await dispatchPromise;
 
     // Check that error logs don't contain sensitive information
-    const warnCalls = consoleSpy.warn.mock.calls.flat();
-    const errorCalls = consoleSpy.error.mock.calls.flat();
+    const warnCalls = mockLogger.warn.mock.calls.flat();
+    const errorCalls = mockLogger.error.mock.calls.flat();
     const allLoggedText = [...warnCalls, ...errorCalls].join(' ');
 
     expect(allLoggedText).not.toContain('sensitive-secret-key');
@@ -602,9 +607,14 @@ describe('Webhook Logging Security Tests', () => {
       status: 500,
     });
 
-    await dispatchWebhook(testConfig, testPayload);
+    jest.useFakeTimers();
+    const dispatchPromise = dispatchWebhook(testConfig, testPayload);
+    for (let attempt = 0; attempt < 5; attempt++) {
+      await jest.advanceTimersByTimeAsync(1000 * Math.pow(2, attempt));
+    }
+    await dispatchPromise;
 
-    expect(consoleSpy.warn).toHaveBeenCalledWith(
+    expect(mockLogger.warn).toHaveBeenCalledWith(
       expect.stringContaining('[webhook] Non-2xx response (500) for https://example.com/webhook'),
       expect.stringContaining('attempt 1')
     );


### PR DESCRIPTION
 ## Summary
  - Add AsyncLocalStorage request context for request-id propagation.
  - Reuse edge `X-Request-Id` for gateway/proxy upstream calls, Soroban RPC calls, webhook deliveries, responses, and usage records.
  - Inject request ids into structured logger payloads while preserving redaction.
  - Document the request-id propagation policy.

  ## Verification
  - JWT_SECRET=test-jwt-secret ADMIN_API_KEY=test-admin-key METRICS_API_KEY=test-metrics-key npx jest --runInBand --forceExit --silent src/utils/
  asyncContext.test.ts src/middleware/requestId.test.ts src/middleware/logging.test.ts src/logger.test.ts src/services/sorobanBilling.test.ts src/
  services/sorobanSettlement.test.ts src/webhooks/webhook.dispatcher.test.ts src/routes/gatewayRoutes.test.ts`
    - 8 suites passed, 75 tests passed.
  - JWT_SECRET=test-jwt-secret ADMIN_API_KEY=test-admin-key METRICS_API_KEY=test-metrics-key npx jest --runInBand --forceExit --silent tests/
  integration/webhooks.test.ts tests/integration/webhook-dispatch-pipeline.test.ts
    - 2 suites passed, 40 tests passed.
  - Targeted proxy propagation test passed.
  - `npm run typecheck` is blocked by existing unrelated repo type errors.
  - Full `npm run lint` is blocked by existing `tests/load/proxy.k6.js parse error.

  Closes #491