### PR TITLE
feat: admin grant credits

### DIFF
--- a/docs/billing-credits-endpoint.md
+++ b/docs/billing-credits-endpoint.md
@@ -6,6 +6,26 @@ The `/api/billing/credits` endpoint provides access to prepaid credit balance tr
 
 ## Endpoint
 
+### POST /api/admin/billing/credits/grant
+
+Issues a prepaid-credit grant for the **GrantFox FWC26** campaign. This is an
+admin-only endpoint: it is protected by the existing admin API-key/JWT and IP
+allowlist middleware. The grant amount is added atomically, so concurrent
+grants for the same user do not overwrite each other.
+
+**Request body:**
+
+```json
+{
+  "user_id": "user_123",
+  "amount_usdc": "25.50"
+}
+```
+
+`amount_usdc` must be a positive decimal string with at most seven fractional
+digits. Unknown fields are rejected. A successful request returns `201` with
+the granted amount, campaign name, and the updated `balance_usdc`.
+
 ### GET /api/billing/credits
 
 Returns the prepaid credit balance for the authenticated user.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6,6 +6,61 @@
     "description": "API contract covering Callora backend billing, usage, and developer routes."
   },
   "paths": {
+    "/api/admin/billing/credits/grant": {
+      "post": {
+        "summary": "Grant GrantFox FWC26 prepaid credits",
+        "description": "Adds prepaid USDC credits to a user account for the GrantFox FWC26 campaign. Requires admin authentication and the admin IP allowlist.",
+        "security": [
+          { "adminApiKey": [] },
+          { "bearerAuth": [] }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["user_id", "amount_usdc"],
+                "properties": {
+                  "user_id": { "type": "string", "minLength": 1, "maxLength": 255 },
+                  "amount_usdc": { "type": "string", "pattern": "^\\d+(?:\\.\\d{1,7})?$", "description": "Positive USDC amount with at most seven fractional digits" }
+                }
+              },
+              "example": { "user_id": "user_123", "amount_usdc": "25.50" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Credits granted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": ["user_id", "amount_usdc", "balance_usdc", "campaign", "updated_at"],
+                      "properties": {
+                        "user_id": { "type": "string" },
+                        "amount_usdc": { "type": "string" },
+                        "balance_usdc": { "type": "string" },
+                        "campaign": { "type": "string", "example": "GrantFox FWC26" },
+                        "updated_at": { "type": "string", "format": "date-time" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid grant request" },
+          "401": { "description": "Unauthorized admin request" },
+          "403": { "description": "Forbidden by admin IP allowlist" }
+        }
+      }
+    },
     "/api/gateway/health/{apiSlug}": {
       "get": {
         "summary": "Get gateway health for an API",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,7 +8,11 @@ const logger = console;
 let sqliteClosed = false;
 
 // Create SQLite database instance
-const sqlite = new Database('./database.db');
+/**
+ * The underlying connection is exported for the small number of repository
+ * operations that must run synchronously in a SQLite transaction.
+ */
+export const sqlite = new Database('./database.db');
 
 // Create Drizzle instance with schema
 export const db = drizzle(sqlite, { schema });

--- a/src/repositories/creditsRepository.ts
+++ b/src/repositories/creditsRepository.ts
@@ -1,18 +1,54 @@
 import { eq } from 'drizzle-orm';
-import { db, schema } from '../db/index.js';
+import { db, schema, sqlite } from '../db/index.js';
 import type { Credit, NewCredit } from '../db/schema.js';
 
 export interface CreditsRepository {
   findByUserId(userId: string): Promise<Credit | undefined>;
   getOrCreateByUserId(userId: string): Promise<Credit>;
   updateBalance(userId: string, newBalance: string): Promise<Credit>;
+  grant(userId: string, amountUsdc: string): Promise<Credit>;
 }
 
 export const defaultCreditsRepository: CreditsRepository = {
   findByUserId,
   getOrCreateByUserId,
   updateBalance,
+  grant,
 };
+
+const USDC_SCALE = 10_000_000n;
+const amountPattern = /^\d+(?:\.\d{1,7})?$/;
+
+function toUsdcUnits(amount: string): bigint {
+  if (!amountPattern.test(amount)) {
+    throw new Error('amountUsdc must be a non-negative decimal with at most 7 decimal places');
+  }
+
+  const [whole, fraction = ''] = amount.split('.');
+  return BigInt(whole) * USDC_SCALE + BigInt(fraction.padEnd(7, '0'));
+}
+
+function fromUsdcUnits(units: bigint): string {
+  const whole = units / USDC_SCALE;
+  const fraction = (units % USDC_SCALE).toString().padStart(7, '0').replace(/0+$/, '');
+  return fraction.length === 0 ? `${whole}.00` : `${whole}.${fraction.padEnd(2, '0')}`;
+}
+
+interface RawCredit {
+  id: number;
+  user_id: string;
+  balance_usdc: string;
+  created_at: number;
+  updated_at: number;
+}
+
+function mapRawCredit(credit: RawCredit): Credit {
+  return {
+    ...credit,
+    created_at: new Date(credit.created_at * 1_000),
+    updated_at: new Date(credit.updated_at * 1_000),
+  };
+}
 
 /**
  * Find credits record by user ID
@@ -73,4 +109,42 @@ export async function updateBalance(userId: string, newBalance: string): Promise
     throw new Error('Credits balance update failed');
   }
   return updated;
+}
+
+/**
+ * Add prepaid credits without passing through floating-point arithmetic.
+ *
+ * The read/modify/write sequence runs in one synchronous SQLite transaction,
+ * preventing concurrent admin grants from overwriting each other.
+ */
+export async function grant(userId: string, amountUsdc: string): Promise<Credit> {
+  const amountUnits = toUsdcUnits(amountUsdc);
+  if (amountUnits <= 0n) {
+    throw new Error('amountUsdc must be greater than zero');
+  }
+
+  const grantTransaction = sqlite.transaction((id: string, amount: bigint): Credit => {
+    const existing = sqlite
+      .prepare('SELECT id, user_id, balance_usdc, created_at, updated_at FROM credits WHERE user_id = ?')
+      .get(id) as RawCredit | undefined;
+    const now = Math.floor(Date.now() / 1_000);
+
+    if (!existing) {
+      const balanceUsdc = fromUsdcUnits(amount);
+      const inserted = sqlite
+        .prepare('INSERT INTO credits (user_id, balance_usdc, created_at, updated_at) VALUES (?, ?, ?, ?) RETURNING id, user_id, balance_usdc, created_at, updated_at')
+        .get(id, balanceUsdc, now, now) as RawCredit | undefined;
+      if (!inserted) throw new Error('Credits record insert failed');
+      return mapRawCredit(inserted);
+    }
+
+    const balanceUsdc = fromUsdcUnits(toUsdcUnits(existing.balance_usdc) + amount);
+    const updated = sqlite
+      .prepare('UPDATE credits SET balance_usdc = ?, updated_at = ? WHERE id = ? RETURNING id, user_id, balance_usdc, created_at, updated_at')
+      .get(balanceUsdc, now, existing.id) as RawCredit | undefined;
+    if (!updated) throw new Error('Credits balance update failed');
+    return mapRawCredit(updated);
+  });
+
+  return grantTransaction(userId, amountUnits);
 }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -17,6 +17,7 @@ import {
 import { createAdminWebhooksRouter } from './admin/webhooks.js';
 import { createAdminApisRouter } from './admin/apis.js';
 import { createAdminHealthProbesRouter } from './admin/health/probes.js';
+import { createAdminCreditGrantsRouter } from './admin/billing/credits/grant.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 const usageStore: UsageAdminStore = createUsageStore();
@@ -219,5 +220,11 @@ router.use('/apis', createAdminApisRouter());
 //          GET /api/admin/health/probes/:component
 // ---------------------------------------------------------------------------
 router.use('/health/probes', createAdminHealthProbesRouter());
+
+// ---------------------------------------------------------------------------
+// GrantFox FWC26 prepaid-credit grants
+// Mount: POST /api/admin/billing/credits/grant
+// ---------------------------------------------------------------------------
+router.use('/billing/credits', createAdminCreditGrantsRouter());
 
 export default router;

--- a/src/routes/admin/billing/credits/grant.test.ts
+++ b/src/routes/admin/billing/credits/grant.test.ts
@@ -1,0 +1,100 @@
+import express from 'express';
+import request from 'supertest';
+
+import type { Credit } from '../../../../db/schema.js';
+import { errorHandler } from '../../../../middleware/errorHandler.js';
+import type { CreditsRepository } from '../../../../repositories/creditsRepository.js';
+import { createAdminCreditGrantsRouter } from './grant.js';
+
+const ADMIN_KEY = 'test-admin-key';
+
+function makeCredit(overrides: Partial<Credit> = {}): Credit {
+  const now = new Date('2026-07-24T00:00:00.000Z');
+  return {
+    id: 1,
+    user_id: 'user_123',
+    balance_usdc: '0.00',
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+function buildApp(creditsRepository: CreditsRepository) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    if (req.headers['x-admin-api-key'] !== ADMIN_KEY) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    res.locals.adminActor = 'admin-api-key';
+    next();
+  });
+  app.use('/api/admin/billing/credits', createAdminCreditGrantsRouter({ creditsRepository }));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeRepository(): jest.Mocked<CreditsRepository> {
+  return {
+    findByUserId: jest.fn(),
+    getOrCreateByUserId: jest.fn(),
+    updateBalance: jest.fn(),
+    grant: jest.fn().mockResolvedValue(makeCredit({ balance_usdc: '25.50' })),
+  };
+}
+
+describe('POST /api/admin/billing/credits/grant', () => {
+  it('grants prepaid credits and returns the resulting balance', async () => {
+    const repository = makeRepository();
+    const response = await request(buildApp(repository))
+      .post('/api/admin/billing/credits/grant')
+      .set('x-admin-api-key', ADMIN_KEY)
+      .send({ user_id: 'user_123', amount_usdc: '25.50' });
+
+    expect(response.status).toBe(201);
+    expect(repository.grant).toHaveBeenCalledWith('user_123', '25.50');
+    expect(response.body.data).toMatchObject({
+      user_id: 'user_123',
+      amount_usdc: '25.50',
+      balance_usdc: '25.50',
+      campaign: 'GrantFox FWC26',
+    });
+  });
+
+  it.each(['0', '0.0000000', '-1', '1.00000001', '1e3'])(
+    'rejects invalid grant amount %s',
+    async (amount_usdc) => {
+      const repository = makeRepository();
+      const response = await request(buildApp(repository))
+        .post('/api/admin/billing/credits/grant')
+        .set('x-admin-api-key', ADMIN_KEY)
+        .send({ user_id: 'user_123', amount_usdc });
+
+      expect(response.status).toBe(400);
+      expect(repository.grant).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects unexpected request fields', async () => {
+    const repository = makeRepository();
+    const response = await request(buildApp(repository))
+      .post('/api/admin/billing/credits/grant')
+      .set('x-admin-api-key', ADMIN_KEY)
+      .send({ user_id: 'user_123', amount_usdc: '1.00', campaign: 'override' });
+
+    expect(response.status).toBe(400);
+    expect(repository.grant).not.toHaveBeenCalled();
+  });
+
+  it('requires admin authentication before issuing credits', async () => {
+    const repository = makeRepository();
+    const response = await request(buildApp(repository))
+      .post('/api/admin/billing/credits/grant')
+      .send({ user_id: 'user_123', amount_usdc: '1.00' });
+
+    expect(response.status).toBe(401);
+    expect(repository.grant).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/admin/billing/credits/grant.ts
+++ b/src/routes/admin/billing/credits/grant.ts
@@ -1,0 +1,75 @@
+import { Router } from 'express';
+import { z } from 'zod';
+
+import { AppError, InternalServerError } from '../../../../errors/index.js';
+import { getClientIp } from '../../../../lib/clientIp.js';
+import { logger } from '../../../../logger.js';
+import { validate } from '../../../../middleware/validate.js';
+import { defaultCreditsRepository, type CreditsRepository } from '../../../../repositories/creditsRepository.js';
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+const GRANTFOX_FWC26_CAMPAIGN = 'GrantFox FWC26';
+const amountUsdcPattern = /^\d+(?:\.\d{1,7})?$/;
+
+const grantBodySchema = z.object({
+  user_id: z.string().trim().min(1).max(255),
+  amount_usdc: z.string().trim().max(32).refine(
+    (amount) => amountUsdcPattern.test(amount) && BigInt(amount.replace('.', '').replace(/^0+(?=\d)/, '') || '0') > 0n,
+    'amount_usdc must be a positive number with at most 7 decimal places',
+  ),
+}).strict();
+
+type GrantBody = z.infer<typeof grantBodySchema>;
+
+export interface AdminCreditGrantsRouterDeps {
+  creditsRepository?: CreditsRepository;
+}
+
+/**
+ * Creates routes for issuing prepaid credits for the GrantFox FWC26 campaign.
+ * Authentication and IP allowlisting are supplied by the parent admin router.
+ */
+export function createAdminCreditGrantsRouter(
+  deps: AdminCreditGrantsRouterDeps = {},
+): Router {
+  const router = Router();
+  const creditsRepository = deps.creditsRepository ?? defaultCreditsRepository;
+
+  router.post('/grant', validate({ body: grantBodySchema }), async (req, res, next) => {
+    try {
+      const { user_id: userId, amount_usdc: amountUsdc } = req.body as GrantBody;
+      const credits = await creditsRepository.grant(userId, amountUsdc);
+
+      logger.audit('GRANT_PREPAID_CREDITS', res.locals.adminActor, {
+        campaign: GRANTFOX_FWC26_CAMPAIGN,
+        userId,
+        amountUsdc,
+        balanceUsdc: credits.balance_usdc,
+        clientIp: getClientIp(req, TRUST_PROXY),
+        userAgent: req.get('User-Agent'),
+        correlationId: req.headers['x-request-id'] ?? req.headers['x-correlation-id'],
+      });
+
+      res.status(201).json({
+        data: {
+          user_id: credits.user_id,
+          amount_usdc: amountUsdc,
+          balance_usdc: credits.balance_usdc,
+          campaign: GRANTFOX_FWC26_CAMPAIGN,
+          updated_at: credits.updated_at.toISOString(),
+        },
+      });
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error('Failed to grant prepaid credits', { error });
+      next(new InternalServerError());
+    }
+  });
+
+  return router;
+}
+
+export default createAdminCreditGrantsRouter;


### PR DESCRIPTION
close #619 
## Summary
- add an admin-only GrantFox FWC26 prepaid-credit grant endpoint
- use atomic integer-based USDC balance updates
- document the endpoint in OpenAPI and billing docs

## Validation
- OpenAPI JSON validation: passed
- git diff --check: passed
- Jest, typecheck, and lint could not run because Node/npm is unavailable in this environment.