### PR TITLE
feat: dispute resolution flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ Business rules:
 
 The migration is in `migrations/0018_subscriptions.sql`.
 
+## Dispute Resolution Endpoints
+
+Developers can open and track disputes against failed or incorrect billing deductions. Admins review and resolve disputes.
+
+**Developer routes** (`requireAuth`):
+
+- `POST /api/billing/disputes` — open a new dispute (`usage_event_id` and `reason` required); returns `201` with the new dispute object. Returns `409` if a dispute for that `usage_event_id` already exists.
+- `GET /api/billing/disputes` — list all disputes opened by the authenticated developer.
+- `GET /api/billing/disputes/:id` — get a single dispute plus its full audit-event trail. Returns `403` if the dispute belongs to another developer, `404` if not found.
+
+**Admin routes** (`adminAuth`):
+
+- `GET /api/billing/disputes/admin/all` — list every dispute across all developers.
+- `POST /api/billing/disputes/:id/resolve` — resolve a dispute. Body: `{ "resolution": "REFUNDED" | "UPHELD", "notes"?: string }`. Returns `404` for unknown disputes, `409` if already resolved.
+
+**State machine**: `OPEN → REFUNDED` (admin grants refund) or `OPEN → UPHELD` (admin upholds the charge).
+
+Every state transition is appended to the `dispute_events` audit trail, which is returned alongside the dispute on `GET /api/billing/disputes/:id`.
+
+The migration is in `migrations/0019_disputes.sql` (rollback: `migrations/0019_disputes.down.sql`).
+
 ## Developer Profile Endpoints
 
 - `GET /api/developers/me` returns the authenticated developer profile and auto-creates a blank profile row on first access.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,8 +11,12 @@
         "summary": "Grant GrantFox FWC26 prepaid credits",
         "description": "Adds prepaid USDC credits to a user account for the GrantFox FWC26 campaign. Requires admin authentication and the admin IP allowlist.",
         "security": [
-          { "adminApiKey": [] },
-          { "bearerAuth": [] }
+          {
+            "adminApiKey": []
+          },
+          {
+            "bearerAuth": []
+          }
         ],
         "requestBody": {
           "required": true,
@@ -21,13 +25,27 @@
               "schema": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["user_id", "amount_usdc"],
+                "required": [
+                  "user_id",
+                  "amount_usdc"
+                ],
                 "properties": {
-                  "user_id": { "type": "string", "minLength": 1, "maxLength": 255 },
-                  "amount_usdc": { "type": "string", "pattern": "^\\d+(?:\\.\\d{1,7})?$", "description": "Positive USDC amount with at most seven fractional digits" }
+                  "user_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "amount_usdc": {
+                    "type": "string",
+                    "pattern": "^\\d+(?:\\.\\d{1,7})?$",
+                    "description": "Positive USDC amount with at most seven fractional digits"
+                  }
                 }
               },
-              "example": { "user_id": "user_123", "amount_usdc": "25.50" }
+              "example": {
+                "user_id": "user_123",
+                "amount_usdc": "25.50"
+              }
             }
           }
         },
@@ -41,13 +59,31 @@
                   "properties": {
                     "data": {
                       "type": "object",
-                      "required": ["user_id", "amount_usdc", "balance_usdc", "campaign", "updated_at"],
+                      "required": [
+                        "user_id",
+                        "amount_usdc",
+                        "balance_usdc",
+                        "campaign",
+                        "updated_at"
+                      ],
                       "properties": {
-                        "user_id": { "type": "string" },
-                        "amount_usdc": { "type": "string" },
-                        "balance_usdc": { "type": "string" },
-                        "campaign": { "type": "string", "example": "GrantFox FWC26" },
-                        "updated_at": { "type": "string", "format": "date-time" }
+                        "user_id": {
+                          "type": "string"
+                        },
+                        "amount_usdc": {
+                          "type": "string"
+                        },
+                        "balance_usdc": {
+                          "type": "string"
+                        },
+                        "campaign": {
+                          "type": "string",
+                          "example": "GrantFox FWC26"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
                       }
                     }
                   }
@@ -55,16 +91,22 @@
               }
             }
           },
-          "400": { "description": "Invalid grant request" },
-          "401": { "description": "Unauthorized admin request" },
-          "403": { "description": "Forbidden by admin IP allowlist" }
+          "400": {
+            "description": "Invalid grant request"
+          },
+          "401": {
+            "description": "Unauthorized admin request"
+          },
+          "403": {
+            "description": "Forbidden by admin IP allowlist"
+          }
         }
       }
     },
     "/api/gateway/health/{apiSlug}": {
       "get": {
         "summary": "Get gateway health for an API",
-        "description": "Returns aggregated upstream latency percentiles and circuit breaker state for a given API slug. Public endpoint — no authentication required. Only aggregated metrics are returned; no tenant identifiers or raw histogram data are exposed. Results are cached in-memory for 5 seconds.",
+        "description": "Returns aggregated upstream latency percentiles and circuit breaker state for a given API slug. Public endpoint \u2014 no authentication required. Only aggregated metrics are returned; no tenant identifiers or raw histogram data are exposed. Results are cached in-memory for 5 seconds.",
         "parameters": [
           {
             "name": "apiSlug",
@@ -582,7 +624,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized — missing or invalid bearer token.",
+            "description": "Unauthorized \u2014 missing or invalid bearer token.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1331,7 +1373,7 @@
         },
         "responses": {
           "201": {
-            "description": "Endpoints registered successfully — per-row details returned",
+            "description": "Endpoints registered successfully \u2014 per-row details returned",
             "content": {
               "application/json": {
                 "schema": {
@@ -1341,7 +1383,7 @@
             }
           },
           "400": {
-            "description": "Validation error — invalid endpoint data, empty array, or too many endpoints",
+            "description": "Validation error \u2014 invalid endpoint data, empty array, or too many endpoints",
             "content": {
               "application/json": {
                 "schema": {
@@ -1715,6 +1757,260 @@
           }
         }
       }
+    },
+    "/api/billing/disputes": {
+      "post": {
+        "summary": "Open a dispute",
+        "description": "Developer opens a dispute against a billing charge (usage event). One open dispute is allowed per usage_event_id.",
+        "tags": [
+          "Billing",
+          "Disputes"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenDisputeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Dispute opened successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "409": {
+            "description": "Dispute already exists for this usage_event_id"
+          }
+        }
+      },
+      "get": {
+        "summary": "List own disputes",
+        "description": "Returns all disputes opened by the authenticated developer.",
+        "tags": [
+          "Billing",
+          "Disputes"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of disputes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "disputes",
+                    "total"
+                  ],
+                  "properties": {
+                    "disputes": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Dispute"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/billing/disputes/{id}": {
+      "get": {
+        "summary": "Get own dispute with audit trail",
+        "description": "Returns a single dispute and its full audit event trail. Only the dispute owner may access it.",
+        "tags": [
+          "Billing",
+          "Disputes"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dispute with events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "dispute",
+                    "events"
+                  ],
+                  "properties": {
+                    "dispute": {
+                      "$ref": "#/components/schemas/Dispute"
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DisputeEvent"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden: dispute belongs to another user"
+          },
+          "404": {
+            "description": "Dispute not found"
+          }
+        }
+      }
+    },
+    "/api/billing/disputes/{id}/resolve": {
+      "post": {
+        "summary": "Resolve a dispute (admin)",
+        "description": "Admin resolves an open dispute as REFUNDED or UPHELD. Requires admin authentication.",
+        "tags": [
+          "Billing",
+          "Disputes"
+        ],
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveDisputeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Dispute resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "401": {
+            "description": "Admin authentication required"
+          },
+          "404": {
+            "description": "Dispute not found"
+          },
+          "409": {
+            "description": "Dispute already resolved"
+          }
+        }
+      }
+    },
+    "/api/billing/disputes/admin/all": {
+      "get": {
+        "summary": "List all disputes (admin)",
+        "description": "Admin endpoint to list every dispute in the system.",
+        "tags": [
+          "Billing",
+          "Disputes"
+        ],
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All disputes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "disputes",
+                    "total"
+                  ],
+                  "properties": {
+                    "disputes": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Dispute"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Admin authentication required"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1886,7 +2182,7 @@
             "type": "string",
             "minLength": 10,
             "maxLength": 1000,
-            "description": "Justification for the upgrade (10–1000 characters)"
+            "description": "Justification for the upgrade (10\u20131000 characters)"
           },
           "requested_overrides": {
             "type": "object",
@@ -3031,6 +3327,121 @@
           "EXPORT_SCHEDULE_NOT_FOUND"
         ],
         "description": "Canonical Callora backend error code."
+      },
+      "Dispute": {
+        "type": "object",
+        "required": [
+          "id",
+          "usage_event_id",
+          "opened_by",
+          "reason",
+          "status",
+          "created_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "usage_event_id": {
+            "type": "string"
+          },
+          "opened_by": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "OPEN",
+              "REFUNDED",
+              "UPHELD"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resolved_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "resolved_by": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "DisputeEvent": {
+        "type": "object",
+        "required": [
+          "id",
+          "dispute_id",
+          "actor",
+          "action",
+          "created_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "dispute_id": {
+            "type": "string"
+          },
+          "actor": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "OpenDisputeRequest": {
+        "type": "object",
+        "required": [
+          "usage_event_id",
+          "reason"
+        ],
+        "properties": {
+          "usage_event_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000
+          }
+        }
+      },
+      "ResolveDisputeRequest": {
+        "type": "object",
+        "required": [
+          "resolution"
+        ],
+        "properties": {
+          "resolution": {
+            "type": "string",
+            "enum": [
+              "REFUNDED",
+              "UPHELD"
+            ]
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 1000
+          }
+        }
       }
     }
   }

--- a/migrations/0019_disputes.down.sql
+++ b/migrations/0019_disputes.down.sql
@@ -1,0 +1,3 @@
+-- Rollback disputes and dispute_events tables
+DROP TABLE IF EXISTS `dispute_events`;
+DROP TABLE IF EXISTS `disputes`;

--- a/migrations/0019_disputes.sql
+++ b/migrations/0019_disputes.sql
@@ -1,0 +1,37 @@
+-- Create disputes table
+-- Tracks per-developer billing disputes with a simple state machine.
+-- States: OPEN → REFUNDED (admin) | OPEN → UPHELD (admin)
+
+CREATE TABLE IF NOT EXISTS `disputes` (
+  `id`             text    PRIMARY KEY NOT NULL,
+  `usage_event_id` text    NOT NULL,
+  `opened_by`      text    NOT NULL,       -- developer user_id
+  `reason`         text    NOT NULL,
+  `status`         text    NOT NULL DEFAULT 'OPEN',
+  `created_at`     text    NOT NULL DEFAULT (datetime('now')),
+  `resolved_at`    text,
+  `resolved_by`    text,
+  CHECK (`status` IN ('OPEN', 'REFUNDED', 'UPHELD'))
+);
+
+-- Enforce: only one non-resolved dispute per usage_event_id
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_disputes_usage_event_open`
+  ON `disputes` (`usage_event_id`)
+  WHERE `status` = 'OPEN';
+
+CREATE INDEX IF NOT EXISTS `idx_disputes_opened_by`      ON `disputes` (`opened_by`);
+CREATE INDEX IF NOT EXISTS `idx_disputes_usage_event_id` ON `disputes` (`usage_event_id`);
+CREATE INDEX IF NOT EXISTS `idx_disputes_status`         ON `disputes` (`status`);
+
+-- Create dispute_events audit trail table
+CREATE TABLE IF NOT EXISTS `dispute_events` (
+  `id`          text    PRIMARY KEY NOT NULL,
+  `dispute_id`  text    NOT NULL,
+  `actor`       text    NOT NULL,
+  `action`      text    NOT NULL,
+  `details`     text,                      -- JSON-encoded optional metadata
+  `created_at`  text    NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (`dispute_id`) REFERENCES `disputes`(`id`) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS `idx_dispute_events_dispute_id` ON `dispute_events` (`dispute_id`);

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -26,8 +26,10 @@ import {
   SorobanRpcError,
 } from "../services/sorobanBilling.js";
 import { redactSimulationDetails } from "../lib/simulationDiagnostics.js";
+import { billingAccessLogMiddleware } from "../middleware/billingAccessLog.js";
 import creditsRouter from "./billing/credits.js";
 import disputesRouter from "./billing/disputes.js";
+import { createFeeAbstractionRouter } from "./billing/feeAbstraction.js";
 
 const router = Router();
 


### PR DESCRIPTION
## Summary

Implements the full dispute resolution flow for the Callora billing system, allowing developers to open disputes against incorrect billing deductions and admins to review and resolve them.

Closes #627

---

## Endpoints

All routes are under `/api/billing/disputes`.

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `POST` | `/` | `requireAuth` | Developer opens a new dispute |
| `GET` | `/` | `requireAuth` | Developer lists their own disputes |
| `GET` | `/:id` | `requireAuth` | Developer gets dispute + full audit trail |
| `GET` | `/admin/all` | `adminAuth` | Admin lists all disputes |
| `POST` | `/:id/resolve` | `adminAuth` | Admin resolves a dispute |

## State Machine

```
OPEN → REFUNDED  (admin grants refund)
OPEN → UPHELD    (admin upholds the charge)
```

Every transition is appended to the `dispute_events` audit trail.

---

## Files Changed

| File | Description |
|------|-------------|
| `src/routes/billing/disputes.ts` | 5-endpoint Router factory with full RBAC |
| `src/services/disputeService.ts` | `InMemoryDisputeRepository` + `DisputeService` + Zod schemas |
| `src/routes/billing.ts` | Mount disputes sub-router; fix missing `billingAccessLogMiddleware` and `feeAbstraction` imports |
| `migrations/0019_disputes.sql` | `disputes` + `dispute_events` tables with indexes |
| `migrations/0019_disputes.down.sql` | Rollback migration |
| `docs/openapi.json` | OpenAPI spec for all 4 dispute paths |
| `README.md` | Dispute Resolution Endpoints section |

---

## Tests

**39/39 passing** (`src/routes/billing/disputes.test.ts`)

Coverage areas:
- `openDisputeSchema` / `resolveDisputeSchema` validation
- `InMemoryDisputeRepository` state machine transitions and audit trail
- `DisputeService` RBAC helpers (`getDisputeForDeveloper`, `listForDeveloper`)
- HTTP layer: auth enforcement (401/403), conflict (409), not found (404), happy paths (201/200) for all 5 endpoints

```
✓ openDisputeSchema — accepts valid input
✓ openDisputeSchema — rejects missing usage_event_id
✓ openDisputeSchema — rejects empty reason
✓ resolveDisputeSchema — accepts REFUNDED
✓ resolveDisputeSchema — accepts UPHELD with notes
✓ resolveDisputeSchema — rejects invalid resolution
✓ InMemoryDisputeRepository — creates dispute in OPEN state
✓ InMemoryDisputeRepository — throws ConflictError on duplicate usage_event_id
✓ InMemoryDisputeRepository — findById returns undefined for unknown id
✓ InMemoryDisputeRepository — findByUser returns only that user disputes
✓ InMemoryDisputeRepository — listAll returns all disputes
✓ resolve — transitions OPEN → REFUNDED
✓ resolve — transitions OPEN → UPHELD
✓ resolve — throws NotFoundError for unknown id
✓ resolve — throws ConflictError when already resolved
✓ audit trail — appends and retrieves events
✓ audit trail — returns empty array for dispute with no events
✓ DisputeService — openDispute creates dispute and appends OPENED event
✓ DisputeService — resolveDispute updates status and appends RESOLVED event
✓ DisputeService — getDisputeForDeveloper throws ForbiddenError for wrong user
✓ DisputeService — getDisputeForDeveloper throws NotFoundError for unknown id
✓ POST /api/billing/disputes — returns 401 without auth
✓ POST /api/billing/disputes — returns 400 for invalid body
✓ POST /api/billing/disputes — opens a dispute and returns 201
✓ POST /api/billing/disputes — returns 409 for duplicate usage_event_id
✓ GET /api/billing/disputes — returns 401 without auth
✓ GET /api/billing/disputes — returns only the authenticated user disputes
✓ GET /api/billing/disputes/:id — returns 401 without auth
✓ GET /api/billing/disputes/:id — returns 403 when another user accesses the dispute
✓ GET /api/billing/disputes/:id — returns dispute + events for the owner
✓ GET /api/billing/disputes/:id — returns 404 for unknown dispute
✓ POST /api/billing/disputes/:id/resolve — returns 401 without admin auth
✓ POST /api/billing/disputes/:id/resolve — resolves a dispute as admin (REFUNDED)
✓ POST /api/billing/disputes/:id/resolve — resolves a dispute as admin (UPHELD)
✓ POST /api/billing/disputes/:id/resolve — returns 400 for invalid resolution value
✓ POST /api/billing/disputes/:id/resolve — returns 404 for unknown dispute
✓ POST /api/billing/disputes/:id/resolve — returns 409 when already resolved
✓ GET /api/billing/disputes/admin/all — returns 401 without admin auth
✓ GET /api/billing/disputes/admin/all — returns all disputes for admin
```

---

## Lint & Type Check

- `npm run lint` — clean on all dispute files
- `npm run typecheck` — no errors in dispute files (pre-existing unrelated errors elsewhere)