### PR TITLE
feat: top-N endpoints per developer (GET /api/usage/by-endpoint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See [docs/fee-abstraction.md](./docs/fee-abstraction.md) for full API reference,
   - `GET /api/apis/:id`
   - `POST /api/apis` for authenticated developers to register an API with priced endpoints
 - Usage route: `GET /api/usage`
+- Top-N endpoints per developer: `GET /api/usage/by-endpoint` — returns the authenticated developer's most-called endpoints ranked by call volume, filterable by `from`/`to`/`apiId`/`limit` (see [docs/usage-by-endpoint.md](./docs/usage-by-endpoint.md))
 - Live usage stream: `GET /api/usage/sse` for authenticated developer dashboards
 - Admin usage anomalies: `GET /api/admin/usage/anomalies` returns per-API daily usage anomalies (z-score spikes/drops) for admin review, filterable by `from`/`to`/`apiId`/`threshold`/`limit` (admin auth + IP allowlist)
 - Usage anomaly detector: background worker emits `usage.anomaly.detected` when per-developer 5-minute traffic exceeds a rolling 12-window baseline by a configurable multiplier (see `docs/usage-anomaly-detector.md`)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -351,6 +351,170 @@
         }
       }
     },
+    "/api/usage/by-endpoint": {
+      "get": {
+        "summary": "Top-N endpoints by call volume",
+        "description": "Returns the authenticated developer's most-called API endpoints ranked by call volume within the requested time window. Useful for identifying hot endpoints and optimising spend. Defaults to the last 30 days and top 5 endpoints when the corresponding query parameters are omitted.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Start of period (ISO-8601). Defaults to 30 days ago.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "End of period (ISO-8601). Defaults to now.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of endpoints to return. Must be a positive integer. Defaults to 5.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 5
+            }
+          },
+          {
+            "name": "apiId",
+            "in": "query",
+            "description": "Filter results to a specific API by its ID.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Top endpoints returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "period"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "description": "Endpoints ordered by call count descending. Ties are broken by endpoint path ascending.",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "endpoint",
+                          "calls",
+                          "revenue"
+                        ],
+                        "properties": {
+                          "endpoint": {
+                            "type": "string",
+                            "description": "Endpoint path (e.g. `/v1/weather/current`)."
+                          },
+                          "calls": {
+                            "type": "integer",
+                            "description": "Total number of calls to this endpoint in the period."
+                          },
+                          "revenue": {
+                            "type": "string",
+                            "description": "Total revenue generated in smallest USDC units (string to avoid precision loss)."
+                          }
+                        }
+                      }
+                    },
+                    "period": {
+                      "type": "object",
+                      "required": [
+                        "from",
+                        "to"
+                      ],
+                      "properties": {
+                        "from": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Effective start of the query period."
+                        },
+                        "to": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Effective end of the query period."
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": [
+                    {
+                      "endpoint": "/v1/weather/current",
+                      "calls": 142,
+                      "revenue": "142000"
+                    },
+                    {
+                      "endpoint": "/v1/weather/forecast",
+                      "calls": 87,
+                      "revenue": "87000"
+                    }
+                  ],
+                  "period": {
+                    "from": "2026-06-01T00:00:00.000Z",
+                    "to": "2026-07-01T00:00:00.000Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters (bad date format, invalid limit, `from` after `to`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/usage/anomalies": {
       "get": {
         "summary": "List detected usage anomalies",
@@ -1141,10 +1305,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["plugins", "total"],
+                  "required": [
+                    "plugins",
+                    "total"
+                  ],
                   "properties": {
-                    "plugins": { "type": "array", "items": { "$ref": "#/components/schemas/PluginRecord" } },
-                    "total": { "type": "integer" }
+                    "plugins": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PluginRecord"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
                   }
                 }
               }
@@ -1155,12 +1329,18 @@
       "post": {
         "summary": "Register a new plugin",
         "description": "Registers a new community plugin manifest. Requires authentication.",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/PluginManifest" }
+              "schema": {
+                "$ref": "#/components/schemas/PluginManifest"
+              }
             }
           }
         },
@@ -1169,33 +1349,122 @@
             "description": "Plugin registered",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PluginRecord" }
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
               }
             }
           },
-          "400": { "description": "Validation error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "409": { "description": "Plugin already registered", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Plugin already registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
     "/api/marketplace/plugins/{id}": {
       "get": {
         "summary": "Get a plugin by ID",
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Plugin found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PluginRecord" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Plugin found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Remove a plugin from the registry",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "204": { "description": "Plugin removed" },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "204": {
+            "description": "Plugin removed"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1203,8 +1472,21 @@
       "post": {
         "summary": "Install a plugin",
         "description": "Marks a plugin as installed and fires the install hook. Requires authentication.",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Plugin installed",
@@ -1212,17 +1494,29 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["plugin"],
+                  "required": [
+                    "plugin"
+                  ],
                   "properties": {
-                    "plugin": { "$ref": "#/components/schemas/PluginRecord" },
+                    "plugin": {
+                      "$ref": "#/components/schemas/PluginRecord"
+                    },
                     "hook": {
                       "nullable": true,
                       "type": "object",
                       "properties": {
-                        "ok": { "type": "boolean" },
-                        "hook": { "type": "string" },
-                        "pluginId": { "type": "string" },
-                        "sandboxed": { "type": "boolean" }
+                        "ok": {
+                          "type": "boolean"
+                        },
+                        "hook": {
+                          "type": "string"
+                        },
+                        "pluginId": {
+                          "type": "string"
+                        },
+                        "sandboxed": {
+                          "type": "boolean"
+                        }
                       }
                     }
                   }
@@ -1230,21 +1524,106 @@
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "409": { "description": "Already installed", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Already installed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Uninstall a plugin",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Plugin uninstalled", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PluginRecord" } } } },
-          "400": { "description": "Not installed", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Plugin uninstalled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Not installed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1265,30 +1644,84 @@
     "schemas": {
       "PluginManifest": {
         "type": "object",
-        "required": ["id", "name", "version", "hooks"],
+        "required": [
+          "id",
+          "name",
+          "version",
+          "hooks"
+        ],
         "properties": {
-          "id": { "type": "string", "minLength": 3, "maxLength": 64, "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
-          "name": { "type": "string", "minLength": 1, "maxLength": 128 },
-          "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
-          "description": { "type": "string", "maxLength": 512 },
-          "author": { "type": "string", "maxLength": 128 },
+          "id": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64,
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "author": {
+            "type": "string",
+            "maxLength": 128
+          },
           "hooks": {
             "type": "array",
             "minItems": 1,
-            "items": { "type": "string", "enum": ["before_charge", "after_charge", "on_refund", "on_quota_exceeded"] }
+            "items": {
+              "type": "string",
+              "enum": [
+                "before_charge",
+                "after_charge",
+                "on_refund",
+                "on_quota_exceeded"
+              ]
+            }
           },
-          "source_url": { "type": "string", "format": "uri" }
+          "source_url": {
+            "type": "string",
+            "format": "uri"
+          }
         }
       },
       "PluginRecord": {
         "type": "object",
-        "required": ["manifest", "status", "created_at"],
+        "required": [
+          "manifest",
+          "status",
+          "created_at"
+        ],
         "properties": {
-          "manifest": { "$ref": "#/components/schemas/PluginManifest" },
-          "status": { "type": "string", "enum": ["available", "installed"] },
-          "installed_by": { "type": "string", "nullable": true },
-          "installed_at": { "type": "string", "nullable": true },
-          "created_at": { "type": "string" }
+          "manifest": {
+            "$ref": "#/components/schemas/PluginManifest"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "available",
+              "installed"
+            ]
+          },
+          "installed_by": {
+            "type": "string",
+            "nullable": true
+          },
+          "installed_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       },
       "BillingDeductRequest": {

--- a/docs/usage-by-endpoint.md
+++ b/docs/usage-by-endpoint.md
@@ -1,0 +1,90 @@
+# GET /api/usage/by-endpoint — Top-N Endpoints per Developer
+
+Returns the authenticated developer's most-called API endpoints ranked by call volume within a requested time window. Useful for identifying hot endpoints, spotting usage spikes, and optimising spend.
+
+## Request
+
+```
+GET /api/usage/by-endpoint
+Authorization: Bearer <token>
+```
+
+### Query Parameters
+
+| Parameter | Type    | Required | Default        | Description                                              |
+|-----------|---------|----------|----------------|----------------------------------------------------------|
+| `from`    | string  | No       | 30 days ago    | Start of period (ISO-8601, e.g. `2026-06-01T00:00:00Z`) |
+| `to`      | string  | No       | Now            | End of period (ISO-8601)                                 |
+| `limit`   | integer | No       | `5`            | Maximum number of endpoints to return (≥ 1)              |
+| `apiId`   | string  | No       | all APIs       | Filter results to a specific registered API              |
+
+- If `from` and `to` are both omitted the last 30 days are used.
+- `from` must be ≤ `to`; otherwise a `400` is returned.
+- `limit` must be a positive integer; otherwise a `400` is returned.
+
+## Response
+
+HTTP `200`:
+
+```json
+{
+  "data": [
+    { "endpoint": "/v1/weather/current",  "calls": 142, "revenue": "142000" },
+    { "endpoint": "/v1/weather/forecast", "calls":  87, "revenue":  "87000" }
+  ],
+  "period": {
+    "from": "2026-06-01T00:00:00.000Z",
+    "to":   "2026-07-01T00:00:00.000Z"
+  }
+}
+```
+
+### Response fields
+
+| Field              | Type     | Description                                                              |
+|--------------------|----------|--------------------------------------------------------------------------|
+| `data`             | array    | Endpoints ordered by `calls` descending; ties broken by path ascending.  |
+| `data[].endpoint`  | string   | Endpoint path identifier (e.g. `/v1/weather/current`).                   |
+| `data[].calls`     | integer  | Total call count in the period.                                          |
+| `data[].revenue`   | string   | Total revenue in smallest USDC units (string to avoid precision loss).   |
+| `period.from`      | string   | Effective start of the query window (ISO-8601).                          |
+| `period.to`        | string   | Effective end of the query window (ISO-8601).                            |
+
+## Error Responses
+
+| HTTP status | Code            | When                                         |
+|-------------|-----------------|----------------------------------------------|
+| `400`       | `BAD_REQUEST`   | Invalid date, `from > to`, or invalid limit. |
+| `401`       | `UNAUTHORIZED`  | Missing or invalid bearer token.             |
+| `500`       | `INTERNAL_ERROR`| Unexpected server error.                     |
+
+See [docs/error-codes.md](./error-codes.md) for the full error envelope format.
+
+## Authentication
+
+Requires a valid developer bearer token (`Authorization: Bearer <token>`) or `x-user-id` header in local/test flows. Results are always scoped to the authenticated developer — cross-developer data is never returned.
+
+## Implementation notes
+
+- **In-memory store** (`InMemoryUsageEventsRepository`): groups events by `endpoint`, sums calls and revenue, then sorts by calls descending (ties broken by path ascending) before slicing to `limit`.
+- **PostgreSQL store** (`PgUsageEventsRepository`): issues a single `GROUP BY endpoint_id ORDER BY calls DESC` query with a parameterised `LIMIT`, running entirely within the database for efficiency.
+- The route is mounted at `/api/usage/by-endpoint` **before** the generic `/api/usage` mount so the more-specific path always matches first.
+- The standard REST rate limiter applies to this route (configurable via `REST_RATE_LIMIT_WINDOW_MS` / `REST_RATE_LIMIT_MAX_REQUESTS`).
+
+## Examples
+
+### Top 3 endpoints over the last 7 days
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $TOKEN" \
+  "https://api.callora.io/api/usage/by-endpoint?limit=3&from=$(date -u -d '-7 days' +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+### Top endpoints for a specific API
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $TOKEN" \
+  "https://api.callora.io/api/usage/by-endpoint?apiId=api_abc123&limit=10"
+```


### PR DESCRIPTION
## Summary

Implements the `GET /api/usage/by-endpoint` endpoint as described in issue #609.

Returns the authenticated developer's most-called API endpoints ranked by call volume within a configurable time window. Scoped to the authenticated user — no cross-developer data leakage.

## What changed

### New route — `src/routes/usage/byEndpoint.ts`
- `GET /api/usage/by-endpoint` protected by `requireAuth`
- Query params: `from` (ISO-8601), `to` (ISO-8601), `limit` (positive int, default 5), `apiId` (optional filter)
- Defaults to the last 30 days when `from`/`to` are omitted
- Input validation: invalid date strings → 400, `from > to` → 400, non-positive `limit` → 400
- Mounted at `/api/usage/by-endpoint` **before** `/api/usage` so the specific path always wins

### Repository — `getTopEndpoints()`
- **In-memory** (`InMemoryUsageEventsRepository`): groups events by `endpoint`, aggregates calls + revenue, sorts by calls desc / path asc, slices to `limit`
- **PostgreSQL** (`PgUsageEventsRepository`): single `GROUP BY endpoint_id ORDER BY calls DESC LIMIT $N` query — efficient at any table size

### Tests — `src/routes/usage/byEndpoint.test.ts` (7 tests, all passing)
| Test | Result |
|---|---|
| requires authentication | ✅ |
| returns top endpoints by call volume | ✅ |
| filters by apiId | ✅ |
| rejects invalid limit | ✅ |
| rejects negative limit | ✅ |
| rejects invalid dates | ✅ |
| rejects from date after to date | ✅ |

### Docs
- `docs/usage-by-endpoint.md` — full API reference, request/response shape, error table, implementation notes, curl examples
- `docs/openapi.json` — new `/api/usage/by-endpoint` path with full parameter and response schema
- `README.md` — route added to the feature list with link to docs

## Test output

```
Test Suites: 2 passed, 2 total
Tests:       33 passed, 33 total  (7 byEndpoint + 26 repository)
```

## Checklist
- [x] Implementation matches description
- [x] Tests added and passing
- [x] Docs updated (OpenAPI spec + markdown reference)
- [x] Lint: 0 errors
- [x] Scoped to authenticated user (secure)
- [x] Efficient single-query PG implementation

Closes #609