### PR TITLE
feat: subscriptions endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ Requires `FEE_BUMPER_SECRET_KEY` environment variable (Stellar secret key `S...`
 
 See [docs/fee-abstraction.md](./docs/fee-abstraction.md) for full API reference, security considerations, rate limits, and emitted events.
 
+## Subscription Endpoints
+
+Authenticated users can subscribe to marketplace APIs with optional metering preferences.
+
+- `POST /api/subscriptions` — subscribe to an API (`api_id` required; optional `metering_limit` as max calls/month)
+- `GET /api/subscriptions` — list subscriptions for the authenticated user; filter by `?status=active|paused|cancelled`
+- `GET /api/subscriptions/:id` — get a single subscription (must belong to the authenticated user)
+- `PATCH /api/subscriptions/:id` — update `status` (`active`/`paused`) or `metering_limit`; body must include at least one field
+- `DELETE /api/subscriptions/:id` — cancel a subscription (soft-delete; sets status to `cancelled`)
+
+Business rules:
+- A user cannot subscribe to their own API (returns `403`).
+- Only one non-cancelled subscription is allowed per user/API pair (returns `409` on conflict).
+- Soft-deleted (deleted) APIs cannot be subscribed to (returns `404`).
+- Cancelled subscriptions cannot be modified or re-cancelled (returns `400`).
+
+The migration is in `migrations/0018_subscriptions.sql`.
+
 ## Developer Profile Endpoints
 
 - `GET /api/developers/me` returns the authenticated developer profile and auto-creates a blank profile row on first access.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -333,7 +333,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["day", "week", "month"]
+              "enum": [
+                "day",
+                "week",
+                "month"
+              ]
             }
           }
         ],
@@ -637,7 +641,10 @@
                               },
                               "type": {
                                 "type": "string",
-                                "enum": ["spike", "drop"]
+                                "enum": [
+                                  "spike",
+                                  "drop"
+                                ]
                               },
                               "calls": {
                                 "type": "integer"
@@ -2209,6 +2216,399 @@
           }
         }
       }
+    },
+    "/api/subscriptions": {
+      "post": {
+        "summary": "Subscribe to a marketplace API",
+        "description": "Subscribes the authenticated user to a marketplace API with optional metering preferences. Each user can hold at most one non-cancelled subscription per API.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "api_id"
+                ],
+                "properties": {
+                  "api_id": {
+                    "type": "integer",
+                    "description": "ID of the marketplace API to subscribe to"
+                  },
+                  "metering_limit": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "Maximum calls per calendar month. Omit or set null for unlimited."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Subscription created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Subscription"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Cannot subscribe to own API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "API not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Subscription already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "List subscriptions",
+        "description": "Returns all subscriptions for the authenticated user, optionally filtered by status.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "paused",
+                "cancelled"
+              ]
+            },
+            "description": "Filter subscriptions by status"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of subscriptions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Subscription"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/subscriptions/{id}": {
+      "get": {
+        "summary": "Get a subscription",
+        "description": "Returns a single subscription belonging to the authenticated user.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscription",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Subscription"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Subscription not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a subscription",
+        "description": "Updates the status (pause/resume) or metering_limit for the authenticated user's subscription.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "paused"
+                    ]
+                  },
+                  "metering_limit": {
+                    "type": "integer",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated subscription",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Subscription"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error or subscription is cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Subscription not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Cancel a subscription",
+        "description": "Cancels the authenticated user's subscription (soft-delete; sets status to 'cancelled').",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancelled subscription",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Subscription"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Subscription is already cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Subscription not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2225,6 +2625,59 @@
       }
     },
     "schemas": {
+      "Subscription": {
+        "type": "object",
+        "description": "A user's subscription to a marketplace API.",
+        "required": [
+          "id",
+          "user_id",
+          "api_id",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Subscription UUID"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "ID of the subscribing user"
+          },
+          "api_id": {
+            "type": "integer",
+            "description": "ID of the subscribed API"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "paused",
+              "cancelled"
+            ],
+            "description": "Current subscription status"
+          },
+          "metering_limit": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Maximum calls per calendar month; null means unlimited"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "cancelled_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
       "QuotaRequest": {
         "type": "object",
         "description": "A developer quota increase request and its current resolution state.",
@@ -2488,7 +2941,11 @@
       },
       "BillingBulkDeductEntry": {
         "type": "object",
-        "required": ["events", "stats", "period"],
+        "required": [
+          "events",
+          "stats",
+          "period"
+        ],
         "properties": {
           "requestId": {
             "type": "string"
@@ -2510,7 +2967,9 @@
       },
       "BillingBulkDeductRequest": {
         "type": "object",
-        "required": ["entries"],
+        "required": [
+          "entries"
+        ],
         "properties": {
           "entries": {
             "type": "array",
@@ -2590,13 +3049,23 @@
       },
       "UsageResponse": {
         "type": "object",
-        "required": ["events", "stats", "period"],
+        "required": [
+          "events",
+          "stats",
+          "period"
+        ],
         "properties": {
           "events": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["id", "apiId", "endpoint", "occurredAt", "revenue"],
+              "required": [
+                "id",
+                "apiId",
+                "endpoint",
+                "occurredAt",
+                "revenue"
+              ],
               "properties": {
                 "id": {
                   "type": "string"
@@ -2619,7 +3088,11 @@
           },
           "stats": {
             "type": "object",
-            "required": ["totalCalls", "totalSpent", "breakdownByApi"],
+            "required": [
+              "totalCalls",
+              "totalSpent",
+              "breakdownByApi"
+            ],
             "properties": {
               "totalCalls": {
                 "type": "integer"
@@ -2631,7 +3104,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["apiId", "calls", "revenue"],
+                  "required": [
+                    "apiId",
+                    "calls",
+                    "revenue"
+                  ],
                   "properties": {
                     "apiId": {
                       "type": "string"
@@ -2649,7 +3126,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["period", "calls", "revenue"],
+                  "required": [
+                    "period",
+                    "calls",
+                    "revenue"
+                  ],
                   "properties": {
                     "period": {
                       "type": "string"
@@ -2667,7 +3148,10 @@
           },
           "period": {
             "type": "object",
-            "required": ["from", "to"],
+            "required": [
+              "from",
+              "to"
+            ],
             "properties": {
               "from": {
                 "type": "string",
@@ -2726,11 +3210,17 @@
             "type": "integer"
           },
           "firstEventAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "lastEventAt": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "statusCodes": {
@@ -2743,7 +3233,9 @@
       },
       "AdminUsageSnapshotResponse": {
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
           "data": {
             "$ref": "#/components/schemas/AdminUsageSnapshot"
@@ -2752,11 +3244,17 @@
       },
       "AdminUsageResetResponse": {
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
           "data": {
             "type": "object",
-            "required": ["developerId", "reset", "priorValues"],
+            "required": [
+              "developerId",
+              "reset",
+              "priorValues"
+            ],
             "properties": {
               "developerId": {
                 "type": "string"
@@ -2773,7 +3271,10 @@
       },
       "ApisListResponse": {
         "type": "object",
-        "required": ["data", "pagination"],
+        "required": [
+          "data",
+          "pagination"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -2783,7 +3284,11 @@
           },
           "pagination": {
             "type": "object",
-            "required": ["limit", "offset", "total"],
+            "required": [
+              "limit",
+              "offset",
+              "total"
+            ],
             "properties": {
               "limit": {
                 "type": "integer"
@@ -2800,7 +3305,12 @@
       },
       "ApiCreateRequest": {
         "type": "object",
-        "required": ["name", "base_url", "category", "endpoints"],
+        "required": [
+          "name",
+          "base_url",
+          "category",
+          "endpoints"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -2818,7 +3328,11 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["path", "method", "price_per_call_usdc"],
+              "required": [
+                "path",
+                "method",
+                "price_per_call_usdc"
+              ],
               "properties": {
                 "path": {
                   "type": "string"
@@ -2925,7 +3439,9 @@
       },
       "BulkEndpointRegistrationRequest": {
         "type": "object",
-        "required": ["endpoints"],
+        "required": [
+          "endpoints"
+        ],
         "properties": {
           "endpoints": {
             "type": "array",
@@ -2933,7 +3449,11 @@
             "maxItems": 50,
             "items": {
               "type": "object",
-              "required": ["path", "method", "price_per_call_usdc"],
+              "required": [
+                "path",
+                "method",
+                "price_per_call_usdc"
+              ],
               "properties": {
                 "path": {
                   "type": "string",
@@ -2966,7 +3486,9 @@
       },
       "BulkEndpointRegistrationResponse": {
         "type": "object",
-        "required": ["endpoints"],
+        "required": [
+          "endpoints"
+        ],
         "properties": {
           "endpoints": {
             "type": "array",
@@ -3043,7 +3565,10 @@
           },
           "developer": {
             "type": "object",
-            "required": ["id", "name"],
+            "required": [
+              "id",
+              "name"
+            ],
             "properties": {
               "id": {
                 "type": "integer"
@@ -3091,11 +3616,19 @@
       },
       "DeveloperRevenueResponse": {
         "type": "object",
-        "required": ["summary", "settlements", "pagination"],
+        "required": [
+          "summary",
+          "settlements",
+          "pagination"
+        ],
         "properties": {
           "summary": {
             "type": "object",
-            "required": ["total_earned", "pending", "available_to_withdraw"],
+            "required": [
+              "total_earned",
+              "pending",
+              "available_to_withdraw"
+            ],
             "properties": {
               "total_earned": {
                 "type": "number"
@@ -3145,7 +3678,11 @@
           },
           "pagination": {
             "type": "object",
-            "required": ["limit", "offset", "total"],
+            "required": [
+              "limit",
+              "offset",
+              "total"
+            ],
             "properties": {
               "limit": {
                 "type": "integer"
@@ -3194,7 +3731,10 @@
       },
       "DeveloperApiKeysResponse": {
         "type": "object",
-        "required": ["data", "meta"],
+        "required": [
+          "data",
+          "meta"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -3204,7 +3744,11 @@
           },
           "meta": {
             "type": "object",
-            "required": ["limit", "nextCursor", "hasMore"],
+            "required": [
+              "limit",
+              "nextCursor",
+              "hasMore"
+            ],
             "properties": {
               "limit": {
                 "type": "integer"
@@ -3222,14 +3766,21 @@
       },
       "GatewayHealthResponse": {
         "type": "object",
-        "required": ["apiSlug", "latency", "breaker"],
+        "required": [
+          "apiSlug",
+          "latency",
+          "breaker"
+        ],
         "properties": {
           "apiSlug": {
             "type": "string"
           },
           "latency": {
             "type": "object",
-            "required": ["p50", "p95"],
+            "required": [
+              "p50",
+              "p95"
+            ],
             "properties": {
               "p50": {
                 "type": "number",
@@ -3245,11 +3796,17 @@
           },
           "breaker": {
             "type": "object",
-            "required": ["state"],
+            "required": [
+              "state"
+            ],
             "properties": {
               "state": {
                 "type": "string",
-                "enum": ["closed", "open", "half-open"]
+                "enum": [
+                  "closed",
+                  "open",
+                  "half-open"
+                ]
               }
             }
           }
@@ -3257,7 +3814,11 @@
       },
       "ErrorResponse": {
         "type": "object",
-        "required": ["code", "message", "requestId"],
+        "required": [
+          "code",
+          "message",
+          "requestId"
+        ],
         "properties": {
           "code": {
             "$ref": "#/components/schemas/ErrorCode"

--- a/migrations/0018_subscriptions.down.sql
+++ b/migrations/0018_subscriptions.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS `idx_subscriptions_api_id`;
+DROP INDEX IF EXISTS `idx_subscriptions_user_id`;
+DROP INDEX IF EXISTS `idx_subscriptions_user_api_active`;
+DROP TABLE IF EXISTS `subscriptions`;

--- a/migrations/0018_subscriptions.sql
+++ b/migrations/0018_subscriptions.sql
@@ -1,0 +1,24 @@
+-- Create subscriptions table
+-- Allows developers to subscribe to marketplace APIs with metering preferences.
+
+CREATE TABLE IF NOT EXISTS `subscriptions` (
+  `id`             text    PRIMARY KEY NOT NULL,
+  `user_id`        text    NOT NULL,
+  `api_id`         integer NOT NULL,
+  `status`         text    NOT NULL DEFAULT 'active',
+  `metering_limit` integer,                          -- max calls/month; NULL = unlimited
+  `created_at`     integer NOT NULL DEFAULT (unixepoch()),
+  `updated_at`     integer NOT NULL DEFAULT (unixepoch()),
+  `cancelled_at`   integer,
+  FOREIGN KEY (`api_id`) REFERENCES `apis`(`id`) ON DELETE CASCADE,
+  CHECK (`status` IN ('active', 'paused', 'cancelled'))
+);
+
+-- Prevent a user from holding more than one non-cancelled subscription per API.
+-- SQLite supports partial/filtered indexes via the WHERE clause.
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_subscriptions_user_api_active`
+  ON `subscriptions` (`user_id`, `api_id`)
+  WHERE `status` != 'cancelled';
+
+CREATE INDEX IF NOT EXISTS `idx_subscriptions_user_id` ON `subscriptions` (`user_id`);
+CREATE INDEX IF NOT EXISTS `idx_subscriptions_api_id`  ON `subscriptions` (`api_id`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import {
   type DeveloperRepository,
   findByUserId,
 } from './repositories/developerRepository.js';
+import { defaultSubscriptionRepository } from './repositories/subscriptionRepository.js';
 import { apiStatusEnum, type ApiStatus, httpMethodEnum } from './db/schema.js';
 import type { Developer } from './db/schema.js';
 import { requireAuth, type AuthenticatedLocals } from './middleware/requireAuth.js';
@@ -318,7 +319,8 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     perDevConcurrency,
     usageEventsRepository,
     apiRepository,
-    developerRepository
+    developerRepository,
+    subscriptionRepository: defaultSubscriptionRepository,
   }));
 
   app.get('/api/developers/apis', requireAuth, async (req, res: express.Response<unknown, AuthenticatedLocals>, next) => {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -108,3 +108,31 @@ export const quotaRequests = sqliteTable('quota_requests', {
 
 export type QuotaRequestRow = typeof quotaRequests.$inferSelect;
 export type NewQuotaRequestRow = typeof quotaRequests.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Subscriptions — per-user subscriptions to marketplace APIs
+// ---------------------------------------------------------------------------
+
+export const subscriptionStatusEnum = ['active', 'paused', 'cancelled'] as const;
+export type SubscriptionStatus = (typeof subscriptionStatusEnum)[number];
+
+export const subscriptions = sqliteTable('subscriptions', {
+  id: text('id').primaryKey(),
+  user_id: text('user_id').notNull(),
+  api_id: integer('api_id')
+    .notNull()
+    .references(() => apis.id, { onDelete: 'cascade' }),
+  status: text('status', { enum: subscriptionStatusEnum }).notNull().default('active'),
+  /** Maximum calls per calendar month. NULL means unlimited. */
+  metering_limit: integer('metering_limit'),
+  created_at: integer('created_at', { mode: 'timestamp' })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  updated_at: integer('updated_at', { mode: 'timestamp' })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  cancelled_at: integer('cancelled_at', { mode: 'timestamp' }),
+});
+
+export type Subscription = typeof subscriptions.$inferSelect;
+export type NewSubscription = typeof subscriptions.$inferInsert;

--- a/src/repositories/subscriptionRepository.ts
+++ b/src/repositories/subscriptionRepository.ts
@@ -1,0 +1,133 @@
+import { and, eq, ne } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { db, schema } from '../db/index.js';
+import type { Subscription } from '../db/schema.js';
+import type { SubscriptionStatus } from '../db/schema.js';
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface CreateSubscriptionInput {
+  user_id: string;
+  api_id: number;
+  metering_limit?: number | null;
+}
+
+export interface UpdateSubscriptionInput {
+  status?: SubscriptionStatus;
+  metering_limit?: number | null;
+}
+
+export interface SubscriptionRepository {
+  create(data: CreateSubscriptionInput): Promise<Subscription>;
+  findById(id: string): Promise<Subscription | undefined>;
+  findByUserId(user_id: string): Promise<Subscription[]>;
+  findActiveByUserAndApi(user_id: string, api_id: number): Promise<Subscription | undefined>;
+  update(id: string, data: UpdateSubscriptionInput): Promise<Subscription | undefined>;
+  cancel(id: string): Promise<Subscription | undefined>;
+}
+
+// ---------------------------------------------------------------------------
+// Default (SQLite / Drizzle) implementation
+// ---------------------------------------------------------------------------
+
+async function create(data: CreateSubscriptionInput): Promise<Subscription> {
+  const id = randomUUID();
+  const now = new Date();
+
+  const [inserted] = await db
+    .insert(schema.subscriptions)
+    .values({
+      id,
+      user_id: data.user_id,
+      api_id: data.api_id,
+      status: 'active',
+      metering_limit: data.metering_limit ?? null,
+      created_at: now,
+      updated_at: now,
+    })
+    .returning();
+
+  if (!inserted) throw new Error('Subscription insert failed');
+  return inserted;
+}
+
+async function findById(id: string): Promise<Subscription | undefined> {
+  const rows = await db
+    .select()
+    .from(schema.subscriptions)
+    .where(eq(schema.subscriptions.id, id))
+    .limit(1);
+  return rows[0];
+}
+
+async function findByUserId(user_id: string): Promise<Subscription[]> {
+  return db
+    .select()
+    .from(schema.subscriptions)
+    .where(eq(schema.subscriptions.user_id, user_id))
+    .orderBy(schema.subscriptions.created_at);
+}
+
+async function findActiveByUserAndApi(
+  user_id: string,
+  api_id: number,
+): Promise<Subscription | undefined> {
+  const rows = await db
+    .select()
+    .from(schema.subscriptions)
+    .where(
+      and(
+        eq(schema.subscriptions.user_id, user_id),
+        eq(schema.subscriptions.api_id, api_id),
+        ne(schema.subscriptions.status, 'cancelled'),
+      ),
+    )
+    .limit(1);
+  return rows[0];
+}
+
+async function update(
+  id: string,
+  data: UpdateSubscriptionInput,
+): Promise<Subscription | undefined> {
+  const now = new Date();
+
+  const [updated] = await db
+    .update(schema.subscriptions)
+    .set({
+      ...(data.status !== undefined ? { status: data.status } : {}),
+      ...(data.metering_limit !== undefined ? { metering_limit: data.metering_limit } : {}),
+      updated_at: now,
+    })
+    .where(eq(schema.subscriptions.id, id))
+    .returning();
+
+  return updated;
+}
+
+async function cancel(id: string): Promise<Subscription | undefined> {
+  const now = new Date();
+
+  const [updated] = await db
+    .update(schema.subscriptions)
+    .set({
+      status: 'cancelled',
+      cancelled_at: now,
+      updated_at: now,
+    })
+    .where(eq(schema.subscriptions.id, id))
+    .returning();
+
+  return updated;
+}
+
+export const defaultSubscriptionRepository: SubscriptionRepository = {
+  create,
+  findById,
+  findByUserId,
+  findActiveByUserAndApi,
+  update,
+  cancel,
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -15,6 +15,10 @@ import { createUsageCsvRouter } from './usage/csv.js';
 import { createUsageByEndpointRouter } from './usage/byEndpoint.js';
 import { createExportSchedulesRouter } from './exports/schedules.js';
 import type { ScheduledExportsService } from '../services/scheduledExports.js';
+import { createSubscriptionRouter } from './subscriptionRoutes.js';
+import type { SubscriptionRepository } from '../repositories/subscriptionRepository.js';
+import type { DeveloperRepository } from '../repositories/developerRepository.js';
+import type { ApiRepository } from '../repositories/apiRepository.js';
 
 const openApiPath = path.join(process.cwd(), 'docs/openapi.json');
 const openApiSpec = JSON.parse(readFileSync(openApiPath, 'utf8'));
@@ -24,6 +28,9 @@ export interface ApiRouterDeps extends Partial<UsageRouterDeps>, Partial<ApisRou
   restRateLimiter?: InMemoryRestRateLimiter;
   perDevConcurrency?: RequestHandler;
   scheduledExportsService?: ScheduledExportsService;
+  subscriptionRepository?: SubscriptionRepository;
+  developerRepository?: DeveloperRepository;
+  apiRepository?: ApiRepository;
 }
 
 export function createApiRouter(deps: ApiRouterDeps = {}): Router {
@@ -51,6 +58,18 @@ export function createApiRouter(deps: ApiRouterDeps = {}): Router {
 
   if (deps.scheduledExportsService) {
     router.use('/exports/schedules', createExportSchedulesRouter(deps.scheduledExportsService));
+  }
+
+  // Subscriptions — developers subscribe to marketplace APIs with metering preferences.
+  if (deps.subscriptionRepository && deps.apiRepository && deps.developerRepository) {
+    router.use(
+      '/subscriptions',
+      createSubscriptionRouter({
+        subscriptionRepository: deps.subscriptionRepository,
+        apiRepository: deps.apiRepository,
+        developerRepository: deps.developerRepository,
+      }),
+    );
   }
 
   // Per-developer concurrency middleware for billing routes — applied BEFORE

--- a/src/routes/subscriptionRoutes.test.ts
+++ b/src/routes/subscriptionRoutes.test.ts
@@ -1,0 +1,509 @@
+import request from 'supertest';
+import express from 'express';
+import { createSubscriptionRouter } from './subscriptionRoutes.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { requestIdMiddleware } from '../middleware/requestId.js';
+import type { SubscriptionRepository } from '../repositories/subscriptionRepository.js';
+import type { ApiRepository } from '../repositories/apiRepository.js';
+import type { DeveloperRepository } from '../repositories/developerRepository.js';
+import type { Api, Developer, Subscription } from '../db/schema.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const now = new Date('2026-01-01T00:00:00.000Z');
+
+const subscriberDeveloper: Developer = {
+  id: 1,
+  user_id: 'user-subscriber',
+  name: 'Subscriber Dev',
+  website: null,
+  description: null,
+  category: null,
+  plan_overrides: null,
+  created_at: now,
+  updated_at: now,
+};
+
+const ownerDeveloper: Developer = {
+  id: 2,
+  user_id: 'user-owner',
+  name: 'Owner Dev',
+  website: null,
+  description: null,
+  category: null,
+  plan_overrides: null,
+  created_at: now,
+  updated_at: now,
+};
+
+const activeApi: Api = {
+  id: 10,
+  developer_id: 2, // owned by ownerDeveloper
+  name: 'Test API',
+  description: null,
+  base_url: 'https://api.example.com',
+  logo_url: null,
+  category: 'search',
+  status: 'active',
+  created_at: now,
+  updated_at: now,
+  deleted_at: null,
+};
+
+const deletedApi: Api = {
+  ...activeApi,
+  id: 11,
+  deleted_at: now,
+};
+
+const makeSubscription = (overrides: Partial<Subscription> = {}): Subscription => ({
+  id: 'sub-001',
+  user_id: 'user-subscriber',
+  api_id: 10,
+  status: 'active',
+  metering_limit: null,
+  created_at: now,
+  updated_at: now,
+  cancelled_at: null,
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeSubscriptionRepo(overrides: Partial<SubscriptionRepository> = {}): SubscriptionRepository {
+  return {
+    create: jest.fn().mockResolvedValue(makeSubscription()),
+    findById: jest.fn().mockResolvedValue(undefined),
+    findByUserId: jest.fn().mockResolvedValue([]),
+    findActiveByUserAndApi: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(makeSubscription()),
+    cancel: jest.fn().mockResolvedValue(makeSubscription({ status: 'cancelled', cancelled_at: now })),
+    ...overrides,
+  };
+}
+
+function makeApiRepo(overrides: Partial<ApiRepository> = {}): ApiRepository {
+  return {
+    create: jest.fn(),
+    createWithEndpoints: jest.fn(),
+    update: jest.fn().mockResolvedValue(null),
+    delete: jest.fn().mockResolvedValue(false),
+    restore: jest.fn().mockResolvedValue(null),
+    listByDeveloper: jest.fn().mockResolvedValue([]),
+    listPublic: jest.fn().mockResolvedValue([]),
+    findById: jest.fn().mockResolvedValue(null),
+    findRawById: jest.fn().mockResolvedValue(activeApi),
+    getEndpoints: jest.fn().mockResolvedValue([]),
+    bulkCreateEndpoints: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as ApiRepository;
+}
+
+function makeDeveloperRepo(overrides: Partial<DeveloperRepository> = {}): DeveloperRepository {
+  return {
+    findByUserId: jest.fn().mockImplementation((userId: string) => {
+      if (userId === subscriberDeveloper.user_id) return Promise.resolve(subscriberDeveloper);
+      if (userId === ownerDeveloper.user_id) return Promise.resolve(ownerDeveloper);
+      return Promise.resolve(undefined);
+    }),
+    getOrCreateByUserId: jest.fn().mockResolvedValue(subscriberDeveloper),
+    upsertProfile: jest.fn().mockResolvedValue(subscriberDeveloper),
+    ...overrides,
+  };
+}
+
+function buildApp(
+  subscriptionRepo: SubscriptionRepository,
+  apiRepo: ApiRepository,
+  developerRepo: DeveloperRepository,
+) {
+  const app = express();
+  app.use(express.json());
+  app.use(requestIdMiddleware);
+  app.use(
+    '/api/subscriptions',
+    createSubscriptionRouter({
+      subscriptionRepository: subscriptionRepo,
+      apiRepository: apiRepo,
+      developerRepository: developerRepo,
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/subscriptions
+// ---------------------------------------------------------------------------
+
+describe('POST /api/subscriptions', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app).post('/api/subscriptions').send({ api_id: 10 });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for missing api_id', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-integer api_id', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 'bad' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when metering_limit is zero', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, metering_limit: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when api does not exist', async () => {
+    const apiRepo = makeApiRepo({ findRawById: jest.fn().mockResolvedValue(null) });
+    const app = buildApp(makeSubscriptionRepo(), apiRepo, makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 99 });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when api is soft-deleted', async () => {
+    const apiRepo = makeApiRepo({ findRawById: jest.fn().mockResolvedValue(deletedApi) });
+    const app = buildApp(makeSubscriptionRepo(), apiRepo, makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 11 });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when subscribing to own API', async () => {
+    // ownerDeveloper (id=2) owns activeApi (developer_id=2)
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-owner') // this user is the owner
+      .send({ api_id: 10 });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 409 when subscription already exists', async () => {
+    const subRepo = makeSubscriptionRepo({
+      findActiveByUserAndApi: jest.fn().mockResolvedValue(makeSubscription()),
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10 });
+    expect(res.status).toBe(409);
+  });
+
+  it('creates a subscription and returns 201', async () => {
+    const created = makeSubscription({ metering_limit: 500 });
+    const subRepo = makeSubscriptionRepo({ create: jest.fn().mockResolvedValue(created) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, metering_limit: 500 });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe(created.id);
+    expect(res.body.status).toBe('active');
+  });
+
+  it('accepts null metering_limit (unlimited)', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, metering_limit: null });
+    expect(res.status).toBe(201);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/subscriptions
+// ---------------------------------------------------------------------------
+
+describe('GET /api/subscriptions', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app).get('/api/subscriptions');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns empty list when user has no subscriptions', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .get('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.total).toBe(0);
+  });
+
+  it('returns all subscriptions for the user', async () => {
+    const subs = [makeSubscription(), makeSubscription({ id: 'sub-002', status: 'paused' })];
+    const subRepo = makeSubscriptionRepo({ findByUserId: jest.fn().mockResolvedValue(subs) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .get('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(2);
+  });
+
+  it('filters by status query param', async () => {
+    const subs = [
+      makeSubscription({ id: 'sub-a', status: 'active' }),
+      makeSubscription({ id: 'sub-b', status: 'paused' }),
+      makeSubscription({ id: 'sub-c', status: 'cancelled', cancelled_at: now }),
+    ];
+    const subRepo = makeSubscriptionRepo({ findByUserId: jest.fn().mockResolvedValue(subs) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .get('/api/subscriptions?status=active')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.data[0].id).toBe('sub-a');
+  });
+
+  it('returns 400 for invalid status filter', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .get('/api/subscriptions?status=invalid')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/subscriptions/:id
+// ---------------------------------------------------------------------------
+
+describe('GET /api/subscriptions/:id', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app).get('/api/subscriptions/sub-001');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for unknown subscription', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .get('/api/subscriptions/does-not-exist')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when subscription belongs to a different user', async () => {
+    const otherUserSub = makeSubscription({ user_id: 'user-other' });
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(otherUserSub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .get('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns the subscription for the owning user', async () => {
+    const sub = makeSubscription();
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(sub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .get('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('sub-001');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/subscriptions/:id
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/subscriptions/:id', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .send({ status: 'paused' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for unknown subscription', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/does-not-exist')
+      .set('x-user-id', 'user-subscriber')
+      .send({ status: 'paused' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when subscription belongs to a different user', async () => {
+    const otherUserSub = makeSubscription({ user_id: 'user-other' });
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(otherUserSub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ status: 'paused' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when trying to modify a cancelled subscription', async () => {
+    const cancelledSub = makeSubscription({ status: 'cancelled', cancelled_at: now });
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(cancelledSub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ status: 'active' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body is empty', async () => {
+    const sub = makeSubscription();
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(sub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when metering_limit is negative', async () => {
+    const sub = makeSubscription();
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(sub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ metering_limit: -1 });
+    expect(res.status).toBe(400);
+  });
+
+  it('pauses a subscription', async () => {
+    const sub = makeSubscription();
+    const paused = makeSubscription({ status: 'paused' });
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      update: jest.fn().mockResolvedValue(paused),
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ status: 'paused' });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('paused');
+  });
+
+  it('updates metering_limit', async () => {
+    const sub = makeSubscription();
+    const updated = makeSubscription({ metering_limit: 1000 });
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      update: jest.fn().mockResolvedValue(updated),
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ metering_limit: 1000 });
+    expect(res.status).toBe(200);
+    expect(res.body.metering_limit).toBe(1000);
+  });
+
+  it('clears metering_limit to null', async () => {
+    const sub = makeSubscription({ metering_limit: 500 });
+    const updated = makeSubscription({ metering_limit: null });
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      update: jest.fn().mockResolvedValue(updated),
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ metering_limit: null });
+    expect(res.status).toBe(200);
+    expect(res.body.metering_limit).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/subscriptions/:id
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/subscriptions/:id', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app).delete('/api/subscriptions/sub-001');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for unknown subscription', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .delete('/api/subscriptions/does-not-exist')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when subscription belongs to a different user', async () => {
+    const otherUserSub = makeSubscription({ user_id: 'user-other' });
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(otherUserSub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .delete('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when subscription is already cancelled', async () => {
+    const cancelledSub = makeSubscription({ status: 'cancelled', cancelled_at: now });
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(cancelledSub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .delete('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(400);
+  });
+
+  it('cancels a subscription and returns cancelled status', async () => {
+    const sub = makeSubscription();
+    const cancelled = makeSubscription({ status: 'cancelled', cancelled_at: now });
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      cancel: jest.fn().mockResolvedValue(cancelled),
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+    const res = await request(app)
+      .delete('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('cancelled');
+    expect(res.body.cancelled_at).not.toBeNull();
+  });
+});

--- a/src/routes/subscriptionRoutes.ts
+++ b/src/routes/subscriptionRoutes.ts
@@ -1,0 +1,237 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
+import { validate } from '../middleware/validate.js';
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+} from '../errors/index.js';
+import type { SubscriptionRepository } from '../repositories/subscriptionRepository.js';
+import type { ApiRepository } from '../repositories/apiRepository.js';
+import type { DeveloperRepository } from '../repositories/developerRepository.js';
+
+// ---------------------------------------------------------------------------
+// Async handler helper
+// ---------------------------------------------------------------------------
+
+function asyncHandler(
+  fn: (
+    req: Request,
+    res: Response<unknown, AuthenticatedLocals>,
+    next: NextFunction,
+  ) => Promise<void>,
+) {
+  return (req: Request, res: Response<unknown, AuthenticatedLocals>, next: NextFunction): void => {
+    fn(req, res, next).catch(next);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Deps interface
+// ---------------------------------------------------------------------------
+
+export interface SubscriptionRoutesDeps {
+  subscriptionRepository: SubscriptionRepository;
+  apiRepository: ApiRepository;
+  developerRepository: DeveloperRepository;
+}
+
+// ---------------------------------------------------------------------------
+// Validation schemas
+// ---------------------------------------------------------------------------
+
+const createSubscriptionSchema = z.object({
+  api_id: z.number().int().positive(),
+  metering_limit: z.number().int().positive().nullable().optional(),
+});
+
+const updateSubscriptionSchema = z
+  .object({
+    status: z.enum(['active', 'paused']).optional(),
+    metering_limit: z.number().int().positive().nullable().optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+const listQuerySchema = z.object({
+  status: z.enum(['active', 'paused', 'cancelled']).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export function createSubscriptionRouter(deps: SubscriptionRoutesDeps): Router {
+  const router = Router();
+  const { subscriptionRepository, apiRepository, developerRepository } = deps;
+
+  // -------------------------------------------------------------------------
+  // POST /api/subscriptions
+  // Subscribe the authenticated user to a marketplace API.
+  // -------------------------------------------------------------------------
+  router.post(
+    '/',
+    requireAuth,
+    validate({ body: createSubscriptionSchema }),
+    asyncHandler(async (req, res) => {
+      const user = res.locals.authenticatedUser;
+      if (!user) throw new UnauthorizedError();
+
+      const body = createSubscriptionSchema.parse(req.body);
+
+      // Verify the API exists
+      const api = await apiRepository.findRawById(body.api_id);
+      if (!api) {
+        throw new NotFoundError(`API ${body.api_id} not found`);
+      }
+
+      // Prevent subscribing to a soft-deleted API
+      if (api.deleted_at !== null && api.deleted_at !== undefined) {
+        throw new NotFoundError(`API ${body.api_id} not found`);
+      }
+
+      // Prevent subscribing to your own API
+      const developer = await developerRepository.findByUserId(user.id);
+      if (developer && api.developer_id === developer.id) {
+        throw new ForbiddenError('You cannot subscribe to your own API', 'FORBIDDEN');
+      }
+
+      // Enforce uniqueness: no active/paused subscription already exists
+      const existing = await subscriptionRepository.findActiveByUserAndApi(user.id, body.api_id);
+      if (existing) {
+        throw new ConflictError('You already have an active subscription for this API');
+      }
+
+      const subscription = await subscriptionRepository.create({
+        user_id: user.id,
+        api_id: body.api_id,
+        metering_limit: body.metering_limit ?? null,
+      });
+
+      res.status(201).json(subscription);
+    }),
+  );
+
+  // -------------------------------------------------------------------------
+  // GET /api/subscriptions
+  // List subscriptions for the authenticated user.
+  // -------------------------------------------------------------------------
+  router.get(
+    '/',
+    requireAuth,
+    validate({ query: listQuerySchema }),
+    asyncHandler(async (req, res) => {
+      const user = res.locals.authenticatedUser;
+      if (!user) throw new UnauthorizedError();
+
+      const query = listQuerySchema.parse(req.query);
+
+      let subscriptions = await subscriptionRepository.findByUserId(user.id);
+
+      if (query.status) {
+        subscriptions = subscriptions.filter((s) => s.status === query.status);
+      }
+
+      res.json({ data: subscriptions, total: subscriptions.length });
+    }),
+  );
+
+  // -------------------------------------------------------------------------
+  // GET /api/subscriptions/:id
+  // Get a single subscription (must belong to the authenticated user).
+  // -------------------------------------------------------------------------
+  router.get(
+    '/:id',
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const user = res.locals.authenticatedUser;
+      if (!user) throw new UnauthorizedError();
+
+      const subscription = await subscriptionRepository.findById(req.params.id);
+      if (!subscription) {
+        throw new NotFoundError('Subscription not found');
+      }
+
+      if (subscription.user_id !== user.id) {
+        throw new ForbiddenError('Access denied');
+      }
+
+      res.json(subscription);
+    }),
+  );
+
+  // -------------------------------------------------------------------------
+  // PATCH /api/subscriptions/:id
+  // Update metering preferences or pause/resume a subscription.
+  // -------------------------------------------------------------------------
+  router.patch(
+    '/:id',
+    requireAuth,
+    validate({ body: updateSubscriptionSchema }),
+    asyncHandler(async (req, res) => {
+      const user = res.locals.authenticatedUser;
+      if (!user) throw new UnauthorizedError();
+
+      const subscription = await subscriptionRepository.findById(req.params.id);
+      if (!subscription) {
+        throw new NotFoundError('Subscription not found');
+      }
+
+      if (subscription.user_id !== user.id) {
+        throw new ForbiddenError('Access denied');
+      }
+
+      if (subscription.status === 'cancelled') {
+        throw new BadRequestError('Cannot modify a cancelled subscription');
+      }
+
+      const body = updateSubscriptionSchema.parse(req.body);
+
+      const updated = await subscriptionRepository.update(req.params.id, body);
+      if (!updated) {
+        throw new NotFoundError('Subscription not found');
+      }
+
+      res.json(updated);
+    }),
+  );
+
+  // -------------------------------------------------------------------------
+  // DELETE /api/subscriptions/:id
+  // Cancel a subscription (soft-delete; sets status to 'cancelled').
+  // -------------------------------------------------------------------------
+  router.delete(
+    '/:id',
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const user = res.locals.authenticatedUser;
+      if (!user) throw new UnauthorizedError();
+
+      const subscription = await subscriptionRepository.findById(req.params.id);
+      if (!subscription) {
+        throw new NotFoundError('Subscription not found');
+      }
+
+      if (subscription.user_id !== user.id) {
+        throw new ForbiddenError('Access denied');
+      }
+
+      if (subscription.status === 'cancelled') {
+        throw new BadRequestError('Subscription is already cancelled');
+      }
+
+      const cancelled = await subscriptionRepository.cancel(req.params.id);
+      if (!cancelled) {
+        throw new NotFoundError('Subscription not found');
+      }
+
+      res.json(cancelled);
+    }),
+  );
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Implements `/api/subscriptions` endpoints per issue #544.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/subscriptions` | Subscribe to a marketplace API |
| GET | `/api/subscriptions` | List user's subscriptions (filter by `?status=`) |
| GET | `/api/subscriptions/:id` | Get a single subscription |
| PATCH | `/api/subscriptions/:id` | Update status or metering_limit |
| DELETE | `/api/subscriptions/:id` | Cancel a subscription (soft-delete) |

## Business Rules

- Cannot subscribe to your own API → `403`
- Duplicate non-cancelled subscription → `409`
- Soft-deleted API → `404`
- Modifying/re-cancelling a cancelled subscription → `400`

## Changes

- `migrations/0018_subscriptions.sql` — table + partial unique index
- `src/db/schema.ts` — Drizzle table definition + type exports
- `src/repositories/subscriptionRepository.ts` — CRUD repository
- `src/routes/subscriptionRoutes.ts` — route handlers with auth + Zod validation
- `src/routes/index.ts` — mount at `/api/subscriptions`
- `src/app.ts` — wire repository into app
- `docs/openapi.json` — Subscription schema + all 5 endpoint paths
- `README.md` — document endpoints and business rules

## Tests

33 focused unit tests covering all endpoints and edge cases — all passing.

Closes #544