### PR TITLE
Feature/db explain

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [docs/fee-abstraction.md](./docs/fee-abstraction.md) for full API reference,
 - Usage route: `GET /api/usage`
 - Live usage stream: `GET /api/usage/sse` for authenticated developer dashboards
 - Admin usage anomalies: `GET /api/admin/usage/anomalies` returns per-API daily usage anomalies (z-score spikes/drops) for admin review, filterable by `from`/`to`/`apiId`/`threshold`/`limit` (admin auth + IP allowlist)
+- Admin DB explain: `POST /api/admin/db/explain` runs `EXPLAIN (ANALYZE, FORMAT JSON)` on a read-only SQL query and returns the query plan for diagnostic use (admin auth + IP allowlist); see [docs/admin-db-explain.md](./docs/admin-db-explain.md)
 - Usage anomaly detector: background worker emits `usage.anomaly.detected` when per-developer 5-minute traffic exceeds a rolling 12-window baseline by a configurable multiplier (see `docs/usage-anomaly-detector.md`)
 - JSON body parsing plus gateway API key authentication for upstream proxy routes
 - Per-user global REST rate limiting for authenticated `/api/billing`, `/api/usage`, `/api/developers`, `/api/vault`, and `/api/keys` traffic, with IP fallback for unauthenticated requests

--- a/docs/admin-db-explain.md
+++ b/docs/admin-db-explain.md
@@ -1,0 +1,156 @@
+# Admin DB Explain Endpoint
+
+`POST /api/admin/db/explain`
+
+Runs `EXPLAIN (ANALYZE, FORMAT JSON)` on a caller-supplied SQL query and returns the
+PostgreSQL query plan as structured JSON. Intended for admin-only diagnostics — use it
+to identify slow queries and missing indexes without requiring direct database access.
+
+---
+
+## Authentication
+
+Both authentication paths are accepted. The request is also gated behind the admin IP
+allowlist (see [IP-ALLOWLIST-SECURITY.md](./IP-ALLOWLIST-SECURITY.md)).
+
+| Method | Header |
+|---|---|
+| API key | `x-admin-api-key: <ADMIN_API_KEY>` |
+| JWT (role=admin) | `Authorization: Bearer <token>` |
+
+---
+
+## Request
+
+```
+POST /api/admin/db/explain
+Content-Type: application/json
+x-admin-api-key: <key>
+```
+
+### Body
+
+| Field | Type | Required | Constraints | Description |
+|---|---|---|---|---|
+| `query` | string | ✅ | 1–50 000 chars | SQL to explain. Must start with `SELECT` or `WITH`. Multi-statement queries are rejected. |
+| `params` | array | ❌ | default `[]` | Positional parameter bindings (`$1`, `$2`, …) passed to `pg.Pool.query`. |
+
+```json
+{
+  "query": "SELECT * FROM usage_events WHERE developer_id = $1 ORDER BY created_at DESC LIMIT 100",
+  "params": ["dev_abc123"]
+}
+```
+
+---
+
+## Response
+
+### 200 OK
+
+```json
+{
+  "plan": "[{\"Plan\":{\"Node Type\":\"Index Scan\",...},\"Planning Time\":0.12,\"Execution Time\":0.93}]"
+}
+```
+
+The `plan` field is the raw `QUERY PLAN` column value returned by PostgreSQL
+(`EXPLAIN (ANALYZE, FORMAT JSON)`).  It is a JSON-serialised string when the standard
+`QUERY PLAN` column is present.  In the unlikely event the column is absent the raw
+`rows` array is returned instead.
+
+### Error responses
+
+| Status | `code` | When |
+|---|---|---|
+| `400` | `BAD_REQUEST` | Missing/invalid body, disallowed query type, multi-statement query, or database execution error (e.g. unknown table) |
+| `401` | `UNAUTHORIZED` | Missing or invalid admin credential |
+| `403` | `FORBIDDEN` | Caller IP not in admin allowlist |
+| `500` | `INTERNAL_SERVER_ERROR` | Database pool not available |
+
+All errors follow the standard envelope:
+
+```json
+{
+  "code": "BAD_REQUEST",
+  "message": "Query not allowed for EXPLAIN analysis. Only SELECT and WITH queries are permitted.",
+  "requestId": "req_abc123"
+}
+```
+
+---
+
+## Query allowlist
+
+Only `SELECT` and `WITH` (CTE) queries are allowed.  The check is applied **before**
+the query is sent to the database:
+
+- Queries that do not start with `SELECT` or `WITH` (case-insensitive) are rejected.
+- Multi-statement queries (containing `;` outside of string literals or comments) are
+  rejected, regardless of what the first statement is.
+
+Rejected examples:
+
+```sql
+INSERT INTO …          -- rejected: not SELECT/WITH
+UPDATE … SET …         -- rejected: not SELECT/WITH
+SELECT 1; DROP TABLE … -- rejected: multi-statement
+```
+
+Allowed examples:
+
+```sql
+SELECT * FROM apis WHERE status = $1
+WITH cte AS (SELECT …) SELECT * FROM cte
+SELECT 'hello; world'  -- semicolon inside string literal is fine
+```
+
+---
+
+## Audit logging
+
+Every call emits a structured Pino audit event with channel label `admin_action`:
+
+```json
+{
+  "event": "DB_EXPLAIN",
+  "actor": "admin-api-key",
+  "clientIp": "10.0.0.5",
+  "userAgent": "curl/8.4.0",
+  "query": "SELECT * FROM usage_events WHERE developer_id = $1",
+  "paramCount": 1
+}
+```
+
+The full query text is logged to support post-incident review.  If your logging
+infrastructure has data-retention policies for sensitive queries, configure log
+filtering before enabling this endpoint in production.
+
+---
+
+## Example — curl
+
+```bash
+curl -s -X POST https://api.callora.io/api/admin/db/explain \
+  -H "Content-Type: application/json" \
+  -H "x-admin-api-key: $ADMIN_API_KEY" \
+  -d '{
+    "query": "SELECT id, developer_id, amount_usdc FROM usage_events WHERE developer_id = $1 LIMIT 10",
+    "params": ["dev_abc123"]
+  }' | jq '.plan | fromjson'
+```
+
+---
+
+## Security considerations
+
+- The endpoint only executes `EXPLAIN (ANALYZE, FORMAT JSON) <query>`.  It does **not**
+  run the query outside of an EXPLAIN context.  However, `EXPLAIN ANALYZE` does execute
+  the query — `SELECT` queries on large tables will consume real I/O and CPU.
+- Parameters are passed as positional bindings (`pg` parameterised queries), so SQL
+  injection through the `params` field is not possible.
+- The allowlist and multi-statement guard defend against accidental or malicious DML
+  being smuggled through the `query` field, but the endpoint should still be treated as
+  a sensitive admin capability and kept behind a strict IP allowlist in production.
+- Do not expose this endpoint to untrusted networks.  A well-crafted `SELECT` against a
+  very large table can act as a denial-of-service against the database.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1141,10 +1141,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["plugins", "total"],
+                  "required": [
+                    "plugins",
+                    "total"
+                  ],
                   "properties": {
-                    "plugins": { "type": "array", "items": { "$ref": "#/components/schemas/PluginRecord" } },
-                    "total": { "type": "integer" }
+                    "plugins": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PluginRecord"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
                   }
                 }
               }
@@ -1155,12 +1165,18 @@
       "post": {
         "summary": "Register a new plugin",
         "description": "Registers a new community plugin manifest. Requires authentication.",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/PluginManifest" }
+              "schema": {
+                "$ref": "#/components/schemas/PluginManifest"
+              }
             }
           }
         },
@@ -1169,33 +1185,122 @@
             "description": "Plugin registered",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PluginRecord" }
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
               }
             }
           },
-          "400": { "description": "Validation error", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "409": { "description": "Plugin already registered", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Plugin already registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
     "/api/marketplace/plugins/{id}": {
       "get": {
         "summary": "Get a plugin by ID",
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Plugin found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PluginRecord" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Plugin found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Remove a plugin from the registry",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "204": { "description": "Plugin removed" },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "204": {
+            "description": "Plugin removed"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1203,8 +1308,21 @@
       "post": {
         "summary": "Install a plugin",
         "description": "Marks a plugin as installed and fires the install hook. Requires authentication.",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Plugin installed",
@@ -1212,17 +1330,29 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["plugin"],
+                  "required": [
+                    "plugin"
+                  ],
                   "properties": {
-                    "plugin": { "$ref": "#/components/schemas/PluginRecord" },
+                    "plugin": {
+                      "$ref": "#/components/schemas/PluginRecord"
+                    },
                     "hook": {
                       "nullable": true,
                       "type": "object",
                       "properties": {
-                        "ok": { "type": "boolean" },
-                        "hook": { "type": "string" },
-                        "pluginId": { "type": "string" },
-                        "sandboxed": { "type": "boolean" }
+                        "ok": {
+                          "type": "boolean"
+                        },
+                        "hook": {
+                          "type": "string"
+                        },
+                        "pluginId": {
+                          "type": "string"
+                        },
+                        "sandboxed": {
+                          "type": "boolean"
+                        }
                       }
                     }
                   }
@@ -1230,21 +1360,221 @@
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "409": { "description": "Already installed", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Already installed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Uninstall a plugin",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Plugin uninstalled", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PluginRecord" } } } },
-          "400": { "description": "Not installed", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Plugin uninstalled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginRecord"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Not installed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/db/explain": {
+      "post": {
+        "summary": "Run EXPLAIN ANALYZE on a read-only SQL query",
+        "description": "Executes `EXPLAIN (ANALYZE, FORMAT JSON)` against the primary database pool for a caller-supplied SELECT or WITH query. Only read-only SQL is accepted; multi-statement payloads and any non-SELECT/WITH keyword are rejected at the boundary before the query reaches the database. The raw JSON query plan is returned so admins can diagnose slow queries and missing indexes without needing direct database access. Every call emits a structured audit log entry (`DB_EXPLAIN`) containing the caller identity, client IP, User-Agent, query text, and parameter count. Requires admin authentication (API key or JWT with role=admin) and the admin IP allowlist.",
+        "security": [
+          {
+            "adminApiKey": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50000,
+                    "description": "SQL query to explain. Must begin with SELECT or WITH (CTEs allowed). Multi-statement queries are rejected.",
+                    "example": "SELECT * FROM usage_events WHERE developer_id = $1 ORDER BY created_at DESC LIMIT 100"
+                  },
+                  "params": {
+                    "type": "array",
+                    "items": {},
+                    "description": "Positional parameter bindings ($1, $2, ...) for the query. Defaults to an empty array.",
+                    "example": [
+                      "dev_abc123"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Query plan returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "plan": {
+                      "description": "The PostgreSQL EXPLAIN (ANALYZE, FORMAT JSON) output. Contains a single JSON plan node when the QUERY PLAN column is present; falls back to the raw rows array otherwise.",
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "description": "JSON-serialised plan from the QUERY PLAN column"
+                        },
+                        {
+                          "type": "array",
+                          "description": "Raw result rows when QUERY PLAN column is absent",
+                          "items": {}
+                        }
+                      ]
+                    }
+                  }
+                },
+                "example": {
+                  "plan": "[{\"Plan\":{\"Node Type\":\"Seq Scan\",\"Relation Name\":\"usage_events\",\"Startup Cost\":0.00,\"Total Cost\":28.50,\"Plan Rows\":500,\"Plan Width\":64,\"Actual Startup Time\":0.02,\"Actual Total Time\":0.85,\"Actual Rows\":500,\"Actual Loops\":1},\"Planning Time\":0.12,\"Execution Time\":0.93}]"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body, disallowed query type, multi-statement query, or database execution error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid admin credential",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden by admin IP allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Database pool not available or internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1265,30 +1595,84 @@
     "schemas": {
       "PluginManifest": {
         "type": "object",
-        "required": ["id", "name", "version", "hooks"],
+        "required": [
+          "id",
+          "name",
+          "version",
+          "hooks"
+        ],
         "properties": {
-          "id": { "type": "string", "minLength": 3, "maxLength": 64, "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
-          "name": { "type": "string", "minLength": 1, "maxLength": 128 },
-          "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
-          "description": { "type": "string", "maxLength": 512 },
-          "author": { "type": "string", "maxLength": 128 },
+          "id": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64,
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 512
+          },
+          "author": {
+            "type": "string",
+            "maxLength": 128
+          },
           "hooks": {
             "type": "array",
             "minItems": 1,
-            "items": { "type": "string", "enum": ["before_charge", "after_charge", "on_refund", "on_quota_exceeded"] }
+            "items": {
+              "type": "string",
+              "enum": [
+                "before_charge",
+                "after_charge",
+                "on_refund",
+                "on_quota_exceeded"
+              ]
+            }
           },
-          "source_url": { "type": "string", "format": "uri" }
+          "source_url": {
+            "type": "string",
+            "format": "uri"
+          }
         }
       },
       "PluginRecord": {
         "type": "object",
-        "required": ["manifest", "status", "created_at"],
+        "required": [
+          "manifest",
+          "status",
+          "created_at"
+        ],
         "properties": {
-          "manifest": { "$ref": "#/components/schemas/PluginManifest" },
-          "status": { "type": "string", "enum": ["available", "installed"] },
-          "installed_by": { "type": "string", "nullable": true },
-          "installed_at": { "type": "string", "nullable": true },
-          "created_at": { "type": "string" }
+          "manifest": {
+            "$ref": "#/components/schemas/PluginManifest"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "available",
+              "installed"
+            ]
+          },
+          "installed_by": {
+            "type": "string",
+            "nullable": true
+          },
+          "installed_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       },
       "BillingDeductRequest": {

--- a/src/routes/admin/explain.test.ts
+++ b/src/routes/admin/explain.test.ts
@@ -296,6 +296,24 @@ describe('POST /api/admin/db/explain', () => {
       expect(successRes.status).toBe(200);
       expect(successRes.body).toHaveProperty('plan');
     });
+
+    it('propagates unexpected non-ZodError errors to the error handler', async () => {
+      // Simulate an unexpected error thrown after successful db query (e.g. from logger.audit).
+      // This covers the final `next(error)` fallthrough in the outer catch block (100% coverage).
+      const unexpectedError = new TypeError('Unexpected runtime error');
+      (logger.audit as jest.Mock).mockImplementationOnce(() => {
+        throw unexpectedError;
+      });
+
+      mockQuery.mockResolvedValueOnce({ rows: [makeExplainRow(SAMPLE_PLAN)] } as unknown as QueryResult);
+      const app = createTestApp();
+      const res = await request(app)
+        .post('/api/admin/db/explain')
+        .send({ query: 'SELECT 1' });
+
+      // The unexpected error is passed to next(); errorHandler maps it to 500
+      expect(res.status).toBe(500);
+    });
   });
 });
 


### PR DESCRIPTION
Closes #630 
  
  What
  
  Adds a diagnostic endpoint that runs EXPLAIN (ANALYZE, FORMAT JSON) on a caller-supplied
  read-only SQL query and returns the structured PostgreSQL query plan. Platform engineers can
  use this to identify slow queries and missing indexes without requiring direct database access.
  
  How it works
  
  - Input validation — Zod schema enforces query (1–50,000 chars) and optional params array
  - Query allowlist — only SELECT and WITH (CTE) statements are accepted; any DML/DDL (INSERT,
  UPDATE, DELETE, DROP, ALTER, TRUNCATE, etc.) is rejected with 400 before touching the database
  - Multi-statement guard — strips single-quoted literals and -- comments from the query string,
  then rejects any remaining semicolon to prevent SELECT 1; DROP TABLE users-style injection
  - Database errors — surfaced as 400 with the PostgreSQL message; missing pool returns 500
  - Audit logging — every call writes a DB_EXPLAIN entry via logger.audit(...) with clientIp,
  userAgent, query, and paramCount
  - Auth — admin IP allowlist + adminAuth middleware (API key or JWT with role=admin) enforced on
  the router
  
  Files changed
  
  ┌──────────────────────────────────┬────────────────────────────────────────────────────┐
  │ File                             │ Change                                             │
  ├──────────────────────────────────┼────────────────────────────────────────────────────┤
  │ src/routes/admin/explain.ts      │ Route implementation                               │
  ├──────────────────────────────────┼────────────────────────────────────────────────────┤
  │ src/routes/admin/explain.test.ts │ +1 test → 29 total, 100% coverage                  │
  ├──────────────────────────────────┼────────────────────────────────────────────────────┤
  │ src/app.ts                       │ Mounts router at /api/admin/db/explain             │
  ├──────────────────────────────────┼────────────────────────────────────────────────────┤
  │ docs/openapi.json                │ OpenAPI 3.1 path + inline request/response schemas │
  ├──────────────────────────────────┼────────────────────────────────────────────────────┤
  │ docs/admin-db-explain.md         │ Full API reference, security notes, curl examples  │
  ├──────────────────────────────────┼────────────────────────────────────────────────────┤
  │ README.md                        │ Admin DB Explain section                           │
  └──────────────────────────────────┴────────────────────────────────────────────────────┘
  
  Tests
  
  29 tests passed
  Statements : 100%
  Branches   : 100%
  Functions  : 100%
  Lines      : 100%
  
  Covers: input validation, allowlist enforcement
  (INSERT/UPDATE/DELETE/DROP/ALTER/CREATE/TRUNCATE/REINDEX all rejected), multi-statement
  detection with string-literal and comment edge cases, successful plan extraction, audit log
  emission, DB error mapping, pool-unavailable 500, and unexpected error propagation.
  
  Security considerations
  
  - All filtering happens before any database call — a malformed query never reaches the pool
  - Query text is logged for auditability but is processed by the logger's existing redaction
  pipeline
  - Endpoint is double-gated: admin IP allowlist check runs before credential verification
