### PR TITLE
feat: admin webhook replay with audit

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -72,6 +72,8 @@ This section is generated from `docs/error-codes.yaml`. Run `npm run error-codes
 | `WEBHOOK_TIMESTAMP_OUT_OF_WINDOW` | Webhooks |
 | `MALFORMED_WEBHOOK_SIGNATURE` | Webhooks |
 | `INVALID_WEBHOOK_SIGNATURE` | Webhooks |
+| `INVALID_DELIVERY_ID` | Webhooks |
+| `DLQ_ENTRY_NOT_FOUND` | Webhooks |
 | `INVALID_IP_FORMAT` | IP allowlist |
 | `IP_NOT_ALLOWED` | IP allowlist |
 | `DATABASE_NOT_AVAILABLE` | DB / infrastructure |

--- a/docs/error-codes.yaml
+++ b/docs/error-codes.yaml
@@ -259,6 +259,14 @@ error_codes:
     section: Webhooks
     description: Webhook signature verification failed
 
+  - code: INVALID_DELIVERY_ID
+    section: Webhooks
+    description: The delivery ID provided for webhook replay is missing or invalid
+
+  - code: DLQ_ENTRY_NOT_FOUND
+    section: Webhooks
+    description: No Dead-Letter Queue entry was found for the given delivery ID
+
   # IP allowlist
   - code: INVALID_IP_FORMAT
     section: IP allowlist

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1141,10 +1141,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["plugins", "total"],
+                  "required": [
+                    "plugins",
+                    "total"
+                  ],
                   "properties": {
-                    "plugins": { "type": "array", "items": { "$ref": "#/components/schemas/PluginRecord" } },
-                    "total": { "type": "integer" }
+                    "plugins": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PluginRecord"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
                   }
                 }
               }
@@ -1155,12 +1165,18 @@
       "post": {
         "summary": "Register a new plugin",
         "description": "Registers a new community plugin manifest. Requires authentication.",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/PluginManifest" }
+              "schema": {
+                "$ref": "#/components/schemas/PluginManifest"
+              }
             }
           }
         },
@@ -1169,33 +1185,122 @@
             "description": "Plugin registered",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PluginRecord" }
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
               }
             }
           },
-          "400": { "description": "Validation error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "409": { "description": "Plugin already registered", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Plugin already registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
     "/api/marketplace/plugins/{id}": {
       "get": {
         "summary": "Get a plugin by ID",
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Plugin found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PluginRecord" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Plugin found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Remove a plugin from the registry",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "204": { "description": "Plugin removed" },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "204": {
+            "description": "Plugin removed"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1203,8 +1308,21 @@
       "post": {
         "summary": "Install a plugin",
         "description": "Marks a plugin as installed and fires the install hook. Requires authentication.",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Plugin installed",
@@ -1212,17 +1330,29 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["plugin"],
+                  "required": [
+                    "plugin"
+                  ],
                   "properties": {
-                    "plugin": { "$ref": "#/components/schemas/PluginRecord" },
+                    "plugin": {
+                      "$ref": "#/components/schemas/PluginRecord"
+                    },
                     "hook": {
                       "nullable": true,
                       "type": "object",
                       "properties": {
-                        "ok": { "type": "boolean" },
-                        "hook": { "type": "string" },
-                        "pluginId": { "type": "string" },
-                        "sandboxed": { "type": "boolean" }
+                        "ok": {
+                          "type": "boolean"
+                        },
+                        "hook": {
+                          "type": "string"
+                        },
+                        "pluginId": {
+                          "type": "string"
+                        },
+                        "sandboxed": {
+                          "type": "boolean"
+                        }
                       }
                     }
                   }
@@ -1230,21 +1360,106 @@
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "409": { "description": "Already installed", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Already installed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Uninstall a plugin",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Plugin uninstalled", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PluginRecord" } } } },
-          "400": { "description": "Not installed", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Plugin uninstalled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Not installed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1265,30 +1480,84 @@
     "schemas": {
       "PluginManifest": {
         "type": "object",
-        "required": ["id", "name", "version", "hooks"],
+        "required": [
+          "id",
+          "name",
+          "version",
+          "hooks"
+        ],
         "properties": {
-          "id": { "type": "string", "minLength": 3, "maxLength": 64, "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
-          "name": { "type": "string", "minLength": 1, "maxLength": 128 },
-          "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
-          "description": { "type": "string", "maxLength": 512 },
-          "author": { "type": "string", "maxLength": 128 },
+          "id": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64,
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "author": {
+            "type": "string",
+            "maxLength": 128
+          },
           "hooks": {
             "type": "array",
             "minItems": 1,
-            "items": { "type": "string", "enum": ["before_charge", "after_charge", "on_refund", "on_quota_exceeded"] }
+            "items": {
+              "type": "string",
+              "enum": [
+                "before_charge",
+                "after_charge",
+                "on_refund",
+                "on_quota_exceeded"
+              ]
+            }
           },
-          "source_url": { "type": "string", "format": "uri" }
+          "source_url": {
+            "type": "string",
+            "format": "uri"
+          }
         }
       },
       "PluginRecord": {
         "type": "object",
-        "required": ["manifest", "status", "created_at"],
+        "required": [
+          "manifest",
+          "status",
+          "created_at"
+        ],
         "properties": {
-          "manifest": { "$ref": "#/components/schemas/PluginManifest" },
-          "status": { "type": "string", "enum": ["available", "installed"] },
-          "installed_by": { "type": "string", "nullable": true },
-          "installed_at": { "type": "string", "nullable": true },
-          "created_at": { "type": "string" }
+          "manifest": {
+            "$ref": "#/components/schemas/PluginManifest"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "available",
+              "installed"
+            ]
+          },
+          "installed_by": {
+            "type": "string",
+            "nullable": true
+          },
+          "installed_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       },
       "BillingDeductRequest": {
@@ -2196,6 +2465,8 @@
           "WEBHOOK_TIMESTAMP_OUT_OF_WINDOW",
           "MALFORMED_WEBHOOK_SIGNATURE",
           "INVALID_WEBHOOK_SIGNATURE",
+          "INVALID_DELIVERY_ID",
+          "DLQ_ENTRY_NOT_FOUND",
           "INVALID_IP_FORMAT",
           "IP_NOT_ALLOWED",
           "DATABASE_NOT_AVAILABLE",

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -189,6 +189,12 @@ export const ErrorCode = {
   /** Webhook signature verification failed */
   INVALID_WEBHOOK_SIGNATURE: "INVALID_WEBHOOK_SIGNATURE",
 
+  /** The delivery ID provided for webhook replay is missing or invalid */
+  INVALID_DELIVERY_ID: "INVALID_DELIVERY_ID",
+
+  /** No Dead-Letter Queue entry was found for the given delivery ID */
+  DLQ_ENTRY_NOT_FOUND: "DLQ_ENTRY_NOT_FOUND",
+
   /** IP address format is invalid */
   INVALID_IP_FORMAT: "INVALID_IP_FORMAT",
 

--- a/src/routes/admin/webhooks.ts
+++ b/src/routes/admin/webhooks.ts
@@ -2,9 +2,10 @@
  * src/routes/admin/webhooks.ts
  *
  * Composes all admin webhook routes under one router:
- *   POST /api/admin/webhooks/rotate-key     (from webhookKeys)
- *   GET  /api/admin/webhooks/grace-window   (from webhookKeys)
- *   GET  /api/admin/webhooks/monitor        ← new
+ *   POST /api/admin/webhooks/rotate-key          (from webhookKeys)
+ *   GET  /api/admin/webhooks/grace-window        (from webhookKeys)
+ *   GET  /api/admin/webhooks/monitor
+ *   POST /api/admin/webhooks/replay              (from replay)
  *
  * Authentication: adminAuth middleware applied at the parent admin router.
  * IP allowlist:   createAdminIpAllowlist() applied at the parent admin router.
@@ -19,8 +20,10 @@ import { AppError, InternalServerError } from '../../errors/index.js';
 import { logger } from '../../logger.js';
 import { getWebhookMonitorSnapshot } from '../../services/webhookMonitor.js';
 import { createWebhookKeysRouter } from './webhookKeys.js';
+import { createAdminWebhookReplayRouter } from './webhooks/replay.js';
 
 export { createWebhookKeysRouter } from './webhookKeys.js';
+export { createAdminWebhookReplayRouter } from './webhooks/replay.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 
@@ -114,6 +117,13 @@ export function createAdminWebhooksRouter(
             next(new InternalServerError('Failed to retrieve webhook monitor data'));
         }
     });
+
+    // ── POST /replay ───────────────────────────────────────────────────────
+    /**
+     * Mounts the replay sub-router under /replay.
+     * The replay endpoint is POST /api/admin/webhooks/replay.
+     */
+    router.use('/replay', createAdminWebhookReplayRouter());
 
     return router;
 }

--- a/src/routes/admin/webhooks/replay.test.ts
+++ b/src/routes/admin/webhooks/replay.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Tests for POST /api/admin/webhooks/replay
+ *
+ * Coverage:
+ *   - Successful replay from DLQ
+ *   - Authorization (API key + JWT)
+ *   - Missing deliveryId validation
+ *   - Non-existent deliveryId
+ *   - Admin audit logging
+ *   - Standardized error envelope
+ *   - Secrets never exposed in response
+ *   - Dispatch is triggered (fire-and-forget)
+ */
+
+jest.mock('better-sqlite3', () => {
+    return class MockDatabase {
+        prepare() { return { get: () => null }; }
+        exec() { }
+        close() { }
+    };
+});
+
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { errorHandler } from '../../../middleware/errorHandler.js';
+import { WebhookStore } from '../../../webhooks/webhook.store.js';
+import { dispatchWebhook } from '../../../webhooks/webhook.dispatcher.js';
+import { createAdminWebhookReplayRouter } from './replay.js';
+import type { DeadLetterEntry } from '../../../webhooks/webhook.types.js';
+
+jest.mock('../../../logger', () => {
+    const actual = jest.requireActual('../../../logger');
+    return {
+        ...actual,
+        logger: {
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            audit: jest.fn(),
+        },
+    };
+});
+
+jest.mock('../../../webhooks/webhook.dispatcher.js', () => ({
+    dispatchWebhook: jest.fn(async () => undefined),
+}));
+
+import { logger } from '../../../logger.js';
+
+const mockedDispatchWebhook = jest.mocked(dispatchWebhook);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ADMIN_KEY = 'test-replay-admin-key';
+const JWT_SECRET = 'test-replay-jwt-secret';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDlqEntry(overrides: Partial<DeadLetterEntry> = {}): DeadLetterEntry {
+    return {
+        deliveryId: 'dlq-replay-001',
+        config: {
+            developerId: 'dev-replay-1',
+            url: 'https://hooks.example.com/receive',
+            events: ['new_api_call'],
+            createdAt: new Date('2026-06-01T00:00:00.000Z'),
+        },
+        payload: {
+            event: 'new_api_call',
+            timestamp: '2026-06-01T12:00:00.000Z',
+            developerId: 'dev-replay-1',
+            data: { apiId: 'api_123', creditsUsed: 5 },
+        },
+        failedAt: '2026-06-01T12:00:05.000Z',
+        lastError: 'HTTP 503 Service Unavailable',
+        attempts: 5,
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+
+    // Simulate the two adminAuth paths used by the real middleware
+    app.use((req, res, next) => {
+        const apiKey = req.headers['x-admin-api-key'];
+        if (apiKey === ADMIN_KEY) {
+            res.locals.adminActor = 'admin-api-key';
+            return next();
+        }
+
+        const auth = req.headers['authorization'];
+        if (auth?.startsWith('Bearer ')) {
+            try {
+                const payload = jwt.verify(auth.slice(7), JWT_SECRET) as { role?: string };
+                if (payload.role === 'admin') {
+                    res.locals.adminActor = 'admin-jwt';
+                    return next();
+                }
+            } catch {
+                // fall through
+            }
+        }
+
+        res.status(401).json({
+            code: 'UNAUTHORIZED',
+            message: 'Unauthorized: admin access required',
+            requestId: 'test',
+        });
+    });
+
+    app.use('/api/admin/webhooks/replay', createAdminWebhookReplayRouter());
+    app.use(errorHandler);
+    return app;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let app: ReturnType<typeof buildApp>;
+
+beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    process.env.JWT_SECRET = JWT_SECRET;
+    WebhookStore.clear();
+    WebhookStore.clearDlq();
+    WebhookStore.clearFailedDeliveries();
+    jest.clearAllMocks();
+    app = buildApp();
+});
+
+afterEach(() => {
+    delete process.env.ADMIN_API_KEY;
+    delete process.env.JWT_SECRET;
+    jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Authorization
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/webhooks/replay — authorization', () => {
+    it('returns 200 with a valid admin API key', async () => {
+        WebhookStore.addToDlq(makeDlqEntry({ deliveryId: 'dlq-auth-1' }));
+
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-auth-1' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(200);
+    });
+
+    it('returns 200 with a valid admin JWT', async () => {
+        WebhookStore.addToDlq(makeDlqEntry({ deliveryId: 'dlq-auth-2' }));
+        const token = jwt.sign({ role: 'admin', sub: 'admin-user' }, JWT_SECRET, { expiresIn: '1h' });
+
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-auth-2' })
+            .set('Authorization', `Bearer ${token}`);
+
+        expect(res.status).toBe(200);
+    });
+
+    it('returns 401 with no credentials', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-auth-3' });
+
+        expect(res.status).toBe(401);
+        expect(res.body.code).toBe('UNAUTHORIZED');
+    });
+
+    it('returns 401 with a wrong API key', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-auth-4' })
+            .set('x-admin-api-key', 'definitely-wrong');
+
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with a non-admin JWT role', async () => {
+        const token = jwt.sign({ role: 'developer', sub: 'user-1' }, JWT_SECRET, { expiresIn: '1h' });
+
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-auth-5' })
+            .set('Authorization', `Bearer ${token}`);
+
+        expect(res.status).toBe(401);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/webhooks/replay — input validation', () => {
+    it('returns 400 when request body is missing entirely', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(400);
+        // express.json() sets req.body to {} even without a body,
+        // so the deliveryId check catches it with INVALID_DELIVERY_ID.
+        expect(res.body.code).toBe('INVALID_DELIVERY_ID');
+    });
+
+    it('returns 400 when deliveryId is missing', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({})
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('INVALID_DELIVERY_ID');
+        expect(res.body.message).toContain('deliveryId');
+    });
+
+    it('returns 400 when deliveryId is not a string', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 12345 })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('INVALID_DELIVERY_ID');
+    });
+
+    it('returns 400 when deliveryId is an empty string', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: '' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when deliveryId is only whitespace', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: '   ' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(400);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Not found
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/webhooks/replay — DLQ entry not found', () => {
+    it('returns 404 when no DLQ entry exists for the given deliveryId', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'nonexistent-delivery' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(404);
+        expect(res.body.code).toBe('DLQ_ENTRY_NOT_FOUND');
+        expect(res.body.message).toContain('nonexistent-delivery');
+    });
+
+    it('returns 404 when the DLQ is empty', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'any-delivery' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(404);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Successful replay
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/webhooks/replay — successful replay', () => {
+    it('returns a 200 with replay metadata', async () => {
+        const entry = makeDlqEntry({
+            deliveryId: 'dlq-success-1',
+            config: {
+                developerId: 'dev-success',
+                url: 'https://hooks.example.com/success',
+                events: ['settlement_completed'],
+                createdAt: new Date('2026-06-01T00:00:00.000Z'),
+            },
+            payload: {
+                event: 'settlement_completed',
+                timestamp: '2026-06-01T12:00:00.000Z',
+                developerId: 'dev-success',
+                data: { settlementId: 'stl_001', amount: '100.00' },
+            },
+        });
+        WebhookStore.addToDlq(entry);
+
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-success-1' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(200);
+
+        const { data } = res.body;
+        expect(data.deliveryId).toBe('dlq-success-1');
+        expect(data.status).toBe('replayed');
+        expect(data.targetUrl).toBe('https://hooks.example.com/success');
+        expect(data.event).toBe('settlement_completed');
+        expect(data.developerId).toBe('dev-success');
+        expect(data.replayedAt).toBeDefined();
+        expect(data.replayedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('triggers dispatchWebhook with the stored config and payload', async () => {
+        const entry = makeDlqEntry({ deliveryId: 'dlq-trigger-1' });
+        WebhookStore.addToDlq(entry);
+
+        await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-trigger-1' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(mockedDispatchWebhook).toHaveBeenCalledTimes(1);
+        expect(mockedDispatchWebhook).toHaveBeenCalledWith(
+            entry.config,
+            entry.payload,
+        );
+    });
+
+    it('replays successfully even with secret_current on the config', async () => {
+        const entry = makeDlqEntry({
+            deliveryId: 'dlq-secret-1',
+            config: {
+                developerId: 'dev-secret',
+                url: 'https://hooks.example.com/secret',
+                events: ['new_api_call'],
+                secret_current: 'whsec_test_secret_value',
+                createdAt: new Date('2026-06-01T00:00:00.000Z'),
+            },
+        });
+        WebhookStore.addToDlq(entry);
+
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-secret-1' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(200);
+
+        // Secret must not appear in the response body
+        expect(JSON.stringify(res.body)).not.toContain('whsec_test_secret_value');
+    });
+
+    it('logs an audit event on successful replay', async () => {
+        WebhookStore.addToDlq(makeDlqEntry({ deliveryId: 'dlq-audit-1' }));
+
+        await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-audit-1' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(logger.audit).toHaveBeenCalledWith(
+            'WEBHOOK_REPLAYED',
+            'admin-api-key',
+            expect.objectContaining({
+                deliveryId: 'dlq-audit-1',
+                developerId: 'dev-replay-1',
+                event: 'new_api_call',
+                targetUrl: 'https://hooks.example.com/receive',
+            }),
+        );
+    });
+
+    it('handles dispatch rejection gracefully (fire-and-forget)', async () => {
+        mockedDispatchWebhook.mockRejectedValueOnce(new Error('network error'));
+
+        WebhookStore.addToDlq(makeDlqEntry({ deliveryId: 'dlq-error-1' }));
+
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-error-1' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        // Even if the dispatch fails asynchronously, the endpoint returns 200
+        expect(res.status).toBe(200);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Response shape (standardized envelope)
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/webhooks/replay — response shape', () => {
+    it('wraps the result in a { data } envelope on success', async () => {
+        WebhookStore.addToDlq(makeDlqEntry({ deliveryId: 'dlq-env-1' }));
+
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-env-1' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data).toHaveProperty('deliveryId');
+        expect(res.body.data).toHaveProperty('status', 'replayed');
+    });
+
+    it('returns a standardized error envelope on 400', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({})
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(400);
+        expect(res.body).toHaveProperty('code');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    it('returns a standardized error envelope on 404', async () => {
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'does-not-exist' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(404);
+        expect(res.body).toHaveProperty('code', 'DLQ_ENTRY_NOT_FOUND');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    it('returns a standardized error envelope on internal error', async () => {
+        // Force WebhookStore.getFromDlq to throw
+        jest.spyOn(WebhookStore, 'getFromDlq').mockImplementationOnce(() => {
+            throw new Error('unexpected error');
+        });
+
+        const res = await request(app)
+            .post('/api/admin/webhooks/replay')
+            .send({ deliveryId: 'dlq-crash-1' })
+            .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(res.status).toBe(500);
+        expect(res.body).toHaveProperty('code');
+        expect(res.body).toHaveProperty('message');
+    });
+});

--- a/src/routes/admin/webhooks/replay.ts
+++ b/src/routes/admin/webhooks/replay.ts
@@ -1,0 +1,166 @@
+/**
+ * src/routes/admin/webhooks/replay.ts
+ *
+ * Admin webhook replay endpoint.
+ *
+ * Route:
+ *   POST /api/admin/webhooks/replay
+ *
+ * Re-dispatches a webhook from the Dead-Letter Queue by deliveryId.
+ * The admin provides the deliveryId of the failed delivery to replay.
+ *
+ * Authentication: adminAuth middleware applied at the parent admin router.
+ * Audit: Every replay is logged via logger.audit() with correlation context.
+ *
+ * Security:
+ *   - Input validation at the boundary (deliveryId must be a non-empty string)
+ *   - No payload/secrets leaked in responses or logs
+ *   - Dispatch runs asynchronously after the response is sent
+ */
+
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { getClientIp } from '../../../lib/clientIp.js';
+import { AppError, BadRequestError, NotFoundError, InternalServerError } from '../../../errors/index.js';
+import { logger } from '../../../logger.js';
+import { WebhookStore } from '../../../webhooks/webhook.store.js';
+import { dispatchWebhook } from '../../../webhooks/webhook.dispatcher.js';
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+/**
+ * Factory that returns the admin webhook replay router.
+ */
+export function createAdminWebhookReplayRouter(): Router {
+    const router = Router();
+
+    /**
+     * @openapi
+     * /api/admin/webhooks/replay:
+     *   post:
+     *     summary: Replay a failed webhook delivery from the Dead-Letter Queue
+     *     description: |
+     *       Re-dispatches a webhook that previously failed, using the original
+     *       payload and configuration stored in the Dead-Letter Queue.
+     *
+     *       The dispatch runs asynchronously — the endpoint returns immediately
+     *       once the replay has been queued. Monitor the delivery via the
+     *       GET /api/admin/webhooks/monitor endpoint.
+     *     security:
+     *       - AdminApiKey: []
+     *       - AdminJWT: []
+     *     requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             type: object
+     *             required: [ deliveryId ]
+     *             properties:
+     *               deliveryId:
+     *                 type: string
+     *                 format: uuid
+     *                 description: The delivery ID from a failed webhook (found in the monitor snapshot).
+     *     responses:
+     *       '200':
+     *         description: Webhook replay queued.
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 data:
+     *                   type: object
+     *                   properties:
+     *                     deliveryId: { type: string, format: uuid }
+     *                     status:    { type: string, enum: [replayed] }
+     *                     targetUrl: { type: string, format: uri }
+     *                     event:     { type: string }
+     *                     developerId: { type: string }
+     *                     replayedAt: { type: string, format: date-time }
+     *       '400': { $ref: '#/components/responses/BadRequest' }
+     *       '401': { $ref: '#/components/responses/Unauthorized' }
+     *       '404': { $ref: '#/components/responses/NotFound' }
+     *       '500': { $ref: '#/components/responses/InternalServerError' }
+     */
+    router.post('/', (req: Request, res: Response, next: NextFunction) => {
+        try {
+            // ── Input validation ────────────────────────────────────────────
+            if (!req.body || typeof req.body !== 'object') {
+                throw new BadRequestError(
+                    'Request body is required',
+                    'INVALID_BODY',
+                );
+            }
+
+            const { deliveryId } = req.body;
+
+            if (!deliveryId || typeof deliveryId !== 'string' || deliveryId.trim() === '') {
+                throw new BadRequestError(
+                    'deliveryId is required and must be a non-empty string',
+                    'INVALID_DELIVERY_ID',
+                );
+            }
+
+            const trimmedDeliveryId = deliveryId.trim();
+
+            // ── Look up DLQ entry ───────────────────────────────────────────
+            const entry = WebhookStore.getFromDlq(trimmedDeliveryId);
+            if (!entry) {
+                throw new NotFoundError(
+                    `No Dead-Letter Queue entry found for deliveryId: ${trimmedDeliveryId}`,
+                    'DLQ_ENTRY_NOT_FOUND',
+                );
+            }
+
+            // ── Fire replay (async, not awaited) ───────────────────────────
+            // The dispatch runs its own retry loop and failure recording.
+            // We do NOT await it so the admin gets an immediate confirmation.
+            dispatchWebhook(entry.config, entry.payload).catch((error) => {
+                logger.error('[admin] Replayed webhook delivery failed', {
+                    deliveryId: trimmedDeliveryId,
+                    developerId: entry.config.developerId,
+                    targetUrl: entry.config.url,
+                    event: entry.payload.event,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            });
+
+            // ── Audit log ───────────────────────────────────────────────────
+            const correlationId =
+                (typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : undefined) ??
+                (typeof req.headers['x-correlation-id'] === 'string' ? req.headers['x-correlation-id'] : undefined);
+
+            logger.audit('WEBHOOK_REPLAYED', res.locals.adminActor, {
+                deliveryId: trimmedDeliveryId,
+                developerId: entry.config.developerId,
+                targetUrl: entry.config.url,
+                event: entry.payload.event,
+                clientIp: getClientIp(req, TRUST_PROXY),
+                userAgent: req.get('User-Agent'),
+                correlationId,
+            });
+
+            return res.status(200).json({
+                data: {
+                    deliveryId: entry.deliveryId,
+                    status: 'replayed',
+                    targetUrl: entry.config.url,
+                    event: entry.payload.event,
+                    developerId: entry.config.developerId,
+                    replayedAt: new Date().toISOString(),
+                },
+            });
+        } catch (error) {
+            if (error instanceof AppError) {
+                next(error);
+                return;
+            }
+            logger.error('[admin] Webhook replay failed unexpectedly', error);
+            next(new InternalServerError('Failed to replay webhook'));
+        }
+    });
+
+    return router;
+}
+
+export default createAdminWebhookReplayRouter();

--- a/src/webhooks/webhook.store.ts
+++ b/src/webhooks/webhook.store.ts
@@ -135,6 +135,11 @@ export const WebhookStore = {
         return deadLetterStore.size;
     },
 
+    /** Look up a single DLQ entry by deliveryId. */
+    getFromDlq(deliveryId: string): DeadLetterEntry | undefined {
+        return deadLetterStore.get(deliveryId);
+    },
+
     /** Clear the DLQ — for testing only. */
     clearDlq(): void {
         deadLetterStore.clear();


### PR DESCRIPTION
## Description

Adds `POST /api/admin/webhooks/replay` endpoint that allows administrators to re-dispatch a failed webhook from the Dead-Letter Queue (DLQ). Every replay is audited via `logger.audit()` with correlation context.

## Changes

### New files
- **`src/routes/admin/webhooks/replay.ts`** — Route handler with:
  - Input validation at the boundary (deliveryId type, empty-string, req.body guard)
  - DLQ entry lookup via `WebhookStore.getFromDlq()`
  - Fire-and-forget re-dispatch using the stored config and payload
  - Structured audit logging with correlation ID, client IP, user agent
  - Standardized error envelope (400/404/500)
  - Inline OpenAPI documentation

- **`src/routes/admin/webhooks/replay.test.ts`** — 21 tests covering:
  - Authorization (API key, JWT, no credentials, wrong key, wrong role)
  - Input validation (missing body, missing deliveryId, non-string, empty, whitespace)
  - Not-found (nonexistent deliveryId, empty DLQ)
  - Success path (metadata, dispatch triggered, secrets not leaked, audit logged, fire-and-forget error handling)
  - Response shape (data envelope, 400/404/500 error envelopes)

### Modified files
- **`src/webhooks/webhook.store.ts`** — Added `getFromDlq(deliveryId)` to look up DLQ entries
- **`src/routes/admin/webhooks.ts`** — Mounted the replay sub-router under `/replay`
- **`docs/error-codes.yaml`** — Registered `INVALID_DELIVERY_ID` and `DLQ_ENTRY_NOT_FOUND` error codes
- **`src/errors/codes.ts`**, **`docs/error-codes.md`**, **`docs/openapi.json`** — Auto-generated from error catalog

## Design Notes

- **DLQ-only scope**: The endpoint replays from the Dead-Letter Queue, which stores the full payload and config. The existing `dispatchWebhook` only calls `recordFailedDelivery` (operational metadata), not `addToDlq`. DLQ entries must be explicitly added. This is a known design limitation — the monitor endpoint shows failed deliveries but they aren't replayable unless also in the DLQ.
- **Fire-and-forget**: Dispatch runs asynchronously after the response is sent. The admin receives immediate 200 confirmation; delivery status can be checked via the monitor endpoint.
- **Error codes registered in the catalog**: `INVALID_DELIVERY_ID` and `DLQ_ENTRY_NOT_FOUND` added to `docs/error-codes.yaml`.

## Testing

```
PASS src/routes/admin/webhooks/replay.test.ts (21 tests)
PASS src/routes/admin/webhooks.test.ts (19 tests — existing, all passing)
```

## Related Issues

Closes #606
