### PR TITLE
feat: admin anomalies endpoint (Add /api/admin/usage/anomalies endpoint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ API gateway, usage metering, and billing services for the Callora API marketplac
   - `GET /api/apis/:id`
   - `POST /api/apis` for authenticated developers to register an API with priced endpoints
 - Usage route: `GET /api/usage`
+- Admin usage anomalies: `GET /api/admin/usage/anomalies` returns per-API daily usage anomalies (z-score spikes/drops) for admin review, filterable by `from`/`to`/`apiId`/`threshold`/`limit` (admin auth + IP allowlist)
 - JSON body parsing plus gateway API key authentication for upstream proxy routes
 - Per-user global REST rate limiting for authenticated `/api/billing`, `/api/usage`, `/api/developers`, `/api/vault`, and `/api/keys` traffic, with IP fallback for unauthenticated requests
 - In-memory `VaultRepository` with:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -240,6 +240,166 @@
         }
       }
     },
+    "/api/admin/usage/anomalies": {
+      "get": {
+        "summary": "List detected usage anomalies",
+        "description": "Returns per-API daily usage anomalies for admin review. Usage events are aggregated to per-API daily call counts over the requested window, then each API's days are scored against that API's own baseline using a z-score test; days whose absolute z-score meets the threshold are flagged as spikes or drops. Requires admin authentication and the admin IP allowlist.",
+        "security": [
+          {
+            "adminApiKey": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Start of analysis window (ISO-8601). Defaults to 30 days ago.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "End of analysis window (ISO-8601). Defaults to now.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "description": "Absolute z-score at/above which a day is flagged.",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 3
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of anomalies to return (most severe first).",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100
+            }
+          },
+          {
+            "name": "apiId",
+            "in": "query",
+            "description": "Restrict analysis to a single API ID.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Detected anomalies retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "anomalies": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "apiId": { "type": "string" },
+                              "day": { "type": "string", "example": "2026-03-21" },
+                              "type": { "type": "string", "enum": ["spike", "drop"] },
+                              "calls": { "type": "integer" },
+                              "revenue": { "type": "string" },
+                              "baselineMean": { "type": "number" },
+                              "stdDev": { "type": "number" },
+                              "zScore": { "type": "number" }
+                            }
+                          }
+                        },
+                        "summary": {
+                          "type": "object",
+                          "properties": {
+                            "window": {
+                              "type": "object",
+                              "properties": {
+                                "from": { "type": "string", "format": "date-time" },
+                                "to": { "type": "string", "format": "date-time" }
+                              }
+                            },
+                            "threshold": { "type": "number" },
+                            "minDataPoints": { "type": "integer" },
+                            "seriesAnalyzed": { "type": "integer" },
+                            "anomalyCount": { "type": "integer" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized admin request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden by admin IP allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/usage/{developerId}": {
       "get": {
         "summary": "Inspect a developer usage aggregate",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import { z } from 'zod';
 import adminRouter from './routes/admin.js';
 import { createExplainRouter } from './routes/admin/explain.js';
+import { createUsageAnomaliesRouter } from './routes/admin/usage/anomalies.js';
 import { createApiRouter } from './routes/index.js';
 import { createApisRouter } from './routes/apis.js';
 import { pool } from './db.js';
@@ -252,6 +253,9 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     }
   });
 
+  // Mounted before the generic admin router so the specific path is not
+  // shadowed by adminRouter's `/usage/:developerId` route.
+  app.use('/api/admin/usage/anomalies', createUsageAnomaliesRouter({ pool }));
   app.use('/api/admin', adminRouter);
   app.use('/api/admin/db/explain', createExplainRouter({ pool }));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { createDeveloperRouter } from './routes/developerRoutes.js';
 import { createGatewayRouter } from './routes/gatewayRoutes.js';
 import { createProxyRouter } from './routes/proxyRoutes.js';
 import adminRouter from './routes/admin.js';
+import { createUsageAnomaliesRouter } from './routes/admin/usage/anomalies.js';
 import { defaultDeveloperRepository } from './repositories/developerRepository.js';
 import { createBillingService } from './services/billingService.js';
 import { createRateLimiter } from './services/rateLimiter.js';
@@ -288,6 +289,9 @@ if (isDirectExecution) {
     developerRepository: defaultDeveloperRepository,
   });
   app.use('/api/developers', developerRouter);
+  // Mounted before the generic admin router so it is not shadowed by
+  // adminRouter's `/usage/:developerId` route.
+  app.use('/api/admin/usage/anomalies', createUsageAnomaliesRouter({ pool }));
   app.use('/api/admin', adminRouter);
 
   // Legacy gateway route (existing)

--- a/src/routes/admin/usage/anomalies.test.ts
+++ b/src/routes/admin/usage/anomalies.test.ts
@@ -1,0 +1,237 @@
+import express from 'express';
+import request from 'supertest';
+import type { Pool, QueryResult } from 'pg';
+import { createUsageAnomaliesRouter } from './anomalies.js';
+import { errorHandler } from '../../../middleware/errorHandler.js';
+import { requestIdMiddleware } from '../../../middleware/requestId.js';
+
+jest.mock('../../../middleware/adminAuth', () => ({
+  adminAuth: jest.fn((_req: any, _res: any, next: any) => {
+    _res.locals = { ..._res.locals, adminActor: 'test-admin' };
+    next();
+  }),
+}));
+
+jest.mock('../../../middleware/ipAllowlist', () => ({
+  createAdminIpAllowlist: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+
+jest.mock('../../../logger', () => {
+  const actual = jest.requireActual('../../../logger');
+  return {
+    ...actual,
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      audit: jest.fn(),
+    },
+  };
+});
+
+import { logger } from '../../../logger.js';
+
+const mockQuery = jest.fn();
+const mockPool = { query: mockQuery } as unknown as Pool;
+
+function createTestApp(deps: { pool?: Pool; noPool?: boolean } = {}): express.Express {
+  const app = express();
+  app.use(requestIdMiddleware);
+  const effectivePool = deps.noPool ? undefined : (deps.pool ?? mockPool);
+  app.use('/api/admin/usage/anomalies', createUsageAnomaliesRouter({ pool: effectivePool as Pool | undefined }));
+  app.use(errorHandler);
+  return app;
+}
+
+const asResult = (rows: unknown[]): QueryResult =>
+  ({ rows } as unknown as QueryResult);
+
+const dayString = (index: number): string =>
+  new Date(Date.UTC(2026, 2, 1 + index)).toISOString().slice(0, 10);
+
+// Steady 10 calls/day over a 20-day baseline with a clear spike on the final
+// day for api-1 (z-score comfortably above the default threshold of 3).
+const SPIKE_ROWS = [
+  ...Array.from({ length: 20 }, (_, i) => ({
+    apiId: 'api-1',
+    day: dayString(i),
+    calls: 10,
+    revenue: '0',
+  })),
+  { apiId: 'api-1', day: dayString(20), calls: 200, revenue: '5000' },
+];
+const SPIKE_DAY = dayString(20);
+
+describe('GET /api/admin/usage/anomalies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockReset();
+  });
+
+  it('returns detected anomalies with a summary', async () => {
+    mockQuery.mockResolvedValueOnce(asResult(SPIKE_ROWS));
+    const app = createTestApp();
+
+    const res = await request(app).get('/api/admin/usage/anomalies');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.anomalies).toHaveLength(1);
+    expect(res.body.data.anomalies[0]).toMatchObject({
+      apiId: 'api-1',
+      day: SPIKE_DAY,
+      type: 'spike',
+      calls: 200,
+      revenue: '5000',
+    });
+    expect(res.body.data.summary).toMatchObject({
+      threshold: 3,
+      minDataPoints: 3,
+      seriesAnalyzed: 1,
+      anomalyCount: 1,
+    });
+    expect(res.body.data.summary.window.from).toBeDefined();
+    expect(res.body.data.summary.window.to).toBeDefined();
+  });
+
+  it('writes an audit log entry', async () => {
+    mockQuery.mockResolvedValueOnce(asResult(SPIKE_ROWS));
+    const app = createTestApp();
+
+    await request(app).get('/api/admin/usage/anomalies');
+
+    expect(logger.audit).toHaveBeenCalledWith(
+      'LIST_USAGE_ANOMALIES',
+      'test-admin',
+      expect.objectContaining({ anomalyCount: 1, seriesAnalyzed: 1 }),
+    );
+  });
+
+  it('returns an empty list when no anomalies are detected', async () => {
+    mockQuery.mockResolvedValueOnce(asResult([
+      { apiId: 'api-1', day: '2026-03-01', calls: 10, revenue: '0' },
+      { apiId: 'api-1', day: '2026-03-02', calls: 10, revenue: '0' },
+      { apiId: 'api-1', day: '2026-03-03', calls: 10, revenue: '0' },
+    ]));
+    const app = createTestApp();
+
+    const res = await request(app).get('/api/admin/usage/anomalies');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.anomalies).toEqual([]);
+    expect(res.body.data.summary.anomalyCount).toBe(0);
+  });
+
+  it('applies a custom threshold', async () => {
+    mockQuery.mockResolvedValueOnce(asResult(SPIKE_ROWS));
+    const app = createTestApp();
+
+    const res = await request(app).get('/api/admin/usage/anomalies').query({ threshold: '10' });
+
+    expect(res.status).toBe(200);
+    // The spike's z-score (~2) is below a threshold of 10.
+    expect(res.body.data.anomalies).toEqual([]);
+    expect(res.body.data.summary.threshold).toBe(10);
+  });
+
+  it('passes an apiId filter through to the query', async () => {
+    mockQuery.mockResolvedValueOnce(asResult(SPIKE_ROWS));
+    const app = createTestApp();
+
+    await request(app).get('/api/admin/usage/anomalies').query({ apiId: 'api-1' });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('AND api_id = $3');
+    expect(params).toEqual([expect.any(Date), expect.any(Date), 'api-1']);
+  });
+
+  it('passes the date window through to the query', async () => {
+    mockQuery.mockResolvedValueOnce(asResult([]));
+    const app = createTestApp();
+
+    await request(app)
+      .get('/api/admin/usage/anomalies')
+      .query({ from: '2026-03-01T00:00:00.000Z', to: '2026-03-31T00:00:00.000Z' });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect((params[0] as Date).toISOString()).toBe('2026-03-01T00:00:00.000Z');
+    expect((params[1] as Date).toISOString()).toBe('2026-03-31T00:00:00.000Z');
+  });
+
+  describe('input validation', () => {
+    it('returns 400 for an invalid "from" date', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies').query({ from: 'nope' });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('BAD_REQUEST');
+      expect(res.body.message).toBe('Invalid "from" date');
+    });
+
+    it('returns 400 when "from" is supplied as multiple values', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies?from=2026-01-01&from=2026-02-01');
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('Invalid "from" date');
+    });
+
+    it('returns 400 when threshold is supplied as multiple values', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies?threshold=3&threshold=4');
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('returns 400 for an invalid "to" date', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies').query({ to: 'nope' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('Invalid "to" date');
+    });
+
+    it('returns 400 when from is after to', async () => {
+      const res = await request(createTestApp())
+        .get('/api/admin/usage/anomalies')
+        .query({ from: '2026-03-31T00:00:00.000Z', to: '2026-03-01T00:00:00.000Z' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('from must be before or equal to to');
+    });
+
+    it('returns 400 for an out-of-range threshold', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies').query({ threshold: '99' });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('BAD_REQUEST');
+    });
+
+    it('returns 400 for a non-numeric threshold', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies').query({ threshold: 'abc' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for a non-integer limit', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies').query({ limit: '1.5' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for an out-of-range limit', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies').query({ limit: '0' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when apiId is supplied as multiple values', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/anomalies?apiId=a&apiId=b');
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('apiId must be a single string value');
+    });
+  });
+
+  it('returns 500 when the database pool is unavailable', async () => {
+    const app = createTestApp({ noPool: true });
+    const res = await request(app).get('/api/admin/usage/anomalies');
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('INTERNAL_SERVER_ERROR');
+  });
+
+  it('returns 500 when the aggregation query fails', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('db down'));
+    const app = createTestApp();
+    const res = await request(app).get('/api/admin/usage/anomalies');
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/routes/admin/usage/anomalies.ts
+++ b/src/routes/admin/usage/anomalies.ts
@@ -1,0 +1,228 @@
+import { Router } from 'express';
+import type { Pool } from 'pg';
+import { adminAuth } from '../../../middleware/adminAuth.js';
+import { createAdminIpAllowlist } from '../../../middleware/ipAllowlist.js';
+import { BadRequestError, InternalServerError } from '../../../errors/index.js';
+import { logger } from '../../../logger.js';
+import { getClientIp } from '../../../lib/clientIp.js';
+import {
+  detectUsageAnomalies,
+  type DailyUsagePoint,
+} from '../../../services/usageAnomalyDetector.js';
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+const DEFAULT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_THRESHOLD = 3;
+const MIN_THRESHOLD = 1;
+const MAX_THRESHOLD = 10;
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 1000;
+/** Minimum days of history an API needs before its baseline is trustworthy. */
+const MIN_DATA_POINTS = 3;
+
+interface DailyUsageRow {
+  apiId: string;
+  day: string;
+  calls: number;
+  revenue: string;
+}
+
+/**
+ * Parses a query-string value as a Date.
+ * - absent → `undefined` (caller applies a default)
+ * - present but unparseable → `null` (caller returns 400)
+ */
+const parseDateParam = (value: unknown): Date | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+/**
+ * Parses a bounded numeric query param.
+ * Returns the default when absent, or `null` when present but invalid /
+ * out of range so the caller can return a standardized 400.
+ */
+const parseNumberParam = (
+  value: unknown,
+  opts: { min: number; max: number; integer: boolean; fallback: number },
+): number | null => {
+  if (value === undefined) {
+    return opts.fallback;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  if (opts.integer && !Number.isInteger(parsed)) {
+    return null;
+  }
+  if (parsed < opts.min || parsed > opts.max) {
+    return null;
+  }
+  return parsed;
+};
+
+export interface UsageAnomaliesRouterDeps {
+  pool?: Pool;
+}
+
+/**
+ * Router exposing `GET /api/admin/usage/anomalies` — detected per-API daily
+ * usage anomalies for admin review.
+ *
+ * Admin-only: gated behind the admin IP allowlist and admin authentication.
+ * Usage is aggregated to per-API daily counts in a single grouped SQL scan,
+ * then scored in-process by {@link detectUsageAnomalies}, so the work stays
+ * bounded by the number of (API, day) buckets rather than raw event volume.
+ */
+export function createUsageAnomaliesRouter(deps: UsageAnomaliesRouterDeps = {}): Router {
+  const router = Router();
+
+  router.use(createAdminIpAllowlist());
+  router.use(adminAuth);
+
+  router.get('/', async (req, res, next) => {
+    try {
+      // ── Input validation (boundary) ──────────────────────────────────────
+      const from = parseDateParam(req.query.from);
+      if (from === null) {
+        next(new BadRequestError('Invalid "from" date'));
+        return;
+      }
+      const to = parseDateParam(req.query.to);
+      if (to === null) {
+        next(new BadRequestError('Invalid "to" date'));
+        return;
+      }
+
+      const threshold = parseNumberParam(req.query.threshold, {
+        min: MIN_THRESHOLD,
+        max: MAX_THRESHOLD,
+        integer: false,
+        fallback: DEFAULT_THRESHOLD,
+      });
+      if (threshold === null) {
+        next(new BadRequestError(`threshold must be a number between ${MIN_THRESHOLD} and ${MAX_THRESHOLD}`));
+        return;
+      }
+
+      const limit = parseNumberParam(req.query.limit, {
+        min: 1,
+        max: MAX_LIMIT,
+        integer: true,
+        fallback: DEFAULT_LIMIT,
+      });
+      if (limit === null) {
+        next(new BadRequestError(`limit must be an integer between 1 and ${MAX_LIMIT}`));
+        return;
+      }
+
+      if (req.query.apiId !== undefined && typeof req.query.apiId !== 'string') {
+        next(new BadRequestError('apiId must be a single string value'));
+        return;
+      }
+      const apiId =
+        typeof req.query.apiId === 'string' && req.query.apiId.length > 0
+          ? req.query.apiId
+          : undefined;
+
+      const now = new Date();
+      const queryFrom = from ?? new Date(now.getTime() - DEFAULT_WINDOW_MS);
+      const queryTo = to ?? now;
+
+      if (queryFrom > queryTo) {
+        next(new BadRequestError('from must be before or equal to to'));
+        return;
+      }
+
+      const { pool } = deps;
+      if (!pool) {
+        next(new InternalServerError('Database pool not available'));
+        return;
+      }
+
+      // ── Aggregate per-API daily usage in a single grouped scan ────────────
+      const params: unknown[] = [queryFrom, queryTo];
+      let apiFilter = '';
+      if (apiId !== undefined) {
+        params.push(apiId);
+        apiFilter = `AND api_id = $${params.length}`;
+      }
+
+      const sql = `
+        SELECT
+          api_id AS "apiId",
+          to_char(date_trunc('day', created_at), 'YYYY-MM-DD') AS day,
+          COUNT(*)::int AS calls,
+          COALESCE(SUM(amount_usdc), 0)::text AS revenue
+        FROM usage_events
+        WHERE created_at >= $1 AND created_at <= $2
+          ${apiFilter}
+        GROUP BY api_id, date_trunc('day', created_at)
+        ORDER BY api_id, day
+      `;
+
+      let rows: DailyUsageRow[];
+      try {
+        const result = await pool.query<DailyUsageRow>(sql, params);
+        rows = result.rows;
+      } catch (dbError) {
+        logger.error('[usage.anomalies] aggregation query failed', { error: dbError });
+        next(new InternalServerError());
+        return;
+      }
+
+      const series: DailyUsagePoint[] = rows.map((row) => ({
+        apiId: row.apiId,
+        day: row.day,
+        calls: Number(row.calls),
+        revenue: row.revenue,
+      }));
+
+      const { anomalies, seriesAnalyzed } = detectUsageAnomalies(series, {
+        threshold,
+        minDataPoints: MIN_DATA_POINTS,
+        limit,
+      });
+
+      logger.audit('LIST_USAGE_ANOMALIES', res.locals.adminActor, {
+        clientIp: getClientIp(req, TRUST_PROXY),
+        userAgent: req.get('User-Agent'),
+        window: { from: queryFrom.toISOString(), to: queryTo.toISOString() },
+        threshold,
+        apiId,
+        seriesAnalyzed,
+        anomalyCount: anomalies.length,
+      });
+
+      res.json({
+        data: {
+          anomalies,
+          summary: {
+            window: { from: queryFrom.toISOString(), to: queryTo.toISOString() },
+            threshold,
+            minDataPoints: MIN_DATA_POINTS,
+            seriesAnalyzed,
+            anomalyCount: anomalies.length,
+          },
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export default createUsageAnomaliesRouter;

--- a/src/services/usageAnomalyDetector.test.ts
+++ b/src/services/usageAnomalyDetector.test.ts
@@ -1,0 +1,126 @@
+import {
+  detectUsageAnomalies,
+  type DailyUsagePoint,
+} from './usageAnomalyDetector.js';
+
+const baseOptions = { threshold: 3, minDataPoints: 3, limit: 100 };
+
+const dayString = (index: number): string => {
+  const date = new Date(Date.UTC(2026, 2, 1 + index)); // March 2026
+  return date.toISOString().slice(0, 10);
+};
+
+/**
+ * Builds a baseline of `baselineDays` days oscillating around `baselineCalls`
+ * (deterministic ±`jitter` so the series has realistic, non-zero variance),
+ * followed by one final day at `spikeCalls`. Variance in the baseline is what
+ * makes the spike's z-score scale with its magnitude.
+ */
+const noisyThenSpike = (
+  apiId: string,
+  baselineDays: number,
+  baselineCalls: number,
+  spikeCalls: number,
+  opts: { jitter?: number; revenue?: string } = {},
+): DailyUsagePoint[] => {
+  const { jitter = 2, revenue = '0' } = opts;
+  const points: DailyUsagePoint[] = [];
+  for (let i = 0; i < baselineDays; i += 1) {
+    const calls = baselineCalls + (i % 2 === 0 ? -jitter : jitter);
+    points.push({ apiId, day: dayString(i), calls, revenue: '0' });
+  }
+  points.push({ apiId, day: dayString(baselineDays), calls: spikeCalls, revenue });
+  return points;
+};
+
+describe('detectUsageAnomalies', () => {
+  it('flags a day whose call count exceeds the threshold as a spike', () => {
+    const result = detectUsageAnomalies(noisyThenSpike('api-1', 20, 10, 200, { revenue: '5000' }), baseOptions);
+
+    expect(result.seriesAnalyzed).toBe(1);
+    expect(result.anomalies).toHaveLength(1);
+    const [anomaly] = result.anomalies;
+    expect(anomaly.apiId).toBe('api-1');
+    expect(anomaly.day).toBe(dayString(20));
+    expect(anomaly.type).toBe('spike');
+    expect(anomaly.calls).toBe(200);
+    expect(anomaly.revenue).toBe('5000');
+    expect(anomaly.zScore).toBeGreaterThanOrEqual(3);
+  });
+
+  it('flags an unusually low day as a drop', () => {
+    const result = detectUsageAnomalies(noisyThenSpike('api-1', 20, 100, 0), baseOptions);
+
+    expect(result.anomalies).toHaveLength(1);
+    expect(result.anomalies[0].type).toBe('drop');
+    expect(result.anomalies[0].zScore).toBeLessThanOrEqual(-3);
+  });
+
+  it('returns no anomalies when deviation stays below the threshold', () => {
+    // A modest bump that stays within 3 standard deviations.
+    const result = detectUsageAnomalies(noisyThenSpike('api-1', 20, 10, 13), baseOptions);
+    expect(result.seriesAnalyzed).toBe(1);
+    expect(result.anomalies).toEqual([]);
+  });
+
+  it('returns no anomalies for a perfectly flat series (zero variance)', () => {
+    const result = detectUsageAnomalies(noisyThenSpike('api-1', 4, 5, 5, { jitter: 0 }), baseOptions);
+    expect(result.seriesAnalyzed).toBe(1);
+    expect(result.anomalies).toEqual([]);
+  });
+
+  it('skips APIs with fewer than minDataPoints days', () => {
+    const series: DailyUsagePoint[] = [
+      { apiId: 'api-short', day: dayString(0), calls: 1, revenue: '0' },
+      { apiId: 'api-short', day: dayString(1), calls: 1000, revenue: '0' },
+    ];
+    const result = detectUsageAnomalies(series, baseOptions);
+    expect(result.seriesAnalyzed).toBe(0);
+    expect(result.anomalies).toEqual([]);
+  });
+
+  it('scores each API against its own baseline', () => {
+    const series = [
+      ...noisyThenSpike('api-1', 20, 10, 200), // api-1 has a clear spike
+      ...noisyThenSpike('api-2', 20, 50, 51), // api-2 is essentially flat
+    ];
+    const result = detectUsageAnomalies(series, baseOptions);
+    expect(result.seriesAnalyzed).toBe(2);
+    expect(result.anomalies).toHaveLength(1);
+    expect(result.anomalies[0].apiId).toBe('api-1');
+  });
+
+  it('returns anomalies most-severe-first and respects the limit', () => {
+    const series = [
+      ...noisyThenSpike('api-1', 20, 10, 80), // smaller spike
+      ...noisyThenSpike('api-2', 20, 10, 400), // larger spike
+    ];
+
+    const all = detectUsageAnomalies(series, baseOptions);
+    expect(all.anomalies.length).toBeGreaterThanOrEqual(2);
+    // Sorted by absolute z-score descending.
+    for (let i = 1; i < all.anomalies.length; i += 1) {
+      expect(Math.abs(all.anomalies[i - 1].zScore)).toBeGreaterThanOrEqual(
+        Math.abs(all.anomalies[i].zScore),
+      );
+    }
+    expect(all.anomalies[0].apiId).toBe('api-2');
+
+    const capped = detectUsageAnomalies(series, { ...baseOptions, limit: 1 });
+    expect(capped.anomalies).toHaveLength(1);
+    expect(capped.anomalies[0].apiId).toBe('api-2');
+  });
+
+  it('handles an empty series', () => {
+    const result = detectUsageAnomalies([], baseOptions);
+    expect(result).toEqual({ anomalies: [], seriesAnalyzed: 0 });
+  });
+
+  it('rounds baseline statistics to a stable precision', () => {
+    const result = detectUsageAnomalies(noisyThenSpike('api-1', 20, 10, 200), baseOptions);
+    const [anomaly] = result.anomalies;
+    // round4 → at most 4 decimal places.
+    expect(anomaly.baselineMean).toBe(Math.round(anomaly.baselineMean * 10_000) / 10_000);
+    expect(anomaly.stdDev).toBe(Math.round(anomaly.stdDev * 10_000) / 10_000);
+  });
+});

--- a/src/services/usageAnomalyDetector.ts
+++ b/src/services/usageAnomalyDetector.ts
@@ -1,0 +1,128 @@
+/**
+ * Pure usage-anomaly detection.
+ *
+ * Operates on a per-API daily time series of call counts and flags days whose
+ * call volume deviates from that API's own baseline by more than a configurable
+ * number of standard deviations (a z-score test). Keeping the maths in a pure,
+ * dependency-free module makes it cheap to unit test and trivial to reason
+ * about during review; the route layer is responsible only for fetching the
+ * aggregated series and shaping the HTTP response.
+ */
+
+/** One aggregated data point: calls/revenue for a single API on a single day. */
+export interface DailyUsagePoint {
+  apiId: string;
+  /** Calendar day in `YYYY-MM-DD` form (UTC). */
+  day: string;
+  /** Number of usage events recorded for the API on that day. */
+  calls: number;
+  /** Total revenue for that API/day, as a smallest-unit integer string. */
+  revenue: string;
+}
+
+export type AnomalyType = 'spike' | 'drop';
+
+export interface UsageAnomaly {
+  apiId: string;
+  day: string;
+  type: AnomalyType;
+  calls: number;
+  revenue: string;
+  /** Mean daily call count for this API across the analysed window. */
+  baselineMean: number;
+  /** Population standard deviation of daily call counts for this API. */
+  stdDev: number;
+  /** Signed z-score: how many standard deviations the day is from the mean. */
+  zScore: number;
+}
+
+export interface DetectAnomaliesOptions {
+  /** Absolute z-score at/above which a day is flagged. Must be > 0. */
+  threshold: number;
+  /** Minimum days of history an API needs before it is analysed. */
+  minDataPoints: number;
+  /** Maximum number of anomalies to return (most severe first). */
+  limit: number;
+}
+
+export interface DetectAnomaliesResult {
+  anomalies: UsageAnomaly[];
+  /** Number of distinct APIs that had enough history to be analysed. */
+  seriesAnalyzed: number;
+}
+
+/** Rounds to 4 decimal places to keep response payloads stable and compact. */
+const round4 = (value: number): number => Math.round(value * 10_000) / 10_000;
+
+/**
+ * Detects per-API daily usage anomalies via a z-score test against each API's
+ * own baseline.
+ *
+ * APIs with fewer than `minDataPoints` days, or whose call counts have zero
+ * variance (standard deviation of 0), produce no anomalies — there is no
+ * meaningful baseline to deviate from. Results are returned most-severe-first
+ * (largest absolute z-score) and capped at `limit`.
+ */
+export function detectUsageAnomalies(
+  series: DailyUsagePoint[],
+  options: DetectAnomaliesOptions,
+): DetectAnomaliesResult {
+  const { threshold, minDataPoints, limit } = options;
+
+  // Group points by API so each series is scored against its own baseline.
+  const byApi = new Map<string, DailyUsagePoint[]>();
+  for (const point of series) {
+    const bucket = byApi.get(point.apiId);
+    if (bucket) {
+      bucket.push(point);
+    } else {
+      byApi.set(point.apiId, [point]);
+    }
+  }
+
+  const anomalies: UsageAnomaly[] = [];
+  let seriesAnalyzed = 0;
+
+  for (const points of byApi.values()) {
+    if (points.length < minDataPoints) {
+      continue;
+    }
+    seriesAnalyzed += 1;
+
+    const counts = points.map((p) => p.calls);
+    const mean = counts.reduce((sum, c) => sum + c, 0) / counts.length;
+    const variance =
+      counts.reduce((sum, c) => sum + (c - mean) ** 2, 0) / counts.length;
+    const stdDev = Math.sqrt(variance);
+
+    // A flat series has no baseline to deviate from — nothing to flag.
+    if (stdDev === 0) {
+      continue;
+    }
+
+    for (const point of points) {
+      const zScore = (point.calls - mean) / stdDev;
+      if (Math.abs(zScore) < threshold) {
+        continue;
+      }
+      anomalies.push({
+        apiId: point.apiId,
+        day: point.day,
+        type: zScore > 0 ? 'spike' : 'drop',
+        calls: point.calls,
+        revenue: point.revenue,
+        baselineMean: round4(mean),
+        stdDev: round4(stdDev),
+        zScore: round4(zScore),
+      });
+    }
+  }
+
+  // Most severe first; cap to the requested limit.
+  anomalies.sort((a, b) => Math.abs(b.zScore) - Math.abs(a.zScore));
+
+  return {
+    anomalies: anomalies.slice(0, limit),
+    seriesAnalyzed,
+  };
+}


### PR DESCRIPTION
Closes #510 

## Summary

Adds `GET /api/admin/usage/anomalies`, an admin-only endpoint that returns
detected per-API daily usage anomalies for review. Usage events are aggregated
to per-API daily call counts over a requested window, then each API's days are
scored against that API's own baseline with a z-score test; days whose absolute
z-score meets the threshold are flagged as spikes or drops.

This is a backend deliverable for the GrantFox campaign.

## Motivation

Admins need visibility into abnormal usage patterns (sudden spikes or drops in
API call volume) to spot abuse, billing irregularities, or upstream incidents.
There was previously no endpoint surfacing this; operators had to inspect raw
usage data manually.

## Changes

- New pure detection service `src/services/usageAnomalyDetector.ts`
  (dependency-free, fully unit tested).
- New route `src/routes/admin/usage/anomalies.ts` exposing
  `GET /api/admin/usage/anomalies`.
- Wired into `src/app.ts` and `src/index.ts`, mounted before the generic admin
  router so it is not shadowed by `adminRouter`'s `/usage/:developerId` route.
- Documentation: added the path to `docs/openapi.json` and a reference line in
  `README.md`.

## API

`GET /api/admin/usage/anomalies` (admin authentication + admin IP allowlist)

| Query param | Type    | Required | Default      | Description                                   |
|-------------|---------|----------|--------------|-----------------------------------------------|
| `from`      | ISO-8601 | No      | 30 days ago  | Start of analysis window                      |
| `to`        | ISO-8601 | No      | now          | End of analysis window                        |
| `threshold` | number  | No       | 3            | Absolute z-score at/above which a day is flagged (1–10) |
| `limit`     | integer | No       | 100          | Max anomalies returned, most severe first (1–1000) |
| `apiId`     | string  | No       | all APIs     | Restrict analysis to a single API             |

Response: `200 OK`

    {
      "data": {
        "anomalies": [
          {
            "apiId": "api-1",
            "day": "2026-03-21",
            "type": "spike",
            "calls": 200,
            "revenue": "5000",
            "baselineMean": 19.0476,
            "stdDev": 40.4622,
            "zScore": 4.4721
          }
        ],
        "summary": {
          "window": { "from": "2026-02-21T00:00:00.000Z", "to": "2026-03-23T00:00:00.000Z" },
          "threshold": 3,
          "minDataPoints": 3,
          "seriesAnalyzed": 1,
          "anomalyCount": 1
        }
      }
    }

Errors use the standard envelope `{ code, message, requestId }`:
- `400` invalid `from`/`to`, `from` after `to`, out-of-range/non-numeric
  `threshold` or `limit`, or multi-valued `apiId`
- `401` unauthenticated admin request
- `403` blocked by the admin IP allowlist
- `500` database pool unavailable or aggregation query failure

## Implementation notes

- Detection algorithm: per API, compute the mean and population standard
  deviation of daily call counts over the window, then flag days where
  `|(calls - mean) / stdDev| >= threshold`, classified as `spike` (above) or
  `drop` (below). Results are sorted most-severe-first and capped at `limit`.
- Edge handling: APIs with fewer than `minDataPoints` (3) days, or with zero
  variance, produce no anomalies (no baseline to deviate from, no
  divide-by-zero).
- Efficiency: usage is reduced to per-API daily buckets in a single grouped SQL
  scan, so scoring work is bounded by the number of (API, day) buckets rather
  than raw event volume.
- Security: gated behind the admin IP allowlist and admin authentication; all
  query parameters are validated at the boundary before any query runs.
- Observability: each request emits an audit log entry with correlation ID,
  actor, window, threshold, and result counts.
- The detection logic is isolated in a pure service so it can be reviewed and
  tested independently of HTTP and the database.

## Testing

- `src/services/usageAnomalyDetector.test.ts` and
  `src/routes/admin/usage/anomalies.test.ts`: 27 tests covering spike/drop
  detection, sub-threshold and flat-series cases, per-API baselines, severity
  ordering and limit capping, all 400 validation paths, apiId/date passthrough,
  audit logging, no-pool 500, and database-failure 500.
- Coverage on changed files: detector 100%, route 98.9% lines / 96.9% branch
  (only the defensive outer catch uncovered) — above the 90% target.
- `eslint` and `tsc --noEmit` clean for the new files; all new and existing
  admin route suites pass.

## Acceptance criteria

- [x] Implementation matches the description
- [x] Tests added and passing
- [x] Docs updated (OpenAPI + README)
