### PR TITLE
Task/audit enrichment

### DIFF
--- a/migrations/0014_webhook_keys.sql
+++ b/migrations/0014_webhook_keys.sql
@@ -1,0 +1,37 @@
+-- Migration: 0014_webhook_keys
+-- Adds the webhook_signing_keys table for dual-key rotation with grace window.
+--
+-- Design:
+--   Each row represents one signing key for the *global* platform webhook
+--   signing secret (not per-developer — those live in webhook.store.ts).
+--   At any moment there is at most one "active" key and one "previous" key
+--   that has not yet passed its grace window expiry.
+--
+-- The application layer enforces the at-most-one active + at-most-one
+-- previous constraint; the DB stores the raw rows for audit trail purposes.
+
+CREATE TABLE IF NOT EXISTS webhook_signing_keys (
+  id          TEXT PRIMARY KEY,               -- UUID v4
+  key_hash    TEXT NOT NULL UNIQUE,           -- SHA-256 hex of the raw secret (never store plaintext)
+  status      TEXT NOT NULL DEFAULT 'active'  -- 'active' | 'previous' | 'expired'
+                CHECK (status IN ('active', 'previous', 'expired')),
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  expires_at  TEXT,                           -- NULL = current key (no expiry); set when demoted
+  created_by  TEXT NOT NULL                   -- admin actor identifier (from res.locals.adminActor)
+);
+
+-- Fast look-up of the active key and all non-expired previous keys
+CREATE INDEX IF NOT EXISTS idx_webhook_signing_keys_status
+  ON webhook_signing_keys (status);
+
+-- Audit log for every rotation event
+CREATE TABLE IF NOT EXISTS webhook_key_rotation_audit (
+  id             TEXT PRIMARY KEY,                       -- UUID v4
+  new_key_id     TEXT NOT NULL REFERENCES webhook_signing_keys(id),
+  previous_key_id TEXT,                                  -- NULL on first-ever rotation
+  grace_window_ms INTEGER NOT NULL,
+  expires_at     TEXT NOT NULL,                          -- when the previous key loses validity
+  rotated_by     TEXT NOT NULL,                          -- admin actor
+  rotated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  correlation_id TEXT                                    -- request-id for tracing
+);

--- a/migrations/0015_apis_soft_delete.sql
+++ b/migrations/0015_apis_soft_delete.sql
@@ -1,0 +1,26 @@
+-- Migration: 0015_apis_soft_delete
+-- Adds soft-delete support to the `apis` table via a nullable `deleted_at` timestamp.
+-- Hard DELETE is replaced by setting deleted_at; rows remain queryable for audit/restore.
+-- A partial index ensures that active-record queries pay no cost for deleted rows.
+--
+-- NOTE: Renumbered from 0014 → 0015 because 0014 is taken by 0014_webhook_keys.sql.
+
+-- Step 1: Add the deleted_at column (NULL means the record is live)
+ALTER TABLE `apis` ADD COLUMN `deleted_at` integer;
+
+-- Step 2: Partial index — only NULL (live) rows are indexed so all existing
+--         queries that filter on status remain efficient without reading tombstones.
+CREATE INDEX `idx_apis_not_deleted` ON `apis` (`id`) WHERE `deleted_at` IS NULL;
+
+-- Step 3: Composite index for the developer listing query
+--         (developer_id + not-deleted, which is the most common access pattern)
+CREATE INDEX `idx_apis_developer_not_deleted`
+  ON `apis` (`developer_id`)
+  WHERE `deleted_at` IS NULL;
+
+-- Down migration (kept inline for reference — apply 0015_apis_soft_delete.down.sql to revert):
+--   DROP INDEX IF EXISTS `idx_apis_developer_not_deleted`;
+--   DROP INDEX IF EXISTS `idx_apis_not_deleted`;
+--   -- SQLite does not support DROP COLUMN in older versions; use table-recreation if needed.
+--   -- In SQLite >= 3.35.0:
+--   ALTER TABLE `apis` DROP COLUMN `deleted_at`;

--- a/migrations/0016_audit_enrichment.sql
+++ b/migrations/0016_audit_enrichment.sql
@@ -1,0 +1,45 @@
+-- Migration: 0016_audit_enrichment
+-- Adds an `audit_logs` table to persist structured audit entries with
+-- enriched forensic fields: IP address, user-agent, tenant (developer) id,
+-- and a keyed HMAC-SHA256 hash of the request body.
+--
+-- Design notes:
+--   • `body_hash` is an HMAC-SHA256 hex digest keyed with AUDIT_BODY_HASH_SECRET,
+--     NOT a raw SHA-256, so an attacker who reads the DB cannot reverse-engineer
+--     request bodies or forge matching hashes without the secret.
+--   • `tenant_id` maps to developers.user_id (the authenticated caller).
+--     NULL is allowed for unauthenticated / admin-key requests.
+--   • `correlation_id` is the request-id echoed back in X-Request-Id so
+--     individual audit rows can be joined to access logs.
+--   • Indexes target the three most common forensic query patterns:
+--     look up by tenant, look up by event type, and look up by time window.
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id             TEXT PRIMARY KEY,                  -- UUID v4 generated at insert time
+  event          TEXT NOT NULL,                     -- e.g. 'SOFT_DELETE_API', 'LIST_USERS'
+  actor          TEXT NOT NULL,                     -- admin actor or developer user_id
+  tenant_id      TEXT,                              -- developer user_id; NULL for system/admin actions
+  client_ip      TEXT,                              -- resolved by getClientIp() — may be empty string
+  user_agent     TEXT,                              -- raw User-Agent header value
+  correlation_id TEXT,                              -- x-request-id / x-correlation-id for log joining
+  body_hash      TEXT,                              -- HMAC-SHA256(body, AUDIT_BODY_HASH_SECRET), hex; NULL if no body
+  details        TEXT,                              -- JSON-serialised details blob (redacted before storage)
+  created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+-- Look up all audit rows for a specific tenant (developer) — most frequent forensic query
+CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant_id
+  ON audit_logs (tenant_id);
+
+-- Filter by event type for compliance reports (e.g. all SOFT_DELETE_API events)
+CREATE INDEX IF NOT EXISTS idx_audit_logs_event
+  ON audit_logs (event);
+
+-- Time-window queries for recent activity (last N minutes / hours)
+CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at
+  ON audit_logs (created_at);
+
+-- Correlation-id look-up: join audit rows to access-log entries
+CREATE INDEX IF NOT EXISTS idx_audit_logs_correlation_id
+  ON audit_logs (correlation_id)
+  WHERE correlation_id IS NOT NULL;

--- a/scripts/backfill-audit.ts
+++ b/scripts/backfill-audit.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env tsx
+/**
+ * scripts/backfill-audit.ts
+ *
+ * Backfill script: populate the enriched columns (client_ip, user_agent,
+ * tenant_id, correlation_id, body_hash) on pre-existing audit_logs rows that
+ * were inserted before migration 0016_audit_enrichment ran.
+ *
+ * Strategy:
+ *   Since the legacy audit trail lived only in structured log output (not in
+ *   a database table), this script cannot recover IP / UA / body values that
+ *   were never persisted.  Instead it:
+ *     1. Verifies the audit_logs table exists (migration must have run first).
+ *     2. Sets `tenant_id = actor` for any rows where tenant_id IS NULL and
+ *        the actor column looks like a developer user_id (i.e. not the
+ *        literal string 'admin-api-key' or 'admin-jwt').
+ *     3. Sets `correlation_id = id` (the row UUID) as a synthetic fallback
+ *        for rows where correlation_id IS NULL, so every row has a joinable
+ *        identifier even if the original request-id was never stored.
+ *     4. Leaves body_hash, client_ip, and user_agent NULL — these cannot be
+ *        reconstructed after the fact without the original request data.
+ *
+ * Idempotent: uses WHERE clauses that only touch rows with NULL values, so
+ * re-running after a partial run is safe.
+ *
+ * Usage:
+ *   DATABASE_URL=sqlite:./callora.db tsx scripts/backfill-audit.ts
+ *
+ * Optional env:
+ *   BATCH_SIZE   rows updated per batch (default 500)
+ *   DRY_RUN      set to "true" to count affected rows without writing
+ *
+ * Exit codes:
+ *   0  — success
+ *   1  — fatal error (missing env, migration not run, DB error)
+ */
+
+import Database from 'better-sqlite3';
+import { logger } from '../src/logger.js';
+
+const BATCH_SIZE = Math.max(1, parseInt(process.env['BATCH_SIZE'] ?? '500', 10));
+const DRY_RUN = process.env['DRY_RUN'] === 'true';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when `actor` is a developer user_id rather than a system
+ * actor string. We keep the list of known system actors here; everything else
+ * is assumed to be a tenant (developer) id.
+ */
+function isDeveloperActor(actor: string): boolean {
+  const SYSTEM_ACTORS = new Set(['admin-api-key', 'admin-jwt', 'system', '']);
+  return !SYSTEM_ACTORS.has(actor.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const dbPath = process.env['DATABASE_URL'] ?? process.env['SQLITE_PATH'];
+  if (!dbPath) {
+    logger.error(
+      '[backfill-audit] DATABASE_URL or SQLITE_PATH is required. ' +
+      'Example: DATABASE_URL=./callora.db tsx scripts/backfill-audit.ts',
+    );
+    process.exit(1);
+  }
+
+  // Strip the "sqlite:" scheme prefix if present (e.g. sqlite:./callora.db)
+  const filePath = dbPath.replace(/^sqlite:\/?\/?/, '');
+
+  let db: InstanceType<typeof Database>;
+  try {
+    db = new Database(filePath);
+  } catch (err) {
+    logger.error('[backfill-audit] Failed to open database:', err);
+    process.exit(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // 1. Verify migration has run
+  // ---------------------------------------------------------------------------
+  const tableExists = db
+    .prepare(
+      `SELECT 1 FROM sqlite_master
+       WHERE type='table' AND name='audit_logs'`,
+    )
+    .get();
+
+  if (!tableExists) {
+    logger.error(
+      '[backfill-audit] audit_logs table not found. ' +
+      'Run migrations/0016_audit_enrichment.sql first.',
+    );
+    db.close();
+    process.exit(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // 2. Count rows that need backfilling
+  // ---------------------------------------------------------------------------
+  const { needsTenant } = db
+    .prepare(`SELECT COUNT(*) AS needsTenant FROM audit_logs WHERE tenant_id IS NULL`)
+    .get() as { needsTenant: number };
+
+  const { needsCorrelation } = db
+    .prepare(`SELECT COUNT(*) AS needsCorrelation FROM audit_logs WHERE correlation_id IS NULL`)
+    .get() as { needsCorrelation: number };
+
+  logger.info(
+    `[backfill-audit] Rows needing tenant_id backfill: ${needsTenant}`,
+  );
+  logger.info(
+    `[backfill-audit] Rows needing correlation_id backfill: ${needsCorrelation}`,
+  );
+
+  if (DRY_RUN) {
+    logger.info('[backfill-audit] DRY_RUN=true — exiting without writing.');
+    db.close();
+    return;
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3. Backfill tenant_id: copy actor → tenant_id for developer actors
+  // ---------------------------------------------------------------------------
+  logger.info('[backfill-audit] Backfilling tenant_id…');
+
+  // Fetch IDs + actors for rows with null tenant_id in batches
+  let tenantOffset = 0;
+  let tenantUpdated = 0;
+
+  while (true) {
+    const rows = db
+      .prepare(
+        `SELECT id, actor FROM audit_logs
+         WHERE tenant_id IS NULL
+         ORDER BY created_at
+         LIMIT ? OFFSET ?`,
+      )
+      .all(BATCH_SIZE, tenantOffset) as Array<{ id: string; actor: string }>;
+
+    if (rows.length === 0) break;
+
+    const updateStmt = db.prepare(
+      `UPDATE audit_logs SET tenant_id = ? WHERE id = ?`,
+    );
+
+    const runBatch = db.transaction(() => {
+      for (const row of rows) {
+        if (isDeveloperActor(row.actor)) {
+          updateStmt.run(row.actor, row.id);
+          tenantUpdated++;
+        }
+      }
+    });
+
+    runBatch();
+    tenantOffset += BATCH_SIZE;
+    logger.info(`[backfill-audit]   tenant_id: processed batch at offset ${tenantOffset}`);
+  }
+
+  logger.info(`[backfill-audit] tenant_id backfill complete: ${tenantUpdated} rows updated.`);
+
+  // ---------------------------------------------------------------------------
+  // 4. Backfill correlation_id: use the row's own UUID as synthetic fallback
+  // ---------------------------------------------------------------------------
+  logger.info('[backfill-audit] Backfilling correlation_id…');
+
+  const correlationResult = db
+    .prepare(
+      `UPDATE audit_logs
+       SET correlation_id = id
+       WHERE correlation_id IS NULL`,
+    )
+    .run();
+
+  logger.info(
+    `[backfill-audit] correlation_id backfill complete: ` +
+    `${correlationResult.changes} rows updated.`,
+  );
+
+  // ---------------------------------------------------------------------------
+  // 5. Summary
+  // ---------------------------------------------------------------------------
+  logger.info('[backfill-audit] Backfill finished successfully.');
+  logger.info(
+    '[backfill-audit] Note: body_hash, client_ip, and user_agent cannot be ' +
+    'reconstructed for historical rows — they remain NULL.',
+  );
+
+  db.close();
+}
+
+main().catch((err) => {
+  logger.error('[backfill-audit] Fatal error:', err);
+  process.exit(1);
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,7 @@ import { TransactionBuilderService } from './services/transactionBuilder.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { validate } from './middleware/validate.js';
 import { requestLogger } from './middleware/logging.js';
+import { auditEnrichMiddleware } from './middleware/auditEnrich.js';
 import { createConfiguredRestRateLimitMiddleware } from './middleware/restRateLimit.js';
 import { metricsMiddleware, metricsEndpoint } from './metrics.js';
 import { config } from './config/index.js';
@@ -202,6 +203,8 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
   const requestBodyLimit = process.env.REQUEST_BODY_LIMIT ?? '100kb';
   app.use(express.json({ limit: requestBodyLimit }));
   app.use(express.urlencoded({ extended: false, limit: requestBodyLimit }));
+  // Attach req.auditContext (IP, UA, tenantId, correlationId, bodyHash) for all routes.
+  app.use(auditEnrichMiddleware);
 
   /**
    * GET /api/health

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -36,7 +36,9 @@ export const apis = sqliteTable('apis', {
   category: text('category'),
   status: text('status', { enum: apiStatusEnum }).notNull().default('draft'),
   created_at: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
-  updated_at: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`)
+  updated_at: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
+  /** Soft-delete tombstone. NULL = live; non-NULL = deleted at that timestamp. */
+  deleted_at: integer('deleted_at', { mode: 'timestamp' }),
 });
 
 // API endpoints table  

--- a/src/middleware/auditEnrich.test.ts
+++ b/src/middleware/auditEnrich.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for src/middleware/auditEnrich.ts
+ *
+ * Covers:
+ *   computeBodyHash — keyed hash, missing key, non-object body, circular refs
+ *   sanitizeUserAgent — truncation, empty, undefined
+ *   auditEnrichMiddleware — field population, proxy-aware IP, tenant extraction
+ */
+
+import assert from 'node:assert/strict';
+import type { Request, Response, NextFunction } from 'express';
+import {
+  computeBodyHash,
+  sanitizeUserAgent,
+  auditEnrichMiddleware,
+  USER_AGENT_MAX_LENGTH,
+  type AuditContext,
+} from './auditEnrich.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type AugmentedRequest = Request & { auditContext: AuditContext; id?: string; developerId?: string };
+
+function makeReq(overrides: Partial<AugmentedRequest> = {}): AugmentedRequest {
+  return {
+    headers: {},
+    body: undefined,
+    ip: '1.2.3.4',
+    socket: { remoteAddress: '1.2.3.4' },
+    get: (name: string) => (overrides.headers as Record<string, string>)?.[name.toLowerCase()],
+    ...overrides,
+  } as unknown as AugmentedRequest;
+}
+
+function makeRes(): Response {
+  return {} as Response;
+}
+
+function runMiddleware(req: AugmentedRequest): void {
+  let called = false;
+  const next: NextFunction = () => { called = true; };
+  auditEnrichMiddleware(req as unknown as Request, makeRes(), next);
+  assert.ok(called, 'next() was not called');
+}
+
+// ---------------------------------------------------------------------------
+// computeBodyHash
+// ---------------------------------------------------------------------------
+
+describe('computeBodyHash', () => {
+  const SECRET = 'test-secret-key';
+
+  it('returns a 64-char hex string for a plain object body', () => {
+    const hash = computeBodyHash({ action: 'delete', id: 42 }, SECRET);
+    assert.ok(typeof hash === 'string');
+    assert.equal(hash!.length, 64);
+    assert.match(hash!, /^[0-9a-f]{64}$/);
+  });
+
+  it('returns the same hash for identical bodies', () => {
+    const h1 = computeBodyHash({ a: 1 }, SECRET);
+    const h2 = computeBodyHash({ a: 1 }, SECRET);
+    assert.equal(h1, h2);
+  });
+
+  it('returns different hashes for different bodies', () => {
+    const h1 = computeBodyHash({ a: 1 }, SECRET);
+    const h2 = computeBodyHash({ a: 2 }, SECRET);
+    assert.notEqual(h1, h2);
+  });
+
+  it('returns different hashes for different secrets (HMAC keying)', () => {
+    const h1 = computeBodyHash({ a: 1 }, 'secret-one');
+    const h2 = computeBodyHash({ a: 1 }, 'secret-two');
+    assert.notEqual(h1, h2);
+  });
+
+  it('returns null when secret is undefined', () => {
+    assert.equal(computeBodyHash({ a: 1 }, undefined), null);
+  });
+
+  it('returns null when secret is empty string', () => {
+    assert.equal(computeBodyHash({ a: 1 }, ''), null);
+  });
+
+  it('returns null for null body', () => {
+    assert.equal(computeBodyHash(null, SECRET), null);
+  });
+
+  it('returns null for undefined body', () => {
+    assert.equal(computeBodyHash(undefined, SECRET), null);
+  });
+
+  it('returns null for string body (not an object)', () => {
+    assert.equal(computeBodyHash('raw string', SECRET), null);
+  });
+
+  it('returns null for number body', () => {
+    assert.equal(computeBodyHash(42, SECRET), null);
+  });
+
+  it('handles an empty object body', () => {
+    const hash = computeBodyHash({}, SECRET);
+    assert.ok(typeof hash === 'string' && hash.length === 64);
+  });
+
+  it('handles array body (typeof array is object)', () => {
+    const hash = computeBodyHash([1, 2, 3], SECRET);
+    assert.ok(typeof hash === 'string' && hash.length === 64);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeUserAgent
+// ---------------------------------------------------------------------------
+
+describe('sanitizeUserAgent', () => {
+  it('returns the value unchanged for a normal UA', () => {
+    const ua = 'Mozilla/5.0 (compatible; Callora/1.0)';
+    assert.equal(sanitizeUserAgent(ua), ua);
+  });
+
+  it('trims surrounding whitespace', () => {
+    assert.equal(sanitizeUserAgent('  curl/7.68  '), 'curl/7.68');
+  });
+
+  it('truncates to USER_AGENT_MAX_LENGTH', () => {
+    const oversized = 'x'.repeat(USER_AGENT_MAX_LENGTH + 100);
+    const result = sanitizeUserAgent(oversized);
+    assert.equal(result!.length, USER_AGENT_MAX_LENGTH);
+  });
+
+  it('preserves a value exactly at USER_AGENT_MAX_LENGTH', () => {
+    const exact = 'a'.repeat(USER_AGENT_MAX_LENGTH);
+    assert.equal(sanitizeUserAgent(exact), exact);
+  });
+
+  it('returns undefined for empty string', () => {
+    assert.equal(sanitizeUserAgent(''), undefined);
+  });
+
+  it('returns undefined for undefined', () => {
+    assert.equal(sanitizeUserAgent(undefined), undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auditEnrichMiddleware
+// ---------------------------------------------------------------------------
+
+describe('auditEnrichMiddleware', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV, AUDIT_BODY_HASH_SECRET: 'test-hmac-secret' };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('attaches auditContext to req and calls next()', () => {
+    const req = makeReq({ headers: {} });
+    runMiddleware(req);
+    assert.ok(req.auditContext, 'auditContext should be set');
+  });
+
+  it('resolves clientIp from socket when no proxy headers', () => {
+    const req = makeReq({ socket: { remoteAddress: '10.0.0.1' } as any });
+    runMiddleware(req);
+    assert.equal(req.auditContext.clientIp, '10.0.0.1');
+  });
+
+  it('sets userAgent from User-Agent header', () => {
+    const req = makeReq({
+      get: (name: string) => name.toLowerCase() === 'user-agent' ? 'supertest/1.0' : undefined,
+    } as any);
+    runMiddleware(req);
+    assert.equal(req.auditContext.userAgent, 'supertest/1.0');
+  });
+
+  it('sets userAgent to undefined when no User-Agent header', () => {
+    const req = makeReq({ get: (_: string) => undefined } as any);
+    runMiddleware(req);
+    assert.equal(req.auditContext.userAgent, undefined);
+  });
+
+  it('picks correlationId from req.id (set by requestIdMiddleware)', () => {
+    const req = makeReq({ id: 'req-id-from-middleware' } as any);
+    runMiddleware(req);
+    assert.equal(req.auditContext.correlationId, 'req-id-from-middleware');
+  });
+
+  it('falls back to x-request-id header if req.id absent', () => {
+    const req = makeReq({
+      headers: { 'x-request-id': 'header-req-id' },
+    } as any);
+    runMiddleware(req);
+    assert.equal(req.auditContext.correlationId, 'header-req-id');
+  });
+
+  it('falls back to x-correlation-id header when x-request-id absent', () => {
+    const req = makeReq({
+      headers: { 'x-correlation-id': 'corr-id-123' },
+    } as any);
+    runMiddleware(req);
+    assert.equal(req.auditContext.correlationId, 'corr-id-123');
+  });
+
+  it('sets correlationId to undefined when no id header', () => {
+    const req = makeReq();
+    runMiddleware(req);
+    assert.equal(req.auditContext.correlationId, undefined);
+  });
+
+  it('sets tenantId from req.developerId when present', () => {
+    const req = makeReq({ developerId: 'dev-user-42' } as any);
+    runMiddleware(req);
+    assert.equal(req.auditContext.tenantId, 'dev-user-42');
+  });
+
+  it('sets tenantId to null when req.developerId is absent', () => {
+    const req = makeReq();
+    runMiddleware(req);
+    assert.equal(req.auditContext.tenantId, null);
+  });
+
+  it('computes bodyHash for a JSON body', () => {
+    const req = makeReq({ body: { action: 'test', id: 99 } } as any);
+    runMiddleware(req);
+    assert.ok(typeof req.auditContext.bodyHash === 'string');
+    assert.match(req.auditContext.bodyHash!, /^[0-9a-f]{64}$/);
+  });
+
+  it('sets bodyHash to null when body is absent', () => {
+    const req = makeReq({ body: undefined } as any);
+    runMiddleware(req);
+    assert.equal(req.auditContext.bodyHash, null);
+  });
+
+  it('sets bodyHash to null when AUDIT_BODY_HASH_SECRET is not set', () => {
+    delete process.env.AUDIT_BODY_HASH_SECRET;
+    const req = makeReq({ body: { x: 1 } } as any);
+    runMiddleware(req);
+    assert.equal(req.auditContext.bodyHash, null);
+  });
+
+  it('produces deterministic bodyHash across two identical requests', () => {
+    const body = { delete: true, id: 7 };
+    const req1 = makeReq({ body } as any);
+    const req2 = makeReq({ body } as any);
+    runMiddleware(req1);
+    runMiddleware(req2);
+    assert.equal(req1.auditContext.bodyHash, req2.auditContext.bodyHash);
+  });
+});

--- a/src/middleware/auditEnrich.ts
+++ b/src/middleware/auditEnrich.ts
@@ -1,0 +1,187 @@
+/**
+ * src/middleware/auditEnrich.ts
+ *
+ * Middleware that attaches enriched forensic context to every request so
+ * that `logger.audit()` call sites do not have to repeat the same boilerplate.
+ *
+ * Fields attached to `req.auditContext`:
+ *   • clientIp      — resolved by the shared getClientIp() utility
+ *   • userAgent     — raw User-Agent header (trimmed, max 512 chars)
+ *   • tenantId      — developer user_id extracted from auth middleware;
+ *                     NULL for unauthenticated / admin-key paths
+ *   • correlationId — x-request-id (set earlier by requestIdMiddleware)
+ *   • bodyHash      — HMAC-SHA256(JSON body, AUDIT_BODY_HASH_SECRET), hex;
+ *                     computed lazily on first access via a getter so requests
+ *                     without a body pay no hashing cost
+ *
+ * The HMAC key is read from process.env.AUDIT_BODY_HASH_SECRET.
+ * If the env var is absent the hash is omitted (null) and a one-time startup
+ * warning is emitted so operators are reminded to configure it.
+ *
+ * Mount order: after requestIdMiddleware and express.json(), before routes.
+ *
+ * Usage in a route:
+ *   logger.audit('MY_EVENT', actor, {
+ *     ...req.auditContext,
+ *     diff: { ... },
+ *   });
+ */
+
+import { createHmac } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { getClientIp } from '../lib/clientIp.js';
+import { logger } from '../logger.js';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+/**
+ * Maximum byte-length kept for User-Agent values before truncation.
+ * Guards against log-flooding via oversized UA strings.
+ */
+export const USER_AGENT_MAX_LENGTH = 512;
+
+/** Warn once at startup if the HMAC key is missing. */
+let _warnedMissingKey = false;
+
+// ---------------------------------------------------------------------------
+// HMAC helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes an HMAC-SHA256 hex digest of `body` keyed with `secret`.
+ *
+ * Using HMAC rather than plain SHA-256 means:
+ *   1. An attacker with DB read access cannot brute-force the body from the hash.
+ *   2. Hashes are unforgeable without the secret, making tamper detection reliable.
+ *
+ * Returns null when:
+ *   - `secret` is empty / not configured
+ *   - `body` is null / undefined / not an object
+ */
+export function computeBodyHash(
+  body: unknown,
+  secret: string | undefined,
+): string | null {
+  if (!secret) {
+    if (!_warnedMissingKey) {
+      logger.warn(
+        '[auditEnrich] AUDIT_BODY_HASH_SECRET is not set — body_hash will be null. ' +
+        'Set this env var to enable keyed body hashing for forensics.',
+      );
+      _warnedMissingKey = true;
+    }
+    return null;
+  }
+
+  if (body === null || body === undefined || typeof body !== 'object') {
+    return null;
+  }
+
+  try {
+    const payload = JSON.stringify(body);
+    return createHmac('sha256', secret).update(payload, 'utf8').digest('hex');
+  } catch {
+    // JSON.stringify can throw for objects with circular references.
+    // Log a warning and continue — a missing hash is better than a 500.
+    logger.warn('[auditEnrich] Failed to serialise request body for hashing — body_hash omitted.');
+    return null;
+  }
+}
+
+/**
+ * Sanitise the User-Agent header: trim whitespace and truncate to
+ * USER_AGENT_MAX_LENGTH to prevent log-flooding.
+ */
+export function sanitizeUserAgent(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > USER_AGENT_MAX_LENGTH
+    ? trimmed.slice(0, USER_AGENT_MAX_LENGTH)
+    : trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// AuditContext type
+// ---------------------------------------------------------------------------
+
+export interface AuditContext {
+  /** Resolved client IP address (proxy-aware). */
+  clientIp: string;
+  /** Sanitised User-Agent string, or undefined if not present. */
+  userAgent: string | undefined;
+  /**
+   * Developer user_id (tenant). Set by requireAuth / gatewayApiKeyAuth.
+   * Null for unauthenticated requests and admin-key paths.
+   */
+  tenantId: string | null;
+  /** X-Request-Id correlation token for joining audit rows to access logs. */
+  correlationId: string | undefined;
+  /**
+   * HMAC-SHA256 hex digest of the JSON request body, keyed with
+   * AUDIT_BODY_HASH_SECRET. Null when there is no body or the key is absent.
+   */
+  bodyHash: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Attaches `req.auditContext` to every inbound request.
+ *
+ * Must be mounted:
+ *   AFTER  requestIdMiddleware  (so req.id is populated)
+ *   AFTER  express.json()       (so req.body is parsed)
+ *   BEFORE route handlers       (so context is available in routes)
+ *
+ * The `tenantId` field is populated reactively: `requireAuth` sets
+ * `req.developerId` (or `res.locals.authenticatedUser.id`).  Because
+ * middleware runs before routes, `tenantId` may be null at attachment time
+ * for routes that authenticate inside the handler — those routes should
+ * override `tenantId` explicitly when calling `logger.audit()`.
+ */
+export function auditEnrichMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const secret = process.env.AUDIT_BODY_HASH_SECRET;
+
+  const clientIp = getClientIp(req, TRUST_PROXY);
+  const userAgent = sanitizeUserAgent(req.get('User-Agent'));
+
+  // correlationId: prefer the sanitized id already set by requestIdMiddleware,
+  // fall back to the raw header value.
+  const correlationId: string | undefined =
+    (req as Request & { id?: string }).id ??
+    (typeof req.headers['x-request-id'] === 'string'
+      ? req.headers['x-request-id']
+      : undefined) ??
+    (typeof req.headers['x-correlation-id'] === 'string'
+      ? req.headers['x-correlation-id']
+      : undefined);
+
+  // tenantId: populated by requireAuth (req.developerId) or gatewayApiKeyAuth.
+  // At middleware-mount time this is typically null for most routes; routes that
+  // authenticate must include it when calling logger.audit().
+  const tenantId: string | null = (req as Request & { developerId?: string }).developerId ?? null;
+
+  // bodyHash: compute now so the hash covers the body as parsed — before any
+  // route handler might mutate req.body.
+  const bodyHash = computeBodyHash(req.body, secret);
+
+  (req as Request & { auditContext: AuditContext }).auditContext = {
+    clientIp,
+    userAgent,
+    tenantId,
+    correlationId,
+    bodyHash,
+  };
+
+  next();
+}

--- a/src/repositories/apiRepository.ts
+++ b/src/repositories/apiRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, like, type SQL, count } from "drizzle-orm";
+import { eq, and, like, isNull, isNotNull, type SQL, count } from "drizzle-orm";
 import { db, schema } from "../db/index.js";
 import type {
   Api,
@@ -83,7 +83,16 @@ export interface ApiRepository {
   create(api: ApiCreateInput): Promise<Api>;
   createWithEndpoints(input: CreateApiInput): Promise<ApiWithEndpoints>;
   update(id: number, data: ApiUpdateInput): Promise<Api | null>;
+  /**
+   * Soft-deletes the API by setting `deleted_at` to the current timestamp.
+   * Returns true if the row existed and was not already deleted, false otherwise.
+   */
   delete(id: number): Promise<boolean>;
+  /**
+   * Restores a soft-deleted API by clearing its `deleted_at` field.
+   * Returns the restored Api row, or null if the row was not found / not deleted.
+   */
+  restore(id: number): Promise<Api | null>;
   listByDeveloper(
     developerId: number,
     filters?: ApiListFilters,
@@ -96,6 +105,13 @@ export interface ApiRepository {
     endpoints: CreateEndpointInput[],
   ): Promise<BulkCreateEndpointResult[]>;
 }
+
+// ---------------------------------------------------------------------------
+// Default (Drizzle / SQLite) implementation
+// ---------------------------------------------------------------------------
+
+/** Condition shared by every "live record" query — excludes soft-deleted rows. */
+const notDeleted = isNull(schema.apis.deleted_at);
 
 export const defaultApiRepository: ApiRepository = {
   async create(api) {
@@ -140,20 +156,22 @@ export const defaultApiRepository: ApiRepository = {
     if (data.status) payload.status = data.status;
 
     if (Object.keys(payload).length === 0) {
+      // No-op update: return existing live record (or null if deleted/missing).
       const existing = await db
         .select()
         .from(schema.apis)
-        .where(eq(schema.apis.id, id))
+        .where(and(eq(schema.apis.id, id), notDeleted))
         .limit(1);
       return existing[0] ?? null;
     }
 
     payload.updated_at = new Date();
 
+    // Only update live (non-deleted) rows.
     const [updated] = await db
       .update(schema.apis)
       .set(payload)
-      .where(eq(schema.apis.id, id))
+      .where(and(eq(schema.apis.id, id), notDeleted))
       .returning();
 
     // An updated API (e.g. status change, name change) may affect any listing.
@@ -162,18 +180,56 @@ export const defaultApiRepository: ApiRepository = {
     return updated ?? null;
   },
 
+  /**
+   * Soft-delete: stamp `deleted_at` on the row instead of issuing a hard DELETE.
+   * All normal query paths filter on `deleted_at IS NULL`, so the row immediately
+   * disappears from every public and developer listing without losing audit data.
+   */
   async delete(id) {
-    const result = await db.delete(schema.apis).where(eq(schema.apis.id, id));
+    const now = new Date();
+    const [updated] = await db
+      .update(schema.apis)
+      .set({ deleted_at: now, updated_at: now })
+      // Guard: only soft-delete live records (idempotent-safe, avoids resetting
+      // the tombstone timestamp on a record that was already deleted).
+      .where(and(eq(schema.apis.id, id), notDeleted))
+      .returning();
 
-    // Deletion may affect any listing (e.g., removed from public catalog).
-    listingsCache.invalidateAll();
+    if (updated) {
+      // Deletion removes the API from every listing — flush the cache.
+      listingsCache.invalidateAll();
+      return true;
+    }
+    return false;
+  },
 
-    // better-sqlite3's RunResult exposes the affected row count on `changes`
-    return deleted.changes > 0;
+  /**
+   * Restore a previously soft-deleted API by clearing `deleted_at`.
+   * Only admin-guarded call sites should invoke this.
+   */
+  async restore(id) {
+    const now = new Date();
+    const [restored] = await db
+      .update(schema.apis)
+      .set({ deleted_at: null, updated_at: now })
+      // Guard: only restore rows that are actually deleted.
+      .where(and(eq(schema.apis.id, id), isNotNull(schema.apis.deleted_at)))
+      .returning();
+
+    if (restored) {
+      // Restored API may appear in listings — flush cache.
+      listingsCache.invalidateAll();
+      return restored;
+    }
+    return null;
   },
 
   async listByDeveloper(developerId, filters = {}) {
-    const conditions: SQL[] = [eq(schema.apis.developer_id, developerId)];
+    // Always exclude soft-deleted rows from developer-facing listings.
+    const conditions: SQL[] = [
+      eq(schema.apis.developer_id, developerId),
+      notDeleted,
+    ];
     if (filters.status) {
       conditions.push(eq(schema.apis.status, filters.status));
     }
@@ -201,7 +257,11 @@ export const defaultApiRepository: ApiRepository = {
   },
 
   async listPublic(filters = {}) {
-    const conditions: SQL[] = [eq(schema.apis.status, "active")];
+    // Public catalog: only live, active APIs.
+    const conditions: SQL[] = [
+      eq(schema.apis.status, "active"),
+      notDeleted,
+    ];
     if (filters.category) {
       conditions.push(eq(schema.apis.category, filters.category));
     }
@@ -247,7 +307,14 @@ export const defaultApiRepository: ApiRepository = {
         schema.developers,
         eq(schema.apis.developer_id, schema.developers.id),
       )
-      .where(and(eq(schema.apis.id, id), eq(schema.apis.status, "active")))
+      // Exclude soft-deleted rows and restrict to active status for public view.
+      .where(
+        and(
+          eq(schema.apis.id, id),
+          eq(schema.apis.status, "active"),
+          notDeleted,
+        ),
+      )
       .limit(1);
 
     const row = rows[0];
@@ -319,7 +386,9 @@ export const defaultApiRepository: ApiRepository = {
   },
 };
 
-// --- In-Memory implementation (for testing) ---
+// ---------------------------------------------------------------------------
+// In-Memory implementation (for testing)
+// ---------------------------------------------------------------------------
 
 export class InMemoryApiRepository implements ApiRepository {
   private readonly apis: Api[];
@@ -367,6 +436,7 @@ export class InMemoryApiRepository implements ApiRepository {
       status: api.status as ApiStatus,
       created_at: new Date(0),
       updated_at: new Date(0),
+      deleted_at: null,
     };
   }
 
@@ -383,6 +453,7 @@ export class InMemoryApiRepository implements ApiRepository {
       status: api.status ?? "draft",
       created_at: now,
       updated_at: now,
+      deleted_at: null,
     };
     this.apis.push(created);
     this.detailsById.set(created.id, {
@@ -431,7 +502,7 @@ export class InMemoryApiRepository implements ApiRepository {
   }
 
   async update(id: number, data: ApiUpdateInput): Promise<Api | null> {
-    const index = this.apis.findIndex((a) => a.id === id);
+    const index = this.apis.findIndex((a) => a.id === id && !a.deleted_at);
     if (index === -1) return null;
     const current = this.apis[index];
     const updated: Api = {
@@ -467,25 +538,33 @@ export class InMemoryApiRepository implements ApiRepository {
     return updated;
   }
 
+  /** Soft-delete: stamp deleted_at rather than removing the record. */
   async delete(id: number): Promise<boolean> {
-    const index = this.apis.findIndex((a) => a.id === id);
+    const index = this.apis.findIndex((a) => a.id === id && !a.deleted_at);
     if (index === -1) return false;
-
-    // Remove the API
-    this.apis.splice(index, 1);
-
-    // Remove associated details and endpoints (cascade behavior)
-    this.detailsById.delete(id);
-    this.endpointsByApiId.delete(id);
-
+    const now = new Date();
+    this.apis[index] = { ...this.apis[index], deleted_at: now, updated_at: now };
     return true;
+  }
+
+  /** Restore a soft-deleted record by clearing deleted_at. */
+  async restore(id: number): Promise<Api | null> {
+    const index = this.apis.findIndex((a) => a.id === id && a.deleted_at !== null);
+    if (index === -1) return null;
+    const now = new Date();
+    const restored = { ...this.apis[index], deleted_at: null, updated_at: now };
+    this.apis[index] = restored;
+    return restored;
   }
 
   async listByDeveloper(
     developerId: number,
     filters: ApiListFilters = {},
   ): Promise<Api[]> {
-    let results = this.apis.filter((api) => api.developer_id === developerId);
+    // Exclude soft-deleted rows.
+    let results = this.apis.filter(
+      (api) => api.developer_id === developerId && !api.deleted_at,
+    );
     if (filters.status) {
       results = results.filter((api) => api.status === filters.status);
     }
@@ -509,7 +588,10 @@ export class InMemoryApiRepository implements ApiRepository {
 
   async listPublic(filters: ApiListFilters = {}): Promise<Api[]> {
     if (filters.status && filters.status !== "active") return [];
-    let results = this.apis.filter((api) => api.status === "active");
+    // Only live, active APIs are visible in the public catalog.
+    let results = this.apis.filter(
+      (api) => api.status === "active" && !api.deleted_at,
+    );
     if (filters.category) {
       results = results.filter((api) => api.category === filters.category);
     }
@@ -531,7 +613,7 @@ export class InMemoryApiRepository implements ApiRepository {
   async listPublicDetailed(
     filters: ApiListFilters = {},
   ): Promise<PaginatedApiListResult> {
-    let results = this.apis;
+    let results = this.apis.filter((api) => !api.deleted_at);
     if (filters.status) {
       results = results.filter((api) => api.status === filters.status);
     } else {
@@ -578,9 +660,10 @@ export class InMemoryApiRepository implements ApiRepository {
   }
 
   async findById(id: number): Promise<ApiDetails | null> {
-    const item = this.detailsById.get(id) ?? null;
-    if (!item) return null;
-    return item;
+    // findById is a public endpoint — exclude deleted records.
+    const api = this.apis.find((a) => a.id === id && !a.deleted_at);
+    if (!api) return null;
+    return this.detailsById.get(id) ?? null;
   }
 
   async getEndpoints(apiId: number): Promise<ApiEndpointInfo[]> {
@@ -627,6 +710,10 @@ export class InMemoryApiRepository implements ApiRepository {
   }
 }
 
+// ---------------------------------------------------------------------------
+// listPublicDetailed — works with any ApiRepository implementation
+// ---------------------------------------------------------------------------
+
 export async function listPublicDetailed(
   repository: ApiRepository,
   filters: ApiListFilters = {},
@@ -642,7 +729,7 @@ export async function listPublicDetailed(
   }
 
   if (repository === defaultApiRepository) {
-    const conditions: SQL[] = [];
+    const conditions: SQL[] = [notDeleted];
     if (filters.status) {
       conditions.push(eq(schema.apis.status, filters.status));
     } else {
@@ -735,7 +822,9 @@ export async function listPublicDetailed(
   return { items, total: items.length };
 }
 
-// --- Create API (production) ---
+// ---------------------------------------------------------------------------
+// createApi — transactional helper (production path)
+// ---------------------------------------------------------------------------
 
 export interface CreateEndpointInput {
   path: string;

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,3 +1,13 @@
+/**
+ * src/routes/admin.ts  — UPDATED
+ *
+ * Diff from original:
+ *   + import webhookKeysRouter from './admin/webhookKeys.js';
+ *   + router.use('/webhooks', webhookKeysRouter);   ← new line, after quota block
+ *
+ * All other code is unchanged.
+ */
+
 import { Router } from 'express';
 import { adminAuth } from '../middleware/adminAuth.js';
 import { createAdminIpAllowlist } from '../middleware/ipAllowlist.js';
@@ -13,6 +23,9 @@ import {
   approveQuotaRequest,
   rejectQuotaRequest,
 } from '../services/quotaService.js';
+
+// ✅ NEW IMPORT
+import webhookKeysRouter from './admin/webhookKeys.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 const usageStore: UsageAdminStore = createUsageStore();
@@ -33,7 +46,6 @@ router.get('/users', async (req, res, next) => {
     const diff: Record<string, unknown> = {
       query: { ...req.query },
     };
-    // Include request body for state-changing methods
     if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method) && req.body && typeof req.body === 'object') {
       diff.body = req.body;
     }
@@ -194,5 +206,12 @@ router.post('/quota/requests/:id/reject', async (req, res, next) => {
     next(new InternalServerError());
   }
 });
+
+// ---------------------------------------------------------------------------
+// ✅ NEW: Webhook signing-key rotation
+// Mounts:  POST /api/admin/webhooks/rotate-key
+//          GET  /api/admin/webhooks/grace-window
+// ---------------------------------------------------------------------------
+router.use('/webhooks', webhookKeysRouter);
 
 export default router;

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,13 +1,3 @@
-/**
- * src/routes/admin.ts  — UPDATED
- *
- * Diff from original:
- *   + import webhookKeysRouter from './admin/webhookKeys.js';
- *   + router.use('/webhooks', webhookKeysRouter);   ← new line, after quota block
- *
- * All other code is unchanged.
- */
-
 import { Router } from 'express';
 import { adminAuth } from '../middleware/adminAuth.js';
 import { createAdminIpAllowlist } from '../middleware/ipAllowlist.js';
@@ -23,9 +13,8 @@ import {
   approveQuotaRequest,
   rejectQuotaRequest,
 } from '../services/quotaService.js';
-
-// ✅ NEW IMPORT
 import webhookKeysRouter from './admin/webhookKeys.js';
+import { createAdminApisRouter } from './admin/apis.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 const usageStore: UsageAdminStore = createUsageStore();
@@ -208,10 +197,17 @@ router.post('/quota/requests/:id/reject', async (req, res, next) => {
 });
 
 // ---------------------------------------------------------------------------
-// ✅ NEW: Webhook signing-key rotation
+// Webhook signing-key rotation
 // Mounts:  POST /api/admin/webhooks/rotate-key
 //          GET  /api/admin/webhooks/grace-window
 // ---------------------------------------------------------------------------
 router.use('/webhooks', webhookKeysRouter);
+
+// ---------------------------------------------------------------------------
+// API soft-delete and restore
+// Mounts:  DELETE /api/admin/apis/:id
+//          POST   /api/admin/apis/:id/restore
+// ---------------------------------------------------------------------------
+router.use('/apis', createAdminApisRouter());
 
 export default router;

--- a/src/routes/admin/apis.test.ts
+++ b/src/routes/admin/apis.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for soft-delete and restore of APIs.
+ *
+ * Covers:
+ *   - DELETE /api/admin/apis/:id  (soft-delete)
+ *   - POST   /api/admin/apis/:id/restore
+ *   - InMemoryApiRepository.delete / .restore behaviour
+ *   - listByDeveloper / listPublic exclusion of deleted rows
+ *   - findById exclusion of deleted rows
+ */
+
+jest.mock("better-sqlite3", () => {
+  return class MockDatabase {
+    prepare() {
+      return { get: () => null };
+    }
+    exec() {}
+    close() {}
+  };
+});
+
+import express from "express";
+import request from "supertest";
+import { errorHandler } from "../../middleware/errorHandler.js";
+import {
+  InMemoryApiRepository,
+  type ApiRepository,
+} from "../../repositories/apiRepository.js";
+import { createAdminApisRouter } from "./apis.js";
+import type { Api } from "../../db/schema.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_KEY = "test-admin-key";
+
+function buildApp(repo: ApiRepository) {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate the admin-auth middleware: set adminActor and skip real checks.
+  app.use((req, res, next) => {
+    if (req.headers["x-admin-api-key"] !== ADMIN_KEY) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    res.locals.adminActor = "admin-api-key";
+    next();
+  });
+
+  app.use("/api/admin/apis", createAdminApisRouter({ apiRepository: repo }));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeApi(overrides: Partial<Api> = {}): Api {
+  const now = new Date();
+  return {
+    id: 1,
+    developer_id: 10,
+    name: "Test API",
+    description: null,
+    base_url: "https://api.test",
+    logo_url: null,
+    category: null,
+    status: "active",
+    created_at: now,
+    updated_at: now,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// InMemoryApiRepository — soft-delete behaviour
+// ---------------------------------------------------------------------------
+
+describe("InMemoryApiRepository — soft-delete", () => {
+  it("delete() returns true and sets deleted_at on a live record", async () => {
+    const repo = new InMemoryApiRepository([makeApi({ id: 1 })]);
+    const result = await repo.delete(1);
+    expect(result).toBe(true);
+    // Row is no longer returned by listByDeveloper
+    const rows = await repo.listByDeveloper(10);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("delete() returns false for an already-deleted record (idempotent safety)", async () => {
+    const api = makeApi({ id: 1, deleted_at: new Date() });
+    const repo = new InMemoryApiRepository([api]);
+    const result = await repo.delete(1);
+    expect(result).toBe(false);
+  });
+
+  it("delete() returns false for a non-existent id", async () => {
+    const repo = new InMemoryApiRepository([]);
+    expect(await repo.delete(999)).toBe(false);
+  });
+
+  it("restore() returns the Api row and clears deleted_at", async () => {
+    const api = makeApi({ id: 1, deleted_at: new Date() });
+    const repo = new InMemoryApiRepository([api]);
+    const restored = await repo.restore(1);
+    expect(restored).not.toBeNull();
+    expect(restored!.deleted_at).toBeNull();
+    expect(restored!.id).toBe(1);
+  });
+
+  it("restore() returns null for a live (non-deleted) record", async () => {
+    const repo = new InMemoryApiRepository([makeApi({ id: 1 })]);
+    expect(await repo.restore(1)).toBeNull();
+  });
+
+  it("restore() returns null for a non-existent id", async () => {
+    const repo = new InMemoryApiRepository([]);
+    expect(await repo.restore(999)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// InMemoryApiRepository — query exclusion
+// ---------------------------------------------------------------------------
+
+describe("InMemoryApiRepository — query exclusion", () => {
+  function makeRepo() {
+    const live = makeApi({ id: 1, developer_id: 10, status: "active" });
+    const deleted = makeApi({
+      id: 2,
+      developer_id: 10,
+      status: "active",
+      deleted_at: new Date(),
+    });
+    return new InMemoryApiRepository([live, deleted]);
+  }
+
+  it("listByDeveloper excludes soft-deleted rows", async () => {
+    const repo = makeRepo();
+    const rows = await repo.listByDeveloper(10);
+    expect(rows.map((r) => r.id)).toEqual([1]);
+  });
+
+  it("listPublic excludes soft-deleted rows", async () => {
+    const repo = makeRepo();
+    const rows = await repo.listPublic();
+    expect(rows.map((r) => r.id)).toEqual([1]);
+  });
+
+  it("findById returns null for a soft-deleted record", async () => {
+    const repo = makeRepo();
+    expect(await repo.findById(2)).toBeNull();
+  });
+
+  it("findById returns the record for a live record", async () => {
+    const repo = makeRepo();
+    const found = await repo.findById(1);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(1);
+  });
+
+  it("delete then restore makes the record visible again in listings", async () => {
+    const repo = makeRepo();
+    await repo.delete(1);
+    expect(await repo.listByDeveloper(10)).toHaveLength(0);
+    await repo.restore(1);
+    expect(await repo.listByDeveloper(10)).toHaveLength(1);
+  });
+
+  it("update on a soft-deleted record returns null", async () => {
+    const repo = makeRepo();
+    const updated = await repo.update(2, { name: "new name" });
+    expect(updated).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP: DELETE /api/admin/apis/:id
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/admin/apis/:id", () => {
+  it("returns 204 and soft-deletes the API", async () => {
+    const repo = new InMemoryApiRepository([makeApi({ id: 42 })]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .delete("/api/admin/apis/42")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(204);
+    // Confirm the record is no longer accessible via normal listing
+    const rows = await repo.listByDeveloper(10);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("returns 404 when the API does not exist", async () => {
+    const repo = new InMemoryApiRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .delete("/api/admin/apis/999")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the API is already deleted", async () => {
+    const repo = new InMemoryApiRepository([
+      makeApi({ id: 5, deleted_at: new Date() }),
+    ]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .delete("/api/admin/apis/5")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for a non-integer id", async () => {
+    const repo = new InMemoryApiRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .delete("/api/admin/apis/abc")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for id=0", async () => {
+    const repo = new InMemoryApiRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .delete("/api/admin/apis/0")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 without admin key", async () => {
+    const repo = new InMemoryApiRepository([makeApi({ id: 1 })]);
+    const app = buildApp(repo);
+
+    const res = await request(app).delete("/api/admin/apis/1");
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP: POST /api/admin/apis/:id/restore
+// ---------------------------------------------------------------------------
+
+describe("POST /api/admin/apis/:id/restore", () => {
+  it("returns 200 with the restored API when the record is deleted", async () => {
+    const repo = new InMemoryApiRepository([
+      makeApi({ id: 7, deleted_at: new Date() }),
+    ]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .post("/api/admin/apis/7/restore")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeDefined();
+    expect(res.body.data.id).toBe(7);
+    expect(res.body.data.deleted_at).toBeNull();
+  });
+
+  it("returns 404 when the API is already live (not deleted)", async () => {
+    const repo = new InMemoryApiRepository([makeApi({ id: 8 })]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .post("/api/admin/apis/8/restore")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the API does not exist", async () => {
+    const repo = new InMemoryApiRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .post("/api/admin/apis/999/restore")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for a non-integer id", async () => {
+    const repo = new InMemoryApiRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .post("/api/admin/apis/abc/restore")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 without admin key", async () => {
+    const repo = new InMemoryApiRepository([
+      makeApi({ id: 7, deleted_at: new Date() }),
+    ]);
+    const app = buildApp(repo);
+
+    const res = await request(app).post("/api/admin/apis/7/restore");
+    expect(res.status).toBe(401);
+  });
+
+  it("restores the API and makes it reappear in developer listings", async () => {
+    const repo = new InMemoryApiRepository([
+      makeApi({ id: 10, deleted_at: new Date() }),
+    ]);
+    const app = buildApp(repo);
+
+    await request(app)
+      .post("/api/admin/apis/10/restore")
+      .set("x-admin-api-key", ADMIN_KEY);
+
+    const rows = await repo.listByDeveloper(10);
+    expect(rows.map((r) => r.id)).toContain(10);
+  });
+});

--- a/src/routes/admin/apis.ts
+++ b/src/routes/admin/apis.ts
@@ -1,0 +1,149 @@
+/**
+ * Admin API management routes — soft-delete and restore.
+ *
+ * All routes in this module sit behind the IP allowlist and admin-auth
+ * middleware that are applied at the parent `/api/admin` router level.
+ * No additional auth wiring is required here.
+ *
+ * Routes:
+ *   DELETE /api/admin/apis/:id   — soft-delete a live API
+ *   POST   /api/admin/apis/:id/restore — restore a soft-deleted API
+ */
+
+import { Router } from "express";
+import { getClientIp } from "../../lib/clientIp.js";
+import {
+  BadRequestError,
+  NotFoundError,
+  AppError,
+  InternalServerError,
+} from "../../errors/index.js";
+import { logger } from "../../logger.js";
+import {
+  defaultApiRepository,
+  type ApiRepository,
+} from "../../repositories/apiRepository.js";
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === "true";
+
+export interface AdminApisRouterDeps {
+  /** Override in tests to inject an in-memory repository. */
+  apiRepository?: ApiRepository;
+}
+
+/**
+ * Factory that returns the admin APIs sub-router.
+ * Mount it under the existing admin router, e.g.:
+ *   adminRouter.use('/apis', createAdminApisRouter());
+ */
+export function createAdminApisRouter(
+  deps: AdminApisRouterDeps = {},
+): Router {
+  const router = Router();
+  const apiRepository = deps.apiRepository ?? defaultApiRepository;
+
+  // ── DELETE /api/admin/apis/:id ──────────────────────────────────────────
+  /**
+   * Soft-delete an API.
+   *
+   * Sets `deleted_at` to the current timestamp; the row is retained for audit
+   * purposes and can be restored via POST /api/admin/apis/:id/restore.
+   *
+   * Returns 204 No Content on success.
+   * Returns 404 if the API does not exist or is already deleted.
+   */
+  router.delete("/:id", async (req, res, next) => {
+    const id = Number(req.params.id);
+
+    if (!Number.isInteger(id) || id <= 0) {
+      next(new BadRequestError("id must be a positive integer"));
+      return;
+    }
+
+    try {
+      const deleted = await apiRepository.delete(id);
+
+      if (!deleted) {
+        next(
+          new NotFoundError(
+            "API not found or already deleted",
+            "NOT_FOUND",
+          ),
+        );
+        return;
+      }
+
+      logger.audit("SOFT_DELETE_API", res.locals.adminActor, {
+        clientIp: getClientIp(req, TRUST_PROXY),
+        userAgent: req.get("User-Agent"),
+        correlationId: req.headers["x-request-id"] ?? req.headers["x-correlation-id"],
+        apiId: id,
+        diff: { deleted_at: new Date().toISOString() },
+      });
+
+      res.status(204).end();
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error("Failed to soft-delete API", { apiId: id, error });
+      next(new InternalServerError());
+    }
+  });
+
+  // ── POST /api/admin/apis/:id/restore ────────────────────────────────────
+  /**
+   * Restore a soft-deleted API.
+   *
+   * Clears `deleted_at`, making the API visible again in all listings.
+   * The API's previous `status` is preserved — if it was `active` before
+   * deletion it will reappear in the public catalog immediately.
+   *
+   * Returns 200 with the restored API row.
+   * Returns 404 if the API does not exist or is not currently deleted.
+   */
+  router.post("/:id/restore", async (req, res, next) => {
+    const id = Number(req.params.id);
+
+    if (!Number.isInteger(id) || id <= 0) {
+      next(new BadRequestError("id must be a positive integer"));
+      return;
+    }
+
+    try {
+      const restored = await apiRepository.restore(id);
+
+      if (!restored) {
+        next(
+          new NotFoundError(
+            "API not found or not currently deleted",
+            "NOT_FOUND",
+          ),
+        );
+        return;
+      }
+
+      logger.audit("RESTORE_API", res.locals.adminActor, {
+        clientIp: getClientIp(req, TRUST_PROXY),
+        userAgent: req.get("User-Agent"),
+        correlationId: req.headers["x-request-id"] ?? req.headers["x-correlation-id"],
+        apiId: id,
+        diff: { deleted_at: null },
+      });
+
+      res.json({ data: restored });
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error("Failed to restore API", { apiId: id, error });
+      next(new InternalServerError());
+    }
+  });
+
+  return router;
+}
+
+export default createAdminApisRouter;

--- a/src/routes/admin/webhookKeys.ts
+++ b/src/routes/admin/webhookKeys.ts
@@ -1,0 +1,212 @@
+/**
+ * src/routes/admin/webhookKeys.ts
+ *
+ * Admin route: POST /api/admin/webhooks/rotate-key
+ *
+ * Generates a new platform webhook signing secret, demotes the previous one
+ * into a configurable grace window, writes an audit log, and notifies the
+ * admin email address (fire-and-forget).
+ *
+ * Authentication:  adminAuth middleware (applied on the parent admin router).
+ * IP allowlist:    createAdminIpAllowlist() (also applied by parent router).
+ *
+ * Mounts as:
+ *   import webhookKeysRouter from './routes/admin/webhookKeys.js';
+ *   adminRouter.use('/webhooks', webhookKeysRouter);
+ *
+ * Which exposes:  POST /api/admin/webhooks/rotate-key
+ */
+
+import { Router } from 'express';
+import { getClientIp } from '../../lib/clientIp.js';
+import {
+  AppError,
+  InternalServerError,
+  BadRequestError,
+} from '../../errors/index.js';
+import { logger } from '../../logger.js';
+import {
+  WebhookSignerService,
+  InMemoryWebhookKeyStore,
+  resolveGraceWindowMs,
+  type WebhookSignerDeps,
+  type RotationResult,
+} from '../../services/webhookSigner.js';
+
+// ---------------------------------------------------------------------------
+// Shared service instance
+// ---------------------------------------------------------------------------
+//
+// In a single-process deploy the in-memory store is sufficient.
+// For multi-replica deployments, replace `InMemoryWebhookKeyStore` with a
+// Postgres/SQLite-backed implementation that satisfies `WebhookKeyStore`.
+//
+// The instance is module-level so it is created once per process and shared
+// across requests, preserving key state between rotations.
+
+const defaultStore = new InMemoryWebhookKeyStore();
+
+/**
+ * Build the admin notification callback.
+ * Logs the notification; swap for nodemailer/SES/etc. as needed.
+ */
+function buildAdminNotifier(): (result: RotationResult) => Promise<void> {
+  const adminEmail = process.env.ADMIN_EMAIL ?? '';
+
+  return async (result: RotationResult) => {
+    const target = adminEmail || '(no ADMIN_EMAIL configured)';
+    logger.info(
+      `[webhook-key-rotation] Admin notification → ${target}`,
+      {
+        event: 'WEBHOOK_KEY_ROTATION_NOTIFICATION',
+        recipient: target,
+        newKeyId: result.newKey.id,
+        previousKeyId: result.previousKey?.id ?? null,
+        graceWindowMs: result.graceWindowMs,
+        previousKeyExpiresAt: result.previousKeyExpiresAt,
+        // rawSecret intentionally NOT logged
+      },
+    );
+
+    // TODO: integrate real email transport here, e.g.:
+    //
+    //   await mailer.send({
+    //     to: adminEmail,
+    //     subject: 'Webhook signing key rotated',
+    //     text: [
+    //       `A new webhook signing key was generated (id: ${result.newKey.id}).`,
+    //       `The previous key expires at: ${result.previousKeyExpiresAt ?? 'N/A'}.`,
+    //       `Grace window: ${result.graceWindowMs / 1000}s.`,
+    //       `Distribute the new key to subscribers before the grace window closes.`,
+    //     ].join('\n'),
+    //   });
+  };
+}
+
+/**
+ * Factory — lets callers inject a custom WebhookSignerService in tests.
+ */
+export function createWebhookKeysRouter(
+  deps?: Partial<WebhookSignerDeps>,
+): Router {
+  const service = new WebhookSignerService({
+    store: deps?.store ?? defaultStore,
+    notifyAdmin: deps?.notifyAdmin ?? buildAdminNotifier(),
+    now: deps?.now,
+    graceWindowMs: deps?.graceWindowMs,
+  });
+
+  const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+  const router = Router();
+
+  // -------------------------------------------------------------------------
+  // POST /rotate-key
+  // -------------------------------------------------------------------------
+  /**
+   * @openapi
+   * /api/admin/webhooks/rotate-key:
+   *   post:
+   *     summary: Rotate the platform webhook signing key
+   *     description: |
+   *       Generates a new HMAC-SHA256 signing key and immediately activates it.
+   *       The previous key remains valid for a configurable grace window
+   *       (WEBHOOK_SECRET_ROTATION_GRACE_MS, default 24 h) so subscribers can
+   *       roll over their verification logic without downtime.
+   *
+   *       **Security notes**
+   *       - The raw secret is returned ONCE in this response and never stored.
+   *         Distribute it to webhook subscribers immediately.
+   *       - Only the SHA-256 hash of each key is persisted in the database.
+   *       - Every call is recorded in the audit log.
+   *     security:
+   *       - AdminApiKey: []
+   *       - AdminJWT: []
+   *     responses:
+   *       '200':
+   *         description: Key rotated successfully.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     newKeyId:             { type: string, format: uuid }
+   *                     rawSecret:            { type: string, description: "One-time exposure — store securely immediately." }
+   *                     graceWindowMs:        { type: integer }
+   *                     previousKeyId:        { type: string, nullable: true }
+   *                     previousKeyExpiresAt: { type: string, format: date-time, nullable: true }
+   *                     rotatedAt:            { type: string, format: date-time }
+   *       '401': { $ref: '#/components/responses/Unauthorized' }
+   *       '403': { $ref: '#/components/responses/Forbidden' }
+   *       '500': { $ref: '#/components/responses/InternalServerError' }
+   */
+  router.post('/rotate-key', async (req, res, next) => {
+    // Validate Content-Type when a body is present (guard against stray data)
+    const contentType = req.get('Content-Type') ?? '';
+    if (req.body && Object.keys(req.body).length > 0 && !contentType.includes('application/json')) {
+      next(new BadRequestError('Content-Type must be application/json when a body is supplied'));
+      return;
+    }
+
+    try {
+      const actor: string = res.locals.adminActor as string;
+      const result = await service.rotateKey(actor);
+
+      // Structured audit entry (also written inside the service, this provides
+      // HTTP-layer context that the service layer cannot see)
+      logger.audit('ADMIN_WEBHOOK_ROTATE_KEY', actor, {
+        clientIp: getClientIp(req, TRUST_PROXY),
+        userAgent: req.get('User-Agent'),
+        newKeyId: result.newKey.id,
+        previousKeyId: result.previousKey?.id ?? null,
+        graceWindowMs: result.graceWindowMs,
+        previousKeyExpiresAt: result.previousKeyExpiresAt,
+      });
+
+      return res.status(200).json({
+        data: {
+          newKeyId: result.newKey.id,
+          /**
+           * rawSecret is returned ONCE and never stored in plaintext.
+           * Subscribers must update their verification logic before
+           * previousKeyExpiresAt to avoid signature failures.
+           */
+          rawSecret: result.rawSecret,
+          graceWindowMs: result.graceWindowMs,
+          previousKeyId: result.previousKey?.id ?? null,
+          previousKeyExpiresAt: result.previousKeyExpiresAt,
+          rotatedAt: result.newKey.created_at,
+        },
+      });
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error('Webhook key rotation failed', error);
+      next(new InternalServerError('Webhook key rotation failed'));
+    }
+  });
+
+  /**
+   * GET /grace-window
+   *
+   * Convenience endpoint — returns the currently-configured grace window so
+   * operators can inspect it without reading server environment variables.
+   */
+  router.get('/grace-window', (_req, res) => {
+    res.json({
+      data: {
+        graceWindowMs: resolveGraceWindowMs(deps?.graceWindowMs),
+        graceWindowHours: resolveGraceWindowMs(deps?.graceWindowMs) / 3_600_000,
+      },
+    });
+  });
+
+  return router;
+}
+
+/** Default export: router using the shared in-memory store. */
+export default createWebhookKeysRouter();

--- a/src/services/webhookSigner.test.ts
+++ b/src/services/webhookSigner.test.ts
@@ -1,0 +1,557 @@
+/**
+ * webhookSigner.test.ts
+ *
+ * Unit + integration tests for:
+ *   - WebhookSignerService (key generation, rotation, grace window, audit log)
+ *   - POST /api/admin/webhooks/rotate-key route
+ *   - GET  /api/admin/webhooks/grace-window route
+ *   - InMemoryWebhookKeyStore
+ *
+ * Coverage target: ≥90% of changed lines.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import crypto from 'crypto';
+import {
+  WebhookSignerService,
+  InMemoryWebhookKeyStore,
+  generateSigningSecret,
+  hashSecret,
+  resolveGraceWindowMs,
+  type RotationResult,
+  type WebhookSignerDeps,
+} from '../../src/services/webhookSigner.js';
+import { createWebhookKeysRouter } from '../../src/routes/admin/webhookKeys.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a fake admin Express app that skips IP allowlist + auth middleware. */
+function buildTestApp(deps?: Partial<WebhookSignerDeps>) {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate adminAuth by injecting a fixed actor
+  app.use((_req, res, next) => {
+    res.locals.adminActor = 'test-admin';
+    next();
+  });
+
+  app.use('/api/admin/webhooks', createWebhookKeysRouter(deps));
+  return app;
+}
+
+/** Advance a fake clock by `ms` milliseconds. */
+function advanceClock(base: Date, ms: number): Date {
+  return new Date(base.getTime() + ms);
+}
+
+// ---------------------------------------------------------------------------
+// generateSigningSecret
+// ---------------------------------------------------------------------------
+
+describe('generateSigningSecret()', () => {
+  it('returns a 64-char hex string (256-bit key)', () => {
+    const secret = generateSigningSecret();
+    expect(secret).toHaveLength(64);
+    expect(/^[0-9a-f]+$/.test(secret)).toBe(true);
+  });
+
+  it('is unique across calls', () => {
+    const a = generateSigningSecret();
+    const b = generateSigningSecret();
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hashSecret
+// ---------------------------------------------------------------------------
+
+describe('hashSecret()', () => {
+  it('returns the SHA-256 hex of the input', () => {
+    const raw = 'my-test-secret';
+    const expected = crypto.createHash('sha256').update(raw).digest('hex');
+    expect(hashSecret(raw)).toBe(expected);
+  });
+
+  it('is deterministic', () => {
+    const raw = generateSigningSecret();
+    expect(hashSecret(raw)).toBe(hashSecret(raw));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveGraceWindowMs
+// ---------------------------------------------------------------------------
+
+describe('resolveGraceWindowMs()', () => {
+  const ORIGINAL_ENV = process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS;
+    } else {
+      process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS = ORIGINAL_ENV;
+    }
+  });
+
+  it('returns the override when provided', () => {
+    expect(resolveGraceWindowMs(30_000)).toBe(30_000);
+  });
+
+  it('reads from env var when no override', () => {
+    process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS = '7200000';
+    expect(resolveGraceWindowMs()).toBe(7_200_000);
+  });
+
+  it('returns 86_400_000 when env var is missing', () => {
+    delete process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS;
+    expect(resolveGraceWindowMs()).toBe(86_400_000);
+  });
+
+  it('ignores non-numeric env var and falls back to default', () => {
+    process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS = 'bad-value';
+    expect(resolveGraceWindowMs()).toBe(86_400_000);
+  });
+
+  it('ignores zero or negative overrides and falls back to env', () => {
+    delete process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS;
+    expect(resolveGraceWindowMs(0)).toBe(86_400_000);
+    expect(resolveGraceWindowMs(-1)).toBe(86_400_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// InMemoryWebhookKeyStore
+// ---------------------------------------------------------------------------
+
+describe('InMemoryWebhookKeyStore', () => {
+  let store: InMemoryWebhookKeyStore;
+
+  beforeEach(() => {
+    store = new InMemoryWebhookKeyStore();
+  });
+
+  it('returns null when no active key exists', async () => {
+    expect(await store.getActiveKey()).toBeNull();
+  });
+
+  it('inserts and retrieves an active key', async () => {
+    const key = {
+      id: 'k1',
+      key_hash: hashSecret('raw'),
+      status: 'active' as const,
+      created_at: new Date().toISOString(),
+      expires_at: null,
+      created_by: 'admin',
+    };
+    await store.insertKey(key);
+    const found = await store.getActiveKey();
+    expect(found?.id).toBe('k1');
+  });
+
+  it('demoteActiveKey returns null when no active key', async () => {
+    const result = await store.demoteActiveKey(new Date());
+    expect(result).toBeNull();
+  });
+
+  it('demoteActiveKey transitions active → previous with expiry', async () => {
+    await store.insertKey({
+      id: 'k1',
+      key_hash: 'aaa',
+      status: 'active',
+      created_at: new Date().toISOString(),
+      expires_at: null,
+      created_by: 'admin',
+    });
+    const expiry = new Date(Date.now() + 60_000);
+    const demoted = await store.demoteActiveKey(expiry);
+    expect(demoted?.status).toBe('previous');
+    expect(demoted?.expires_at).toBe(expiry.toISOString());
+    expect(await store.getActiveKey()).toBeNull();
+  });
+
+  it('getValidPreviousKeys returns only keys within grace window', async () => {
+    const now = new Date('2025-01-01T12:00:00Z');
+    const future = new Date(now.getTime() + 1_000);
+    const past = new Date(now.getTime() - 1_000);
+
+    await store.insertKey({ id: 'k-future', key_hash: 'aaa', status: 'previous', created_at: now.toISOString(), expires_at: future.toISOString(), created_by: 'admin' });
+    await store.insertKey({ id: 'k-past',   key_hash: 'bbb', status: 'previous', created_at: now.toISOString(), expires_at: past.toISOString(),   created_by: 'admin' });
+
+    const valid = await store.getValidPreviousKeys(now);
+    expect(valid.map((k) => k.id)).toContain('k-future');
+    expect(valid.map((k) => k.id)).not.toContain('k-past');
+  });
+
+  it('expireStaleKeys moves expired previous keys to expired status', async () => {
+    const past = new Date(Date.now() - 1_000);
+    await store.insertKey({ id: 'k1', key_hash: 'aaa', status: 'previous', created_at: new Date().toISOString(), expires_at: past.toISOString(), created_by: 'admin' });
+    await store.expireStaleKeys(new Date());
+    const keys = store._getKeys();
+    expect(keys.find((k) => k.id === 'k1')?.status).toBe('expired');
+  });
+
+  it('insertAuditEntry records an audit row', async () => {
+    const entry = {
+      id: 'a1',
+      new_key_id: 'k1',
+      previous_key_id: null,
+      grace_window_ms: 3600,
+      expires_at: new Date().toISOString(),
+      rotated_by: 'admin',
+      rotated_at: new Date().toISOString(),
+      correlation_id: null,
+    };
+    await store.insertAuditEntry(entry);
+    expect(store._getAuditLog()).toHaveLength(1);
+    expect(store._getAuditLog()[0].id).toBe('a1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WebhookSignerService
+// ---------------------------------------------------------------------------
+
+describe('WebhookSignerService', () => {
+  let store: InMemoryWebhookKeyStore;
+  let notifyAdmin: jest.Mock;
+  let fakeNow: Date;
+  let service: WebhookSignerService;
+
+  function buildService(overrides?: Partial<WebhookSignerDeps>) {
+    return new WebhookSignerService({
+      store,
+      notifyAdmin,
+      now: () => fakeNow,
+      graceWindowMs: 60_000, // 1 minute for fast tests
+      ...overrides,
+    });
+  }
+
+  beforeEach(() => {
+    store = new InMemoryWebhookKeyStore();
+    notifyAdmin = jest.fn().mockResolvedValue(undefined);
+    fakeNow = new Date('2025-06-01T10:00:00Z');
+    service = buildService();
+  });
+
+  // ── rotateKey ─────────────────────────────────────────────────────────────
+
+  describe('rotateKey()', () => {
+    it('returns a rawSecret of 64 hex chars', async () => {
+      const result = await service.rotateKey('admin');
+      expect(result.rawSecret).toHaveLength(64);
+      expect(/^[0-9a-f]+$/.test(result.rawSecret)).toBe(true);
+    });
+
+    it('new key is persisted with status "active"', async () => {
+      await service.rotateKey('admin');
+      const active = await store.getActiveKey();
+      expect(active?.status).toBe('active');
+    });
+
+    it('hash of rawSecret matches persisted key_hash', async () => {
+      const result = await service.rotateKey('admin');
+      expect(result.newKey.key_hash).toBe(hashSecret(result.rawSecret));
+    });
+
+    it('previousKey is null on first rotation', async () => {
+      const result = await service.rotateKey('admin');
+      expect(result.previousKey).toBeNull();
+      expect(result.previousKeyExpiresAt).toBeNull();
+    });
+
+    it('second rotation demotes first key to previous', async () => {
+      const r1 = await service.rotateKey('admin');
+      const r2 = await service.rotateKey('admin');
+      expect(r2.previousKey?.id).toBe(r1.newKey.id);
+      expect(r2.previousKey?.status).toBe('previous');
+    });
+
+    it('previous key expires at now + graceWindowMs', async () => {
+      await service.rotateKey('admin');
+      const r2 = await service.rotateKey('admin');
+      const expected = new Date(fakeNow.getTime() + 60_000).toISOString();
+      expect(r2.previousKeyExpiresAt).toBe(expected);
+    });
+
+    it('reflects graceWindowMs in result', async () => {
+      const result = await service.rotateKey('admin');
+      expect(result.graceWindowMs).toBe(60_000);
+    });
+
+    it('writes an audit log entry', async () => {
+      await service.rotateKey('admin');
+      expect(store._getAuditLog()).toHaveLength(1);
+    });
+
+    it('audit entry references correct key IDs', async () => {
+      const r1 = await service.rotateKey('admin');
+      const r2 = await service.rotateKey('admin');
+      const log = store._getAuditLog();
+      expect(log[1].new_key_id).toBe(r2.newKey.id);
+      expect(log[1].previous_key_id).toBe(r1.newKey.id);
+    });
+
+    it('calls notifyAdmin with the rotation result', async () => {
+      const result = await service.rotateKey('admin');
+      expect(notifyAdmin).toHaveBeenCalledTimes(1);
+      expect(notifyAdmin).toHaveBeenCalledWith(result);
+    });
+
+    it('does NOT rethrow when notifyAdmin rejects', async () => {
+      notifyAdmin.mockRejectedValue(new Error('SMTP down'));
+      await expect(service.rotateKey('admin')).resolves.toBeDefined();
+    });
+
+    it('generates a unique key on every call', async () => {
+      const r1 = await service.rotateKey('admin');
+      fakeNow = advanceClock(fakeNow, 1);
+      const r2 = await service.rotateKey('admin');
+      expect(r1.rawSecret).not.toBe(r2.rawSecret);
+      expect(r1.newKey.id).not.toBe(r2.newKey.id);
+    });
+  });
+
+  // ── getActiveKeyHashes ───────────────────────────────────────────────────
+
+  describe('getActiveKeyHashes()', () => {
+    it('returns empty array before any rotation', async () => {
+      expect(await service.getActiveKeyHashes()).toEqual([]);
+    });
+
+    it('returns only active key hash after first rotation', async () => {
+      const r = await service.rotateKey('admin');
+      const hashes = await service.getActiveKeyHashes();
+      expect(hashes).toContain(hashSecret(r.rawSecret));
+      expect(hashes).toHaveLength(1);
+    });
+
+    it('returns both active and previous hashes within grace window', async () => {
+      const r1 = await service.rotateKey('admin');
+      const r2 = await service.rotateKey('admin');
+      const hashes = await service.getActiveKeyHashes();
+      expect(hashes).toContain(hashSecret(r1.rawSecret)); // previous — still valid
+      expect(hashes).toContain(hashSecret(r2.rawSecret)); // active
+      expect(hashes).toHaveLength(2);
+    });
+
+    it('excludes previous key after grace window expires', async () => {
+      const r1 = await service.rotateKey('admin');
+      await service.rotateKey('admin');
+
+      // Advance clock past grace window
+      const afterGrace = advanceClock(fakeNow, 60_001);
+      const hashes = await service.getActiveKeyHashes(afterGrace);
+      expect(hashes).not.toContain(hashSecret(r1.rawSecret));
+      expect(hashes).toHaveLength(1); // only new active key
+    });
+
+    it('expires stale previous keys lazily on read', async () => {
+      await service.rotateKey('admin');
+      await service.rotateKey('admin');
+
+      const afterGrace = advanceClock(fakeNow, 60_001);
+      await service.getActiveKeyHashes(afterGrace);
+
+      const keys = store._getKeys();
+      const expiredKeys = keys.filter((k) => k.status === 'expired');
+      expect(expiredKeys).toHaveLength(1);
+    });
+  });
+
+  // ── edge cases ───────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('three consecutive rotations: only current + most-recent-previous remain valid', async () => {
+      const r1 = await service.rotateKey('admin');
+      fakeNow = advanceClock(fakeNow, 1);
+      const r2 = await service.rotateKey('admin');
+      fakeNow = advanceClock(fakeNow, 1);
+      await service.rotateKey('admin');
+
+      const hashes = await service.getActiveKeyHashes();
+      // r1 was demoted when r2 was generated; then r2 was demoted when r3 was generated.
+      // The store only keeps one "previous" slot active — the most recently demoted key (r2).
+      // r1 was overwritten/expired — confirm it is NOT present.
+      expect(hashes).not.toContain(hashSecret(r1.rawSecret));
+      expect(hashes).toContain(hashSecret(r2.rawSecret));
+    });
+
+    it('audit log grows by one entry per rotation', async () => {
+      await service.rotateKey('admin');
+      await service.rotateKey('admin');
+      await service.rotateKey('admin');
+      expect(store._getAuditLog()).toHaveLength(3);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP route: POST /api/admin/webhooks/rotate-key
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/webhooks/rotate-key', () => {
+  let app: ReturnType<typeof buildTestApp>;
+  let store: InMemoryWebhookKeyStore;
+  let notifyAdmin: jest.Mock;
+
+  beforeEach(() => {
+    store = new InMemoryWebhookKeyStore();
+    notifyAdmin = jest.fn().mockResolvedValue(undefined);
+    app = buildTestApp({ store, notifyAdmin, graceWindowMs: 60_000 });
+  });
+
+  it('returns 200 with the expected shape', async () => {
+    const res = await request(app).post('/api/admin/webhooks/rotate-key').send();
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      newKeyId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      rawSecret: expect.stringMatching(/^[0-9a-f]{64}$/),
+      graceWindowMs: 60_000,
+      previousKeyId: null,
+      previousKeyExpiresAt: null,
+      rotatedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+    });
+  });
+
+  it('rawSecret is a valid 64-char hex string', async () => {
+    const res = await request(app).post('/api/admin/webhooks/rotate-key').send();
+    expect(res.body.data.rawSecret).toHaveLength(64);
+  });
+
+  it('successive calls return different rawSecrets', async () => {
+    const r1 = await request(app).post('/api/admin/webhooks/rotate-key').send();
+    const r2 = await request(app).post('/api/admin/webhooks/rotate-key').send();
+    expect(r1.body.data.rawSecret).not.toBe(r2.body.data.rawSecret);
+    expect(r1.body.data.newKeyId).not.toBe(r2.body.data.newKeyId);
+  });
+
+  it('second call includes previousKeyId from first rotation', async () => {
+    const r1 = await request(app).post('/api/admin/webhooks/rotate-key').send();
+    const r2 = await request(app).post('/api/admin/webhooks/rotate-key').send();
+    expect(r2.body.data.previousKeyId).toBe(r1.body.data.newKeyId);
+    expect(r2.body.data.previousKeyExpiresAt).toBeTruthy();
+  });
+
+  it('calls notifyAdmin once per rotation', async () => {
+    await request(app).post('/api/admin/webhooks/rotate-key').send();
+    expect(notifyAdmin).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists an audit log entry per rotation', async () => {
+    await request(app).post('/api/admin/webhooks/rotate-key').send();
+    await request(app).post('/api/admin/webhooks/rotate-key').send();
+    expect(store._getAuditLog()).toHaveLength(2);
+  });
+
+  it('returns 400 for non-JSON Content-Type with body', async () => {
+    const res = await request(app)
+      .post('/api/admin/webhooks/rotate-key')
+      .set('Content-Type', 'text/plain')
+      .send('bad body');
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts empty JSON body ({})', async () => {
+    const res = await request(app)
+      .post('/api/admin/webhooks/rotate-key')
+      .set('Content-Type', 'application/json')
+      .send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts no body at all', async () => {
+    const res = await request(app)
+      .post('/api/admin/webhooks/rotate-key');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 500 when the store throws an unexpected error', async () => {
+    const brokenStore = new InMemoryWebhookKeyStore();
+    jest.spyOn(brokenStore, 'insertKey').mockRejectedValue(new Error('DB exploded'));
+
+    const brokenApp = buildTestApp({ store: brokenStore, graceWindowMs: 60_000 });
+    const res = await request(brokenApp).post('/api/admin/webhooks/rotate-key').send();
+    expect(res.status).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP route: GET /api/admin/webhooks/grace-window
+// ---------------------------------------------------------------------------
+
+describe('GET /api/admin/webhooks/grace-window', () => {
+  it('returns the configured grace window', async () => {
+    const app = buildTestApp({ graceWindowMs: 3_600_000 });
+    const res = await request(app).get('/api/admin/webhooks/grace-window');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      graceWindowMs: 3_600_000,
+      graceWindowHours: 1,
+    });
+  });
+
+  it('returns default when no override is given', async () => {
+    delete process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS;
+    const app = buildTestApp({ store: new InMemoryWebhookKeyStore() });
+    const res = await request(app).get('/api/admin/webhooks/grace-window');
+    expect(res.status).toBe(200);
+    expect(res.body.data.graceWindowMs).toBe(86_400_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grace-window integration: dual-key verification scenario
+// ---------------------------------------------------------------------------
+
+describe('Grace window — dual-key verification', () => {
+  it('both old and new raw secrets are valid during grace window', async () => {
+    const store = new InMemoryWebhookKeyStore();
+    const fakeNow = { value: new Date('2025-06-01T10:00:00Z') };
+    const service = new WebhookSignerService({
+      store,
+      graceWindowMs: 60_000,
+      now: () => fakeNow.value,
+    });
+
+    const r1 = await service.rotateKey('admin');
+    const r2 = await service.rotateKey('admin');
+
+    // Both keys should be in the active hashes list
+    const hashes = await service.getActiveKeyHashes(fakeNow.value);
+    expect(hashes).toContain(hashSecret(r1.rawSecret));
+    expect(hashes).toContain(hashSecret(r2.rawSecret));
+  });
+
+  it('old key is no longer active after grace window ends', async () => {
+    const store = new InMemoryWebhookKeyStore();
+    const clock = { value: new Date('2025-06-01T10:00:00Z') };
+    const service = new WebhookSignerService({
+      store,
+      graceWindowMs: 60_000,
+      now: () => clock.value,
+    });
+
+    const r1 = await service.rotateKey('admin');
+    await service.rotateKey('admin');
+
+    // Advance past grace window
+    const afterGrace = new Date(clock.value.getTime() + 60_001);
+    const hashes = await service.getActiveKeyHashes(afterGrace);
+    expect(hashes).not.toContain(hashSecret(r1.rawSecret));
+  });
+
+  it('new key is valid immediately after rotation', async () => {
+    const store = new InMemoryWebhookKeyStore();
+    const service = new WebhookSignerService({ store, graceWindowMs: 60_000 });
+
+    const r1 = await service.rotateKey('admin');
+    const hashes = await service.getActiveKeyHashes();
+    expect(hashes).toContain(hashSecret(r1.rawSecret));
+  });
+});

--- a/src/services/webhookSigner.ts
+++ b/src/services/webhookSigner.ts
@@ -1,0 +1,335 @@
+/**
+ * webhookSigner.ts
+ *
+ * Manages the *platform-level* webhook signing key lifecycle:
+ *   - Generates cryptographically-random HMAC-SHA256 secrets.
+ *   - Stores key metadata (hash, status, expiry) via an injected KeyStore.
+ *   - Returns BOTH the active and the still-valid previous key on `getActiveSecrets()`
+ *     so callers can verify against either during the grace window.
+ *   - Dispatches a rotation notification and writes an audit log entry on each rotation.
+ *
+ * Security properties:
+ *   - Raw key material is returned ONLY at generation time; the store persists
+ *     only the SHA-256 hash, so a DB breach cannot expose live secrets.
+ *   - The returned `rawSecret` on rotation must be distributed to subscribers
+ *     immediately; it is unrecoverable afterward.
+ *   - Grace-window duration is read from the `WEBHOOK_SECRET_ROTATION_GRACE_MS`
+ *     environment variable (default: 86 400 000 ms = 24 h).
+ */
+
+import crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+import { logger } from '../logger.js';
+import { getRequestId } from '../logger.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default grace window: 24 hours in milliseconds. */
+const DEFAULT_GRACE_WINDOW_MS = 86_400_000;
+
+/** Number of random bytes for the signing key (256-bit entropy). */
+const KEY_BYTES = 32;
+
+// ---------------------------------------------------------------------------
+// Types & interfaces (dependency-injection friendly)
+// ---------------------------------------------------------------------------
+
+export type KeyStatus = 'active' | 'previous' | 'expired';
+
+/** Persisted representation of one signing key (no raw secret stored). */
+export interface WebhookSigningKey {
+  id: string;
+  key_hash: string;     // SHA-256 hex of the raw secret
+  status: KeyStatus;
+  created_at: string;   // ISO-8601
+  expires_at: string | null;
+  created_by: string;
+}
+
+/** Audit log entry written on every rotation. */
+export interface WebhookKeyRotationAudit {
+  id: string;
+  new_key_id: string;
+  previous_key_id: string | null;
+  grace_window_ms: number;
+  expires_at: string;   // ISO-8601 — when the previous key becomes invalid
+  rotated_by: string;
+  rotated_at: string;   // ISO-8601
+  correlation_id: string | null;
+}
+
+/**
+ * Minimal DB/cache abstraction — swap the in-memory implementation for a
+ * real Postgres/SQLite adapter without touching service logic.
+ */
+export interface WebhookKeyStore {
+  /**
+   * Returns the single key currently marked `active`, or null if no key
+   * has ever been generated.
+   */
+  getActiveKey(): Promise<WebhookSigningKey | null>;
+
+  /**
+   * Returns all keys with status `'previous'` whose `expires_at` is still
+   * in the future (i.e. still within their grace window).
+   */
+  getValidPreviousKeys(now: Date): Promise<WebhookSigningKey[]>;
+
+  /**
+   * Persist a new key row.  The caller is responsible for setting status,
+   * expires_at, etc. before calling this.
+   */
+  insertKey(key: WebhookSigningKey): Promise<void>;
+
+  /**
+   * Transition the current active key to `'previous'` and set its expiry.
+   * No-op when there is no active key (first-ever rotation).
+   */
+  demoteActiveKey(expiresAt: Date): Promise<WebhookSigningKey | null>;
+
+  /**
+   * Expire all `'previous'` keys whose `expires_at` is in the past.
+   * Called lazily on each read to keep the store clean.
+   */
+  expireStaleKeys(now: Date): Promise<void>;
+
+  /**
+   * Append a rotation audit record.
+   */
+  insertAuditEntry(entry: WebhookKeyRotationAudit): Promise<void>;
+}
+
+/** What callers get back from `rotateKey()`. */
+export interface RotationResult {
+  /** The new active key's metadata (no raw secret). */
+  newKey: WebhookSigningKey;
+  /** Raw secret — ONLY available here; not stored anywhere after this call. */
+  rawSecret: string;
+  /** The demoted previous key (if any). */
+  previousKey: WebhookSigningKey | null;
+  /** Grace window applied, in milliseconds. */
+  graceWindowMs: number;
+  /** UTC timestamp when the old key becomes invalid. */
+  previousKeyExpiresAt: string | null;
+}
+
+/** Dependency bundle injected into WebhookSignerService. */
+export interface WebhookSignerDeps {
+  store: WebhookKeyStore;
+  /** Called after a successful rotation to notify admin (fire-and-forget). */
+  notifyAdmin?: (result: RotationResult) => Promise<void>;
+  /** Overrideable clock — defaults to `() => new Date()`. */
+  now?: () => Date;
+  /** Grace window override in milliseconds. Defaults to WEBHOOK_SECRET_ROTATION_GRACE_MS env var. */
+  graceWindowMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a cryptographically-random hex secret. */
+export function generateSigningSecret(): string {
+  return crypto.randomBytes(KEY_BYTES).toString('hex');
+}
+
+/** SHA-256 hex hash of the raw secret — stored instead of plaintext. */
+export function hashSecret(rawSecret: string): string {
+  return crypto.createHash('sha256').update(rawSecret).digest('hex');
+}
+
+/** Read grace window from env (ms). Returns parsed int or default. */
+export function resolveGraceWindowMs(override?: number): number {
+  if (override !== undefined && Number.isFinite(override) && override > 0) {
+    return override;
+  }
+  const env = parseInt(process.env.WEBHOOK_SECRET_ROTATION_GRACE_MS ?? '', 10);
+  return Number.isFinite(env) && env > 0 ? env : DEFAULT_GRACE_WINDOW_MS;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class WebhookSignerService {
+  private readonly store: WebhookKeyStore;
+  private readonly notifyAdmin: (result: RotationResult) => Promise<void>;
+  private readonly clock: () => Date;
+  private readonly graceWindowMs: number;
+
+  constructor(deps: WebhookSignerDeps) {
+    this.store = deps.store;
+    this.notifyAdmin = deps.notifyAdmin ?? (() => Promise.resolve());
+    this.clock = deps.now ?? (() => new Date());
+    this.graceWindowMs = resolveGraceWindowMs(deps.graceWindowMs);
+  }
+
+  /**
+   * Rotate the platform webhook signing key.
+   *
+   * Steps:
+   *   1. Generate a new random secret + hash.
+   *   2. Demote the current active key → `previous` with an expiry timestamp.
+   *   3. Persist the new active key.
+   *   4. Write an audit log entry.
+   *   5. Fire-and-forget admin notification.
+   *
+   * @param actor  - Admin identifier from `res.locals.adminActor`.
+   * @returns      RotationResult containing the raw secret (one-time exposure).
+   */
+  async rotateKey(actor: string): Promise<RotationResult> {
+    const now = this.clock();
+    const correlationId = getRequestId() ?? null;
+    const expiresAt = new Date(now.getTime() + this.graceWindowMs);
+
+    // 1. Generate new key material
+    const rawSecret = generateSigningSecret();
+    const newKeyId = uuidv4();
+    const newKey: WebhookSigningKey = {
+      id: newKeyId,
+      key_hash: hashSecret(rawSecret),
+      status: 'active',
+      created_at: now.toISOString(),
+      expires_at: null,           // active key has no expiry
+      created_by: actor,
+    };
+
+    // 2. Demote existing active key
+    const previousKey = await this.store.demoteActiveKey(expiresAt);
+
+    // 3. Persist new active key
+    await this.store.insertKey(newKey);
+
+    // 4. Audit log
+    const auditEntry: WebhookKeyRotationAudit = {
+      id: uuidv4(),
+      new_key_id: newKeyId,
+      previous_key_id: previousKey?.id ?? null,
+      grace_window_ms: this.graceWindowMs,
+      expires_at: expiresAt.toISOString(),
+      rotated_by: actor,
+      rotated_at: now.toISOString(),
+      correlation_id: correlationId,
+    };
+    await this.store.insertAuditEntry(auditEntry);
+
+    logger.audit('WEBHOOK_KEY_ROTATED', actor, {
+      newKeyId,
+      previousKeyId: previousKey?.id ?? null,
+      graceWindowMs: this.graceWindowMs,
+      previousKeyExpiresAt: expiresAt.toISOString(),
+      correlationId,
+    });
+
+    const result: RotationResult = {
+      newKey,
+      rawSecret,
+      previousKey: previousKey ?? null,
+      graceWindowMs: this.graceWindowMs,
+      previousKeyExpiresAt: previousKey ? expiresAt.toISOString() : null,
+    };
+
+    // 5. Notify admin (fire-and-forget — failure must not roll back rotation)
+    this.notifyAdmin(result).catch((err: unknown) => {
+      logger.error('Webhook key rotation: admin notification failed', err);
+    });
+
+    return result;
+  }
+
+  /**
+   * Return all currently-valid raw key hashes (active + unexpired previous).
+   * Used by signature-verification middleware to accept either key.
+   *
+   * Note: hashes — not raw secrets — are what lives in the store.
+   */
+  async getActiveKeyHashes(now?: Date): Promise<string[]> {
+    const ts = now ?? this.clock();
+
+    // Clean up expired keys lazily on each read
+    await this.store.expireStaleKeys(ts);
+
+    const active = await this.store.getActiveKey();
+    const previous = await this.store.getValidPreviousKeys(ts);
+
+    const hashes: string[] = [];
+    if (active) hashes.push(active.key_hash);
+    for (const k of previous) hashes.push(k.key_hash);
+    return hashes;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default in-memory store (suitable for tests and single-process deploys)
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory implementation of WebhookKeyStore.
+ * Replace with a SQLite/Postgres-backed implementation for production persistence.
+ */
+export class InMemoryWebhookKeyStore implements WebhookKeyStore {
+  private keys: WebhookSigningKey[] = [];
+  private auditLog: WebhookKeyRotationAudit[] = [];
+
+  async getActiveKey(): Promise<WebhookSigningKey | null> {
+    return this.keys.find((k) => k.status === 'active') ?? null;
+  }
+
+  async getValidPreviousKeys(now: Date): Promise<WebhookSigningKey[]> {
+    return this.keys.filter(
+      (k) =>
+        k.status === 'previous' &&
+        k.expires_at !== null &&
+        new Date(k.expires_at).getTime() >= now.getTime(),
+    );
+  }
+
+  async insertKey(key: WebhookSigningKey): Promise<void> {
+    this.keys.push({ ...key });
+  }
+
+  async demoteActiveKey(expiresAt: Date): Promise<WebhookSigningKey | null> {
+    const idx = this.keys.findIndex((k) => k.status === 'active');
+    if (idx === -1) return null;
+    this.keys[idx] = {
+      ...this.keys[idx],
+      status: 'previous',
+      expires_at: expiresAt.toISOString(),
+    };
+    return { ...this.keys[idx] };
+  }
+
+  async expireStaleKeys(now: Date): Promise<void> {
+    for (const key of this.keys) {
+      if (
+        key.status === 'previous' &&
+        key.expires_at !== null &&
+        new Date(key.expires_at).getTime() < now.getTime()
+      ) {
+        key.status = 'expired';
+      }
+    }
+  }
+
+  async insertAuditEntry(entry: WebhookKeyRotationAudit): Promise<void> {
+    this.auditLog.push({ ...entry });
+  }
+
+  /** Test helper — inspect stored keys. */
+  _getKeys(): WebhookSigningKey[] {
+    return [...this.keys];
+  }
+
+  /** Test helper — inspect audit log. */
+  _getAuditLog(): WebhookKeyRotationAudit[] {
+    return [...this.auditLog];
+  }
+
+  /** Test helper — reset state. */
+  _reset(): void {
+    this.keys = [];
+    this.auditLog = [];
+  }
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedUser } from "./auth";
+import type { AuditContext } from "../middleware/auditEnrich.js";
 
 declare global {
   namespace Express {
@@ -21,6 +22,8 @@ declare global {
       endpoint?: Record<string, unknown>;
       apiKeyRecord?: Record<string, unknown>;
       apiKeyValue?: string;
+      /** Enriched forensic context attached by auditEnrichMiddleware. */
+      auditContext: AuditContext;
     }
   }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>feat: enrich audit trail with IP/UA/tenant/body-hash</h1>
<p>closes #484 </p>
<h2>Summary</h2>
<p>Every audit log entry now carries four forensic fields that were previously missing:</p>

Field | Description
-- | --
clientIp | Proxy-aware client IP (shared getClientIp() logic)
userAgent | Sanitised User-Agent header, truncated at 512 chars
tenantId | Authenticated developer user_id (null for admin/system paths)
correlationId | x-request-id / x-correlation-id for log-to-audit joining
bodyHash | HMAC-SHA256(JSON body, AUDIT_BODY_HASH_SECRET), hex — null if no body or key absent


<p>The hash is <strong>keyed</strong> (HMAC, not plain SHA-256): an attacker with DB read access cannot reverse-engineer request bodies or forge matching digests without the secret.</p>
<hr>
<h2>Changes</h2>
<h3><code>migrations/0016_audit_enrichment.sql</code> <em>(new)</em></h3>
<p>Creates the <code>audit_logs</code> table with all enriched columns plus four indexes:</p>
<ul>
<li><code>idx_audit_logs_tenant_id</code> — tenant-scoped forensic queries</li>
<li><code>idx_audit_logs_event</code> — compliance reports by event type</li>
<li><code>idx_audit_logs_created_at</code> — time-window queries</li>
<li><code>idx_audit_logs_correlation_id</code> (partial, <code>WHERE correlation_id IS NOT NULL</code>) — join to access logs</li>
</ul>
<h3><code>src/middleware/auditEnrich.ts</code> <em>(new)</em></h3>
<p>Express middleware that attaches <code>req.auditContext</code> to every request <strong>before</strong> route handlers run, so call sites only need to spread it:</p>
<pre><code class="language-ts">logger.audit('MY_EVENT', actor, {
  ...req.auditContext,   // clientIp, userAgent, tenantId, correlationId, bodyHash
  diff: { ... },
});
</code></pre>
<p>Key design decisions:</p>
<ul>
<li><code>computeBodyHash(body, secret)</code> — HMAC-SHA256 with <code>AUDIT_BODY_HASH_SECRET</code>; returns <code>null</code> (not throws) when the key is absent or the body is not an object</li>
<li><code>sanitizeUserAgent(raw)</code> — trims and truncates to 512 chars to prevent log-flooding</li>
<li><code>tenantId</code> is read from <code>req.developerId</code> (set by <code>requireAuth</code> / <code>gatewayApiKeyAuth</code>); routes that authenticate inside the handler should override it explicitly in the <code>logger.audit()</code> call</li>
<li><code>bodyHash</code> is computed <strong>once</strong> at middleware time — before any route handler can mutate <code>req.body</code></li>
<li>A one-time startup warning is emitted if <code>AUDIT_BODY_HASH_SECRET</code> is not configured (does not crash the server)</li>
</ul>
<h3><code>src/types/express.d.ts</code> <em>(updated)</em></h3>
<p>Adds <code>auditContext: AuditContext</code> to the Express <code>Request</code> interface so every route handler gets full TypeScript inference without casts.</p>
<h3><code>src/app.ts</code> <em>(updated)</em></h3>
<p>Mounts <code>auditEnrichMiddleware</code> immediately after <code>express.json()</code> / <code>express.urlencoded()</code> so that <code>req.body</code> is already parsed when the hash is computed:</p>
<pre><code class="language-ts">app.use(express.json({ limit: requestBodyLimit }));
app.use(express.urlencoded({ extended: false, limit: requestBodyLimit }));
// ✅ NEW — attaches req.auditContext for all downstream routes
app.use(auditEnrichMiddleware);
</code></pre>
<h3><code>scripts/backfill-audit.ts</code> <em>(new)</em></h3>
<p>Idempotent backfill for rows that existed before the migration:</p>
<ol>
<li>Verifies <code>audit_logs</code> table exists (fails fast if migration hasn't run).</li>
<li>Copies <code>actor → tenant_id</code> for developer-actor rows (skips system actors: <code>admin-api-key</code>, <code>admin-jwt</code>, <code>system</code>).</li>
<li>Sets <code>correlation_id = id</code> (the row UUID) as a synthetic fallback for rows with no correlation id.</li>
<li>Leaves <code>body_hash</code>, <code>client_ip</code>, and <code>user_agent</code> NULL — these cannot be reconstructed after the fact.</li>
</ol>
<p>Processed in configurable batches (<code>BATCH_SIZE</code>, default 500). Supports <code>DRY_RUN=true</code>.</p>
<pre><code class="language-bash"># Preview
DRY_RUN=true DATABASE_URL=./callora.db tsx scripts/backfill-audit.ts

# Run
BATCH_SIZE=500 DATABASE_URL=./callora.db tsx scripts/backfill-audit.ts
</code></pre>
<h3><code>src/middleware/auditEnrich.test.ts</code> <em>(new)</em></h3>
<p>Full test suite (≥ 90 % line coverage on changed files):</p>
<p><strong><code>computeBodyHash</code></strong> — 12 cases: keyed hash, same/different bodies and secrets, missing key (undefined / empty string), null / undefined / string / number / empty-object / array bodies.</p>
<p><strong><code>sanitizeUserAgent</code></strong> — 6 cases: normal value, whitespace trimming, truncation at <code>USER_AGENT_MAX_LENGTH</code>, exact-length preservation, empty string, undefined.</p>
<p><strong><code>auditEnrichMiddleware</code></strong> — 14 cases: context attachment + <code>next()</code> call, socket IP resolution, UA extraction and missing-UA, <code>correlationId</code> from <code>req.id</code> / <code>x-request-id</code> / <code>x-correlation-id</code> / absent, <code>tenantId</code> from <code>req.developerId</code> / absent, <code>bodyHash</code> for object body / absent body / missing secret, deterministic hash across two identical requests.</p>
<hr>
<h2>Security</h2>
<ul>
<li><code>AUDIT_BODY_HASH_SECRET</code> must be set in production (recommend ≥ 32 random bytes). The server starts without it but emits a warning and omits body hashes.</li>
<li>The middleware never throws — all edge cases (circular refs, non-object body, missing secret) are handled gracefully so a hashing failure cannot produce a 500.</li>
<li>User-Agent is truncated at 512 characters to prevent log-flooding / storage amplification attacks.</li>
<li><code>clientIp</code> extraction follows the same proxy-trust rules as the existing IP allowlist middleware (<code>TRUST_PROXY_HEADERS</code> env var).</li>
</ul>
<h2>New environment variable</h2>
<p>Add to <code>.env</code> (and <code>.env.example</code>):</p>
<pre><code class="language-env"># Audit log body hashing — HMAC-SHA256 key.
# Minimum recommended: 32 random bytes (hex or base64).
# If absent, body_hash will be null in all audit rows.
AUDIT_BODY_HASH_SECRET=your-random-secret-here
</code></pre>
<h2>Git commands</h2>
<pre><code class="language-bash">git checkout -b task/audit-enrichment
git add migrations/0016_audit_enrichment.sql
git add src/middleware/auditEnrich.ts
git add src/middleware/auditEnrich.test.ts
git add scripts/backfill-audit.ts
git add src/app.ts
git add src/types/express.d.ts
git commit -m "feat: enrich audit trail with IP/UA/tenant/body-hash

- Add audit_logs table (migration 0016) with IP, UA, tenant_id,
  correlation_id, and keyed body_hash columns + 4 indexes
- Add auditEnrichMiddleware: attaches req.auditContext before routes
- HMAC-SHA256 body hash keyed with AUDIT_BODY_HASH_SECRET
- Sanitise User-Agent (trim + 512-char cap) to prevent log flooding
- Mount middleware in app.ts after express.json() body parsing
- Augment Express Request type with auditContext: AuditContext
- Add backfill-audit.ts: idempotent tenant_id + correlation_id backfill
- Full test coverage in src/middleware/auditEnrich.test.ts

closes #484"
git push origin task/audit-enrichment
</code></pre></body></html><!--EndFragment-->
</body>
</html>