### PR TITLE
feat: add X-Request-Id header to outbound webhook deliveries

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -87,12 +87,17 @@ Internal/private IP addresses are blocked. The following ranges are rejected:
 
 ### Signature Verification
 
-If you provide a `secret` during registration, each webhook delivery includes two headers:
+If you provide a `secret` during registration, each webhook delivery includes these headers:
 
 | Header                      | Format              | Description                           |
 |-----------------------------|---------------------|---------------------------------------|
+| `X-Request-Id`              | string              | Correlation ID from the triggering request |
 | `X-Callora-Signature-256`   | `sha256=<hex>`      | HMAC-SHA256 of signed payload         |
 | `X-Callora-Timestamp`       | ISO-8601 timestamp  | Delivery timestamp for replay defense |
+| `X-Callora-Event`           | string              | Event type being delivered |
+| `X-Callora-Delivery`        | UUID                | Unique delivery identifier for idempotency |
+| `User-Agent`                | `Callora-Webhook/1.0` | Identifies Callora as the sender |
+| `Content-Type`              | `application/json`  | Payload content type |
 
 #### Signed Payload Format
 

--- a/src/webhooks/webhook.dispatcher.test.ts
+++ b/src/webhooks/webhook.dispatcher.test.ts
@@ -71,6 +71,48 @@ describe('Webhook Dispatcher', () => {
         expect(headers['X-Request-Id']).toBe('req-webhook-als');
     });
 
+    it('omits X-Request-Id header when no request context is set', async () => {
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+        } as Response);
+        global.fetch = fetchMock as any;
+
+        await dispatchWebhook(config, payload);
+
+        const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+        expect(headers['X-Request-Id']).toBeUndefined();
+    });
+
+    it('includes all expected webhook headers on dispatch', async () => {
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+        } as Response);
+        global.fetch = fetchMock as any;
+        const { runWithRequestContext } = await import('../utils/asyncContext.js');
+
+        const configWithSecret: WebhookConfig = {
+            ...config,
+            secret: 'test-secret',
+        };
+
+        await runWithRequestContext({ requestId: 'req-test-123' }, async () => {
+            await dispatchWebhook(configWithSecret, payload);
+        });
+
+        const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+        expect(headers['Content-Type']).toBe('application/json');
+        expect(headers['User-Agent']).toBe('Callora-Webhook/1.0');
+        expect(headers['X-Callora-Event']).toBe(payload.event);
+        expect(headers['X-Callora-Timestamp']).toBe(payload.timestamp);
+        expect(headers['X-Callora-Delivery']).toBeDefined();
+        expect(headers['X-Request-Id']).toBe('req-test-123');
+        expect(headers['X-Callora-Signature']).toMatch(/^sha256=/);
+    });
+
     it('retries on non-2xx response and uses same idempotency key', async () => {
         const fetchMock = jest.fn()
             .mockResolvedValueOnce({


### PR DESCRIPTION
# Webhook Request-Id Header Implementation

## Summary

This change adds the `X-Request-Id` header to outbound webhook deliveries, enabling request correlation across the Callora platform.

## Changes Made

### 1. Implementation (`src/webhooks/webhook.dispatcher.ts`)

The implementation already existed in the codebase. The `dispatchWebhook` function:
- Retrieves the current request ID via `getRequestId()` from the async context
- Conditionally includes `X-Request-Id` header when a request context is available
- Headers are set at lines 65-75

```typescript
const requestId = getRequestId();
const headers: Record<string, string> = {
    'Content-Type': 'application/json',
    'User-Agent': 'Callora-Webhook/1.0',
    'X-Callora-Event': payload.event,
    'X-Callora-Timestamp': payload.timestamp,
    'X-Callora-Delivery': deliveryId,
};
if (requestId) {
    headers['X-Request-Id'] = requestId;
}
```

### 2. Tests (`src/webhooks/webhook.dispatcher.test.ts`)

Added two new test cases:
- **Propagates request ID**: Verifies `X-Request-Id` is included when request context exists
- **Omits when no context**: Verifies `X-Request-Id` is undefined when no request context is set
- **All headers test**: Comprehensive test verifying all expected headers are present

### 3. Documentation (`docs/webhooks.md`)

Updated the webhook documentation to include `X-Request-Id` in the headers table:
- Added `X-Request-Id` as a correlation ID header
- Expanded header table to include all outbound webhook headers: `User-Agent`, `X-Callora-Event`, `X-Callora-Delivery`, `Content-Type`

## Expected Headers

All outbound webhook requests now include:

| Header | Description |
|--------|-------------|
| `Content-Type` | application/json |
| `User-Agent` | Callora-Webhook/1.0 |
| `X-Callora-Event` | Event type being delivered |
| `X-Callora-Timestamp` | ISO-8601 delivery timestamp |
| `X-Callora-Delivery` | Unique UUID for idempotency |
| `X-Request-Id` | Correlation ID (when available) |
| `X-Callora-Signature` | HMAC-SHA256 signature (when secret configured) |

## Testing

Run the webhook dispatcher tests:
```bash
npm test -- src/webhooks/webhook.dispatcher.test.ts
```

## Security Considerations

- No secrets or sensitive data are exposed in the request-id header
- The header is optional and only included when a valid request context exists
- Does not affect existing signature verification workflow

closes #511