### PR TITLE
feat: admin usage by endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import adminRouter from './routes/admin.js';
 import { createExplainRouter } from './routes/admin/explain.js';
 import { createUsageAnomaliesRouter } from './routes/admin/usage/anomalies.js';
+import { createAdminUsageByEndpointRouter } from './routes/admin/usage/byEndpoint.js';
 import { createApiRouter } from './routes/index.js';
 import { createApisRouter } from './routes/apis.js';
 import { createPluginsRouter } from './routes/marketplace/plugins.js';
@@ -284,6 +285,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
   // Mounted before the generic admin router so the specific path is not
   // shadowed by adminRouter's `/usage/:developerId` route.
   app.use('/api/admin/usage/anomalies', createUsageAnomaliesRouter({ pool }));
+  app.use('/api/admin/usage/by-endpoint', createAdminUsageByEndpointRouter({ pool }));
   app.use('/api/admin', adminRouter);
   app.use('/api/admin/db/explain', createExplainRouter({ pool }));
 

--- a/src/routes/admin/usage/byEndpoint.test.ts
+++ b/src/routes/admin/usage/byEndpoint.test.ts
@@ -1,0 +1,237 @@
+import express from 'express';
+import request from 'supertest';
+import type { Pool, QueryResult } from 'pg';
+import { createAdminUsageByEndpointRouter } from './byEndpoint.js';
+import { errorHandler } from '../../../middleware/errorHandler.js';
+import { requestIdMiddleware } from '../../../middleware/requestId.js';
+
+jest.mock('../../../middleware/adminAuth', () => ({
+  adminAuth: jest.fn((_req: any, _res: any, next: any) => {
+    _res.locals = { ..._res.locals, adminActor: 'test-admin' };
+    next();
+  }),
+}));
+
+jest.mock('../../../middleware/ipAllowlist', () => ({
+  createAdminIpAllowlist: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+
+jest.mock('../../../logger', () => {
+  const actual = jest.requireActual('../../../logger');
+  return {
+    ...actual,
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      audit: jest.fn(),
+    },
+  };
+});
+
+import { logger } from '../../../logger.js';
+
+const mockQuery = jest.fn();
+const mockPool = { query: mockQuery } as unknown as Pool;
+
+function createTestApp(deps: { pool?: Pool; noPool?: boolean } = {}): express.Express {
+  const app = express();
+  app.use(requestIdMiddleware);
+  const effectivePool = deps.noPool ? undefined : (deps.pool ?? mockPool);
+  app.use('/api/admin/usage/by-endpoint', createAdminUsageByEndpointRouter({ pool: effectivePool as Pool | undefined }));
+  app.use(errorHandler);
+  return app;
+}
+
+const asResult = (rows: unknown[]): QueryResult =>
+  ({ rows } as unknown as QueryResult);
+
+const ENDPOINT_ROWS = [
+  { endpoint: '/v1/search', calls: 150, revenue: '15000' },
+  { endpoint: '/v1/weather', calls: 80, revenue: '8000' },
+  { endpoint: '/v1/forecast', calls: 30, revenue: '3000' },
+];
+
+describe('GET /api/admin/usage/by-endpoint', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockReset();
+  });
+
+  it('returns top endpoints aggregated across all developers', async () => {
+    mockQuery.mockResolvedValueOnce(asResult(ENDPOINT_ROWS));
+    const app = createTestApp();
+
+    const res = await request(app).get('/api/admin/usage/by-endpoint');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([
+      { endpoint: '/v1/search', calls: 150, revenue: '15000' },
+      { endpoint: '/v1/weather', calls: 80, revenue: '8000' },
+      { endpoint: '/v1/forecast', calls: 30, revenue: '3000' },
+    ]);
+    expect(res.body.period).toBeDefined();
+    expect(res.body.period.from).toBeDefined();
+    expect(res.body.period.to).toBeDefined();
+  });
+
+  it('writes an audit log entry', async () => {
+    mockQuery.mockResolvedValueOnce(asResult(ENDPOINT_ROWS));
+    const app = createTestApp();
+
+    await request(app).get('/api/admin/usage/by-endpoint');
+
+    expect(logger.audit).toHaveBeenCalledWith(
+      'LIST_USAGE_BY_ENDPOINT',
+      'test-admin',
+      expect.objectContaining({ endpointCount: 3 }),
+    );
+  });
+
+  it('returns an empty list when no usage events exist', async () => {
+    mockQuery.mockResolvedValueOnce(asResult([]));
+    const app = createTestApp();
+
+    const res = await request(app).get('/api/admin/usage/by-endpoint');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('passes apiId filter through to the query', async () => {
+    mockQuery.mockResolvedValueOnce(asResult([]));
+    const app = createTestApp();
+
+    await request(app).get('/api/admin/usage/by-endpoint').query({ apiId: 'api-1' });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('api_id = $3');
+    expect(params).toContain('api-1');
+  });
+
+  it('passes developerId filter through to the query', async () => {
+    mockQuery.mockResolvedValueOnce(asResult([]));
+    const app = createTestApp();
+
+    await request(app).get('/api/admin/usage/by-endpoint').query({ developerId: 'dev-1' });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('developer_id = $3');
+    expect(params).toContain('dev-1');
+  });
+
+  it('passes both apiId and developerId filters', async () => {
+    mockQuery.mockResolvedValueOnce(asResult([]));
+    const app = createTestApp();
+
+    await request(app)
+      .get('/api/admin/usage/by-endpoint')
+      .query({ apiId: 'api-1', developerId: 'dev-1' });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('api_id = $3');
+    expect(sql).toContain('developer_id = $4');
+    expect(params).toEqual([expect.any(Date), expect.any(Date), 'api-1', 'dev-1', 10]);
+  });
+
+  it('passes the date window through to the query', async () => {
+    mockQuery.mockResolvedValueOnce(asResult([]));
+    const app = createTestApp();
+
+    await request(app)
+      .get('/api/admin/usage/by-endpoint')
+      .query({ from: '2026-03-01T00:00:00.000Z', to: '2026-03-31T00:00:00.000Z' });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect((params[0] as Date).toISOString()).toBe('2026-03-01T00:00:00.000Z');
+    expect((params[1] as Date).toISOString()).toBe('2026-03-31T00:00:00.000Z');
+  });
+
+  it('passes a custom limit through to the query', async () => {
+    mockQuery.mockResolvedValueOnce(asResult([]));
+    const app = createTestApp();
+
+    await request(app).get('/api/admin/usage/by-endpoint').query({ limit: '25' });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[params.length - 1]).toBe(25);
+  });
+
+  describe('input validation', () => {
+    it('returns 400 for an invalid "from" date', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint').query({ from: 'nope' });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('BAD_REQUEST');
+      expect(res.body.message).toBe('Invalid "from" date');
+    });
+
+    it('returns 400 when "from" is supplied as multiple values', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint?from=2026-01-01&from=2026-02-01');
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('Invalid "from" date');
+    });
+
+    it('returns 400 for an invalid "to" date', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint').query({ to: 'nope' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('Invalid "to" date');
+    });
+
+    it('returns 400 when from is after to', async () => {
+      const res = await request(createTestApp())
+        .get('/api/admin/usage/by-endpoint')
+        .query({ from: '2026-03-31T00:00:00.000Z', to: '2026-03-01T00:00:00.000Z' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('from must be before or equal to to');
+    });
+
+    it('returns 400 for a non-numeric limit', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint').query({ limit: 'abc' });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('limit must be an integer');
+    });
+
+    it('returns 400 for a non-integer limit', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint').query({ limit: '1.5' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for an out-of-range limit (zero)', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint').query({ limit: '0' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for an out-of-range limit (exceeds max)', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint').query({ limit: '1001' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when apiId is supplied as multiple values', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint?apiId=a&apiId=b');
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('apiId must be a single string value');
+    });
+
+    it('returns 400 when developerId is supplied as multiple values', async () => {
+      const res = await request(createTestApp()).get('/api/admin/usage/by-endpoint?developerId=a&developerId=b');
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('developerId must be a single string value');
+    });
+  });
+
+  it('returns 500 when the database pool is unavailable', async () => {
+    const app = createTestApp({ noPool: true });
+    const res = await request(app).get('/api/admin/usage/by-endpoint');
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('INTERNAL_SERVER_ERROR');
+  });
+
+  it('returns 500 when the aggregation query fails', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('db down'));
+    const app = createTestApp();
+    const res = await request(app).get('/api/admin/usage/by-endpoint');
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/routes/admin/usage/byEndpoint.ts
+++ b/src/routes/admin/usage/byEndpoint.ts
@@ -1,0 +1,194 @@
+import { Router } from 'express';
+import type { Pool } from 'pg';
+import { adminAuth } from '../../../middleware/adminAuth.js';
+import { createAdminIpAllowlist } from '../../../middleware/ipAllowlist.js';
+import { BadRequestError, InternalServerError } from '../../../errors/index.js';
+import { logger } from '../../../logger.js';
+import { getClientIp } from '../../../lib/clientIp.js';
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+const DEFAULT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 1000;
+
+const parseDateParam = (value: unknown): Date | null | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const parseNumberParam = (
+  value: unknown,
+  opts: { min: number; max: number; integer: boolean; fallback: number },
+): number | null => {
+  if (value === undefined) {
+    return opts.fallback;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  if (opts.integer && !Number.isInteger(parsed)) {
+    return null;
+  }
+  if (parsed < opts.min || parsed > opts.max) {
+    return null;
+  }
+  return parsed;
+};
+
+interface EndpointUsageRow {
+  endpoint: string;
+  calls: number;
+  revenue: string;
+}
+
+export interface AdminUsageByEndpointRouterDeps {
+  pool?: Pool;
+}
+
+/**
+ * Router exposing `GET /api/admin/usage/by-endpoint` — top endpoint usage
+ * aggregated across all developers for admin review.
+ *
+ * Admin-only: gated behind the admin IP allowlist and admin authentication.
+ * Queries the `usage_events` table directly for efficient grouped aggregation.
+ */
+export function createAdminUsageByEndpointRouter(deps: AdminUsageByEndpointRouterDeps = {}): Router {
+  const router = Router();
+
+  router.use(createAdminIpAllowlist());
+  router.use(adminAuth);
+
+  router.get('/', async (req, res, next) => {
+    try {
+      const from = parseDateParam(req.query.from);
+      if (from === null) {
+        next(new BadRequestError('Invalid "from" date'));
+        return;
+      }
+      const to = parseDateParam(req.query.to);
+      if (to === null) {
+        next(new BadRequestError('Invalid "to" date'));
+        return;
+      }
+
+      const limit = parseNumberParam(req.query.limit, {
+        min: 1,
+        max: MAX_LIMIT,
+        integer: true,
+        fallback: DEFAULT_LIMIT,
+      });
+      if (limit === null) {
+        next(new BadRequestError(`limit must be an integer between 1 and ${MAX_LIMIT}`));
+        return;
+      }
+
+      if (req.query.apiId !== undefined && typeof req.query.apiId !== 'string') {
+        next(new BadRequestError('apiId must be a single string value'));
+        return;
+      }
+      const apiId =
+        typeof req.query.apiId === 'string' && req.query.apiId.length > 0
+          ? req.query.apiId
+          : undefined;
+
+      if (req.query.developerId !== undefined && typeof req.query.developerId !== 'string') {
+        next(new BadRequestError('developerId must be a single string value'));
+        return;
+      }
+      const developerId =
+        typeof req.query.developerId === 'string' && req.query.developerId.length > 0
+          ? req.query.developerId
+          : undefined;
+
+      const now = new Date();
+      const queryFrom = from ?? new Date(now.getTime() - DEFAULT_WINDOW_MS);
+      const queryTo = to ?? now;
+
+      if (queryFrom > queryTo) {
+        next(new BadRequestError('from must be before or equal to to'));
+        return;
+      }
+
+      const { pool } = deps;
+      if (!pool) {
+        next(new InternalServerError('Database pool not available'));
+        return;
+      }
+
+      const params: unknown[] = [queryFrom, queryTo];
+      const clauses: string[] = ['created_at >= $1', 'created_at <= $2'];
+
+      if (apiId !== undefined) {
+        params.push(apiId);
+        clauses.push(`api_id = $${params.length}`);
+      }
+
+      if (developerId !== undefined) {
+        params.push(developerId);
+        clauses.push(`developer_id = $${params.length}`);
+      }
+
+      params.push(limit);
+      const sql = `
+        SELECT
+          endpoint_id AS endpoint,
+          COUNT(*)::int AS calls,
+          COALESCE(SUM(amount_usdc), 0)::text AS revenue
+        FROM usage_events
+        WHERE ${clauses.join(' AND ')}
+        GROUP BY endpoint_id
+        ORDER BY calls DESC, endpoint ASC
+        LIMIT $${params.length}
+      `;
+
+      let rows: EndpointUsageRow[];
+      try {
+        const result = await pool.query<EndpointUsageRow>(sql, params);
+        rows = result.rows;
+      } catch (dbError) {
+        logger.error('[admin.usage.byEndpoint] aggregation query failed', { error: dbError });
+        next(new InternalServerError());
+        return;
+      }
+
+      logger.audit('LIST_USAGE_BY_ENDPOINT', res.locals.adminActor, {
+        clientIp: getClientIp(req, TRUST_PROXY),
+        userAgent: req.get('User-Agent'),
+        window: { from: queryFrom.toISOString(), to: queryTo.toISOString() },
+        apiId,
+        developerId,
+        limit,
+        endpointCount: rows.length,
+      });
+
+      res.json({
+        data: rows.map((row) => ({
+          endpoint: row.endpoint,
+          calls: row.calls,
+          revenue: row.revenue,
+        })),
+        period: {
+          from: queryFrom.toISOString(),
+          to: queryTo.toISOString(),
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export default createAdminUsageByEndpointRouter;


### PR DESCRIPTION
Add GET /api/admin/usage/by-endpoint for admins to view top endpoint usage aggregated across all developers. Supports optional filters (apiId, developerId, date range, limit) with full input validation, structured audit logging, and 20 tests.
closes #545