### PR TITLE
feat: billing access log middleware

### DIFF
--- a/src/middleware/billingAccessLog.test.ts
+++ b/src/middleware/billingAccessLog.test.ts
@@ -1,0 +1,318 @@
+import { EventEmitter } from 'node:events';
+import type { Request, Response } from 'express';
+
+import {
+  createBillingAccessLogMiddleware,
+  billingLogger,
+  BILLING_LOG_REDACTED_VALUE,
+  billingAccessLogMiddleware,
+} from './billingAccessLog.js';
+
+describe('createBillingAccessLogMiddleware', () => {
+  test('logs billing request with correlation id and billing fields', () => {
+    const infoSpy = jest.spyOn(billingLogger, 'info').mockImplementation(() => billingLogger);
+
+    try {
+      const middleware = createBillingAccessLogMiddleware();
+
+      const req = Object.assign(new EventEmitter(), {
+        method: 'POST',
+        path: '/billing/deduct',
+        headers: { 'x-request-id': 'billing-req-1' },
+        id: 'billing-req-1',
+        body: {
+          requestId: 'client-req-1',
+          apiId: 'api-123',
+          endpointId: 'ep-456',
+          apiKeyId: 'ak-789',
+          amountUsdc: '1.50',
+        },
+      }) as unknown as EventEmitter &
+        Request & {
+          headers: Record<string, string>;
+          id?: string;
+          body: Record<string, unknown>;
+        };
+
+      const res = Object.assign(new EventEmitter(), {
+        statusCode: 200,
+        writableEnded: true,
+        setHeader: jest.fn(),
+        write: jest.fn(() => true),
+        end: jest.fn(() => true),
+        locals: {
+          authenticatedUser: { id: 'user-1' },
+        },
+      }) as unknown as EventEmitter &
+        Response & {
+          statusCode: number;
+          write: jest.Mock;
+          end: jest.Mock;
+          setHeader: jest.Mock;
+          writableEnded: boolean;
+          locals: Record<string, unknown>;
+        };
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          correlationId: 'billing-req-1',
+          requestId: 'billing-req-1',
+          method: 'POST',
+          path: '/billing/deduct',
+          status: 200,
+          statusCode: 200,
+          ms: expect.any(Number),
+          durationMs: expect.any(Number),
+          userId: 'user-1',
+          apiId: 'api-123',
+          endpointId: 'ep-456',
+          apiKeyId: 'ak-789',
+          amountUsdc: '1.50',
+          billingRequestId: 'client-req-1',
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('logs with warn level for 4xx responses', () => {
+    const warnSpy = jest.spyOn(billingLogger, 'warn').mockImplementation(() => billingLogger);
+
+    try {
+      const middleware = createBillingAccessLogMiddleware();
+
+      const req = Object.assign(new EventEmitter(), {
+        method: 'POST',
+        path: '/billing/deduct',
+        headers: {},
+        id: 'billing-warn',
+        body: { amountUsdc: '0' },
+      }) as unknown as EventEmitter & Request & { id?: string; body: Record<string, unknown> };
+
+      const res = Object.assign(new EventEmitter(), {
+        statusCode: 402,
+        writableEnded: true,
+        write: jest.fn(() => true),
+        end: jest.fn(() => true),
+        setHeader: jest.fn(),
+        locals: {},
+      }) as unknown as EventEmitter &
+        Response & {
+          statusCode: number;
+          write: jest.Mock;
+          end: jest.Mock;
+          setHeader: jest.Mock;
+          writableEnded: boolean;
+          locals: Record<string, unknown>;
+        };
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ status: 402, statusCode: 402 }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('logs with error level for 5xx responses', () => {
+    const errorSpy = jest.spyOn(billingLogger, 'error').mockImplementation(() => billingLogger);
+
+    try {
+      const middleware = createBillingAccessLogMiddleware();
+
+      const req = Object.assign(new EventEmitter(), {
+        method: 'POST',
+        path: '/billing/deduct',
+        headers: {},
+        id: 'billing-error',
+        body: {},
+      }) as unknown as EventEmitter & Request & { id?: string; body: Record<string, unknown> };
+
+      const res = Object.assign(new EventEmitter(), {
+        statusCode: 502,
+        writableEnded: true,
+        write: jest.fn(() => true),
+        end: jest.fn(() => true),
+        setHeader: jest.fn(),
+        locals: {},
+      }) as unknown as EventEmitter &
+        Response & {
+          statusCode: number;
+          write: jest.Mock;
+          end: jest.Mock;
+          setHeader: jest.Mock;
+          writableEnded: boolean;
+          locals: Record<string, unknown>;
+        };
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ status: 502, statusCode: 502 }),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test('redacts configured fields', () => {
+    const infoSpy = jest.spyOn(billingLogger, 'info').mockImplementation(() => billingLogger);
+
+    try {
+      const middleware = createBillingAccessLogMiddleware({
+        redactFields: ['amountUsdc', 'apiKeyId'],
+      });
+
+      const req = Object.assign(new EventEmitter(), {
+        method: 'POST',
+        path: '/billing/deduct',
+        headers: {},
+        id: 'billing-redact',
+        body: {
+          apiKeyId: 'ak-secret',
+          amountUsdc: '100.00',
+        },
+      }) as unknown as EventEmitter & Request & { id?: string; body: Record<string, unknown> };
+
+      const res = Object.assign(new EventEmitter(), {
+        statusCode: 200,
+        writableEnded: true,
+        write: jest.fn(() => true),
+        end: jest.fn(() => true),
+        setHeader: jest.fn(),
+        locals: {},
+      }) as unknown as EventEmitter &
+        Response & {
+          statusCode: number;
+          write: jest.Mock;
+          end: jest.Mock;
+          setHeader: jest.Mock;
+          writableEnded: boolean;
+          locals: Record<string, unknown>;
+        };
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          amountUsdc: BILLING_LOG_REDACTED_VALUE,
+          apiKeyId: BILLING_LOG_REDACTED_VALUE,
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('emits on close if response not writableEnded', () => {
+    const infoSpy = jest.spyOn(billingLogger, 'info').mockImplementation(() => billingLogger);
+
+    try {
+      const middleware = createBillingAccessLogMiddleware();
+
+      const req = Object.assign(new EventEmitter(), {
+        method: 'GET',
+        path: '/billing/request/test-1',
+        headers: {},
+        id: 'billing-close',
+        body: {},
+      }) as unknown as EventEmitter & Request & { id?: string; body: Record<string, unknown> };
+
+      const res = Object.assign(new EventEmitter(), {
+        statusCode: 200,
+        writableEnded: false,
+        write: jest.fn(() => true),
+        end: jest.fn(() => true),
+        setHeader: jest.fn(),
+        locals: {},
+      }) as unknown as EventEmitter &
+        Response & {
+          statusCode: number;
+          write: jest.Mock;
+          end: jest.Mock;
+          setHeader: jest.Mock;
+          writableEnded: boolean;
+          locals: Record<string, unknown>;
+        };
+
+      middleware(req, res, jest.fn());
+      res.emit('close');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ method: 'GET', path: '/billing/request/test-1' }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('emits only once on finish + close', () => {
+    const infoSpy = jest.spyOn(billingLogger, 'info').mockImplementation(() => billingLogger);
+
+    try {
+      const middleware = createBillingAccessLogMiddleware();
+
+      const req = Object.assign(new EventEmitter(), {
+        method: 'POST',
+        path: '/billing/deduct',
+        headers: {},
+        id: 'billing-once',
+        body: {},
+      }) as unknown as EventEmitter & Request & { id?: string; body: Record<string, unknown> };
+
+      const res = Object.assign(new EventEmitter(), {
+        statusCode: 200,
+        writableEnded: true,
+        write: jest.fn(() => true),
+        end: jest.fn(() => true),
+        setHeader: jest.fn(),
+        locals: {},
+      }) as unknown as EventEmitter &
+        Response & {
+          statusCode: number;
+          write: jest.Mock;
+          end: jest.Mock;
+          setHeader: jest.Mock;
+          writableEnded: boolean;
+          locals: Record<string, unknown>;
+        };
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+      res.emit('close');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});
+
+describe('billingLogger', () => {
+  test('has channel=billing', () => {
+    expect(billingLogger).toBeDefined();
+    expect(billingLogger.bindings?.()).toEqual(
+      expect.objectContaining({ channel: 'billing' }),
+    );
+  });
+});
+
+describe('billingAccessLogMiddleware', () => {
+  test('is a function', () => {
+    expect(typeof billingAccessLogMiddleware).toBe('function');
+  });
+});

--- a/src/middleware/billingAccessLog.ts
+++ b/src/middleware/billingAccessLog.ts
@@ -1,0 +1,130 @@
+import type { NextFunction, Request, Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { getClientIp } from '../lib/clientIp.js';
+import { getRequestId } from '../utils/asyncContext.js';
+import { logger } from './logging.js';
+import { sanitizeRequestId } from './requestId.js';
+
+export const BILLING_LOG_REDACTED_VALUE = '[REDACTED]';
+
+export const billingLogger = logger.child({ channel: 'billing' });
+
+export interface BillingAccessLogPayload {
+  correlationId: string;
+  requestId: string;
+  method: string;
+  path: string;
+  status: number;
+  statusCode: number;
+  ms: number;
+  durationMs: number;
+  userId?: string;
+  clientIp?: string;
+  apiId?: string;
+  endpointId?: string;
+  apiKeyId?: string;
+  amountUsdc?: string;
+  billingRequestId?: string;
+}
+
+export interface BillingAccessLogOptions {
+  redactFields?: readonly string[];
+  logger?: Pick<typeof logger, 'info' | 'warn' | 'error'>;
+}
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+function extractBillingPayload(req: Request): Partial<BillingAccessLogPayload> {
+  const body = req.body as Record<string, unknown> | undefined;
+  if (!body || typeof body !== 'object') return {};
+
+  const payload: Partial<BillingAccessLogPayload> = {};
+  if (typeof body.apiId === 'string') payload.apiId = body.apiId;
+  if (typeof body.endpointId === 'string') payload.endpointId = body.endpointId;
+  if (typeof body.apiKeyId === 'string') payload.apiKeyId = body.apiKeyId;
+  if (typeof body.amountUsdc === 'string') payload.amountUsdc = body.amountUsdc;
+  if (typeof body.requestId === 'string') payload.billingRequestId = body.requestId;
+  return payload;
+}
+
+function extractUser(res: Response): string | undefined {
+  const locals = res.locals as Record<string, unknown>;
+  const user = locals.authenticatedUser as { id?: string } | undefined;
+  return user?.id;
+}
+
+export function createBillingAccessLogMiddleware(options: BillingAccessLogOptions = {}) {
+  const redactFields = options.redactFields?.map((f) => f.toLowerCase()) ?? [];
+  const billingLoggerInstance = options.logger ?? billingLogger;
+
+  return function billingAccessLogMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const startAt = process.hrtime.bigint();
+    const requestId =
+      sanitizeRequestId(req.id) ??
+      getRequestId() ??
+      sanitizeRequestId(
+        Array.isArray(req.headers['x-request-id'])
+          ? req.headers['x-request-id'][0]
+          : req.headers['x-request-id'],
+      ) ??
+      uuidv4();
+
+    const clientIp = getClientIp(req, TRUST_PROXY);
+
+    const emitLog = (): void => {
+      const elapsedMs = Number(process.hrtime.bigint() - startAt) / 1_000_000;
+      const status = res.statusCode;
+      const userId = extractUser(res);
+      const billingContext = extractBillingPayload(req);
+
+      const payload: BillingAccessLogPayload = {
+        correlationId: requestId,
+        requestId,
+        method: req.method,
+        path: req.path,
+        status,
+        statusCode: status,
+        ms: Number(elapsedMs.toFixed(3)),
+        durationMs: Number(elapsedMs.toFixed(3)),
+        ...(userId ? { userId } : {}),
+        ...(clientIp ? { clientIp } : {}),
+        ...billingContext,
+      };
+
+      if (redactFields.length > 0) {
+        const lowerKeyToActual = Object.keys(payload).reduce<Record<string, string>>(
+          (map, key) => {
+            map[key.toLowerCase()] = key;
+            return map;
+          },
+          {},
+        );
+        for (const field of redactFields) {
+          const actualKey = lowerKeyToActual[field];
+          if (actualKey) {
+            (payload as unknown as Record<string, string>)[actualKey] = BILLING_LOG_REDACTED_VALUE;
+          }
+        }
+      }
+
+      if (status >= 500) {
+        billingLoggerInstance.error({ ...payload }, 'billing request completed');
+      } else if (status >= 400) {
+        billingLoggerInstance.warn({ ...payload }, 'billing request completed');
+      } else {
+        billingLoggerInstance.info({ ...payload }, 'billing request completed');
+      }
+    };
+
+    res.once('finish', emitLog);
+    res.once('close', () => {
+      if (!res.writableEnded) {
+        emitLog();
+      }
+    });
+
+    next();
+  };
+}
+
+export const billingAccessLogMiddleware = createBillingAccessLogMiddleware();

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -14,6 +14,7 @@ import {
 import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
 import { idempotencyMiddleware } from '../middleware/idempotency.js';
 import { billingDeductHistogramMiddleware } from '../middleware/metricsHistogram.js';
+import { billingAccessLogMiddleware } from '../middleware/billingAccessLog.js';
 import { BillingService, type BillingDeductResult } from '../services/billing.js';
 import { createSorobanRpcBillingClient, SorobanRpcError } from '../services/sorobanBilling.js';
 import { redactSimulationDetails } from '../lib/simulationDiagnostics.js';
@@ -21,6 +22,8 @@ import creditsRouter from './billing/credits.js';
 import disputesRouter from './billing/disputes.js';
 
 const router = Router();
+
+router.use(billingAccessLogMiddleware);
 
 // Mount credits sub-router
 router.use('/credits', creditsRouter);


### PR DESCRIPTION
## Description

Closes #614

Implements a structured billing access log middleware that logs billing operations with dedicated billing context. Uses a pino child logger with `channel: 'billing'` for filtered log streams.

## Changes

- **`src/middleware/billingAccessLog.ts`** (new) — Middleware that captures billing-specific fields from requests (`apiId`, `endpointId`, `apiKeyId`, `amountUsdc`, `billingRequestId`) and authenticated user context, logging them with correlation ID, timing, and severity-appropriate log levels.
- **`src/middleware/billingAccessLog.test.ts`** (new) — 8 tests covering: billing field capture, 4xx/5xx severity levels, field redaction, close-on-unfinished-response, and single-emit semantics.
- **`src/routes/billing.ts`** — Mounts `billingAccessLogMiddleware` at the router level so all billing sub-routes benefit.

## Test Results

```
PASS src/middleware/billingAccessLog.test.ts
  createBillingAccessLogMiddleware
    ✓ logs billing request with correlation id and billing fields
    ✓ logs with warn level for 4xx responses
    ✓ logs with error level for 5xx responses
    ✓ redacts configured fields
    ✓ emits on close if response not writableEnded
    ✓ emits only once on finish + close
  billingLogger
    ✓ has channel=billing
  billingAccessLogMiddleware
    ✓ is a function
Tests:       8 passed
``"



Closes #614