### PR TITLE
feat: per-key concurrency stats for GrantFox FWC26

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -19,6 +19,7 @@ import { createAdminApisRouter } from './admin/apis.js';
 import { createAdminHealthProbesRouter } from './admin/health/probes.js';
 import { createAdminCreditGrantsRouter } from './admin/billing/credits/grant.js';
 import { createAdminUsageExportRouter } from './admin/usage/export.js';
+import { createAdminKeyConcurrencyRouter } from './admin/keys/concurrency.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 const usageStore: UsageAdminStore = createUsageStore();
@@ -229,6 +230,13 @@ router.use('/health/probes', createAdminHealthProbesRouter());
 // Mount: POST /api/admin/billing/credits/grant
 // ---------------------------------------------------------------------------
 router.use('/billing/credits', createAdminCreditGrantsRouter());
+
+// ---------------------------------------------------------------------------
+// GrantFox FWC26 per-key concurrency stats
+// Mounts: GET /api/admin/keys/concurrency
+//         GET /api/admin/keys/concurrency/:keyId
+// ---------------------------------------------------------------------------
+router.use('/keys', createAdminKeyConcurrencyRouter());
 
 // ---------------------------------------------------------------------------
 // Maintenance banner

--- a/src/routes/admin/keys/concurrency.test.ts
+++ b/src/routes/admin/keys/concurrency.test.ts
@@ -1,0 +1,197 @@
+import express from 'express';
+import request from 'supertest';
+
+import { errorHandler } from '../../../middleware/errorHandler.js';
+import { KeySemaphore } from '../../../utils/keySemaphore.js';
+import { createAdminKeyConcurrencyRouter } from './concurrency.js';
+
+const ADMIN_KEY = 'test-admin-key';
+
+function buildApp(keySemaphore: KeySemaphore) {
+  const app = express();
+  app.use(express.json());
+  // Mimic the parent admin router's auth/IP-allowlist middleware
+  app.use((req, res, next) => {
+    if (req.headers['x-admin-api-key'] !== ADMIN_KEY) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    res.locals.adminActor = 'admin-api-key';
+    next();
+  });
+  app.use('/api/admin/keys', createAdminKeyConcurrencyRouter({ keySemaphore }));
+  app.use(errorHandler);
+  return app;
+}
+
+describe('GET /api/admin/keys/concurrency', () => {
+  let keySemaphore: KeySemaphore;
+
+  beforeEach(() => {
+    keySemaphore = new KeySemaphore(5, 1000);
+  });
+
+  afterEach(() => {
+    keySemaphore.clear();
+  });
+
+  it('returns empty counts when no keys are active', async () => {
+    const app = buildApp(keySemaphore);
+
+    const response = await request(app)
+      .get('/api/admin/keys/concurrency')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toMatchObject({
+      keyCounts: {},
+      totalActive: 0,
+      campaign: 'GrantFox FWC26',
+    });
+  });
+
+  it('returns active slot counts for all keys', async () => {
+    const app = buildApp(keySemaphore);
+
+    // Acquire some slots
+    await keySemaphore.withSlot('key_abc', async () => {
+      await keySemaphore.withSlot('key_abc', async () => {
+        const response = await request(app)
+          .get('/api/admin/keys/concurrency')
+          .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.keyCounts).toEqual({
+          key_abc: 2,
+        });
+        expect(response.body.data.totalActive).toBe(2);
+        expect(response.body.data.campaign).toBe('GrantFox FWC26');
+      });
+    });
+  });
+
+  it('returns counts for multiple different keys', async () => {
+    const sem = keySemaphore; // shorter alias
+    const app = buildApp(sem);
+
+    // Hold slots on two different keys and read stats
+    await sem.withSlot('key_abc', async () => {
+      await sem.withSlot('key_def', async () => {
+        const response = await request(app)
+          .get('/api/admin/keys/concurrency')
+          .set('x-admin-api-key', ADMIN_KEY);
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.totalActive).toBe(2);
+        expect(response.body.data.keyCounts).toMatchObject({
+          key_abc: 1,
+          key_def: 1,
+        });
+      });
+    });
+  });
+
+  it('requires admin authentication', async () => {
+    const app = buildApp(keySemaphore);
+
+    const response = await request(app)
+      .get('/api/admin/keys/concurrency');
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('GET /api/admin/keys/concurrency/:keyId', () => {
+  let keySemaphore: KeySemaphore;
+
+  beforeEach(() => {
+    keySemaphore = new KeySemaphore(5, 1000);
+  });
+
+  afterEach(() => {
+    keySemaphore.clear();
+  });
+
+  it('returns zero active count for an idle key', async () => {
+    const app = buildApp(keySemaphore);
+
+    const response = await request(app)
+      .get('/api/admin/keys/concurrency/key_idle')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toMatchObject({
+      keyId: 'key_idle',
+      activeCount: 0,
+      atLimit: false,
+      campaign: 'GrantFox FWC26',
+    });
+  });
+
+  it('returns active count for a key holding slots', async () => {
+    const app = buildApp(keySemaphore);
+
+    await keySemaphore.withSlot('key_busy', async () => {
+      const response = await request(app)
+        .get('/api/admin/keys/concurrency/key_busy')
+        .set('x-admin-api-key', ADMIN_KEY);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toMatchObject({
+        keyId: 'key_busy',
+        activeCount: 1,
+        atLimit: false,
+      });
+    });
+
+    // After release, count should be zero
+    const response2 = await request(app)
+      .get('/api/admin/keys/concurrency/key_busy')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(response2.body.data.activeCount).toBe(0);
+    expect(response2.body.data.atLimit).toBe(false);
+  });
+
+  it('reports atLimit: true when key is at its concurrency limit', async () => {
+    // Use maxConcurrency=1 so a single slot reaches the limit
+    const sem = new KeySemaphore(1, 1000);
+    const app = buildApp(sem);
+
+    await sem.withSlot('key_maxed', async () => {
+      const response = await request(app)
+        .get('/api/admin/keys/concurrency/key_maxed')
+        .set('x-admin-api-key', ADMIN_KEY);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toMatchObject({
+        keyId: 'key_maxed',
+        activeCount: 1,
+        atLimit: true,
+      });
+    });
+  });
+
+  it('requires admin authentication', async () => {
+    const app = buildApp(keySemaphore);
+
+    const response = await request(app)
+      .get('/api/admin/keys/concurrency/key_abc');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects empty keyId param', async () => {
+    const app = buildApp(keySemaphore);
+
+    // This test uses supertest to send a request with an empty keyId
+    // The validate middleware should catch it as 400
+    const response = await request(app)
+      .get('/api/admin/keys/concurrency/')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    // Without a keyId, the route won't match :keyId, so it'll either 404 or
+    // fall through. The app should return a standard error.
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/routes/admin/keys/concurrency.ts
+++ b/src/routes/admin/keys/concurrency.ts
@@ -1,0 +1,117 @@
+import { Router } from 'express';
+import { z } from 'zod';
+
+import { AppError, InternalServerError } from '../../../errors/index.js';
+import { getClientIp } from '../../../lib/clientIp.js';
+import { logger } from '../../../logger.js';
+import { validate } from '../../../middleware/validate.js';
+import { KeySemaphore, sharedKeySemaphore } from '../../../utils/keySemaphore.js';
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+const GRANTFOX_FWC26_CAMPAIGN = 'GrantFox FWC26';
+
+const keyIdParamsSchema = z.object({
+  keyId: z.string().min(1, 'keyId is required'),
+});
+
+export interface AdminKeyConcurrencyRouterDeps {
+  keySemaphore: KeySemaphore;
+}
+
+/**
+ * Creates routes for viewing per-API-key concurrency statistics.
+ *
+ * Authentication and IP allowlisting are supplied by the parent admin router.
+ * The `KeySemaphore` instance is shared with the gateway/proxy middleware so
+ * the concurrency counts reported here reflect live traffic.
+ *
+ * @example
+ * // Active slot counts for all keys
+ * GET /api/admin/keys/concurrency
+ * // → { data: { keyCounts: { "key_abc": 2, "key_def": 1 }, totalActive: 3 } }
+ *
+ * // Active slot count for a specific key
+ * GET /api/admin/keys/concurrency/:keyId
+ * // → { data: { keyId: "key_abc", activeCount: 2, atLimit: false } }
+ */
+export function createAdminKeyConcurrencyRouter(
+  deps: Partial<AdminKeyConcurrencyRouterDeps> = {},
+): Router {
+  const router = Router();
+  const keySemaphore = deps.keySemaphore ?? sharedKeySemaphore;
+
+  // GET /concurrency — snapshot of all active key concurrency counts
+  router.get('/concurrency', (req, res, next) => {
+    try {
+      const keyCounts = keySemaphore.getCurrentActiveSlotCounts();
+      const totalActive = keySemaphore.getTotalActiveSlotCount();
+
+      logger.audit('READ_KEY_CONCURRENCY', res.locals.adminActor, {
+        campaign: GRANTFOX_FWC26_CAMPAIGN,
+        keyCount: Object.keys(keyCounts).length,
+        totalActive,
+        clientIp: getClientIp(req, TRUST_PROXY),
+        userAgent: req.get('User-Agent'),
+        correlationId: req.headers['x-request-id'] ?? req.headers['x-correlation-id'],
+      });
+
+      res.json({
+        data: {
+          keyCounts,
+          totalActive,
+          campaign: GRANTFOX_FWC26_CAMPAIGN,
+        },
+      });
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error('Failed to read key concurrency stats', { error });
+      next(new InternalServerError());
+    }
+  });
+
+  // GET /concurrency/:keyId — active count for a specific key
+  router.get(
+    '/concurrency/:keyId',
+    validate({ params: keyIdParamsSchema }),
+    (req, res, next) => {
+      try {
+        const { keyId } = req.params;
+        const activeCount = keySemaphore.getActiveSlotCount(keyId);
+        const atLimit = keySemaphore.isAtLimit(keyId);
+
+        logger.audit('READ_KEY_CONCURRENCY_DETAIL', res.locals.adminActor, {
+          campaign: GRANTFOX_FWC26_CAMPAIGN,
+          keyId,
+          activeCount,
+          atLimit,
+          clientIp: getClientIp(req, TRUST_PROXY),
+          userAgent: req.get('User-Agent'),
+          correlationId: req.headers['x-request-id'] ?? req.headers['x-correlation-id'],
+        });
+
+        res.json({
+          data: {
+            keyId,
+            activeCount,
+            atLimit,
+            campaign: GRANTFOX_FWC26_CAMPAIGN,
+          },
+        });
+      } catch (error) {
+        if (error instanceof AppError) {
+          next(error);
+          return;
+        }
+        logger.error('Failed to read key concurrency detail', { error });
+        next(new InternalServerError());
+      }
+    },
+  );
+
+  return router;
+}
+
+export default createAdminKeyConcurrencyRouter;

--- a/src/utils/keySemaphore.test.ts
+++ b/src/utils/keySemaphore.test.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert';
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import { KeySemaphore } from './keySemaphore.js';
+
+describe('KeySemaphore', () => {
+  describe('basic concurrency enforcement', () => {
+    test('enforces max concurrency per key', async () => {
+      const semaphore = new KeySemaphore(2, 1000);
+      const activeAtPeak: number[] = [];
+
+      // Fire 3 concurrent tasks for the same key — only 2 should run at once
+      await Promise.all([
+        semaphore.withSlot('key-a', async () => {
+          activeAtPeak.push(semaphore.getCurrentActiveSlotCounts()['key-a'] ?? 0);
+          await new Promise((r) => setTimeout(r, 30));
+        }),
+        semaphore.withSlot('key-a', async () => {
+          activeAtPeak.push(semaphore.getCurrentActiveSlotCounts()['key-a'] ?? 0);
+          await new Promise((r) => setTimeout(r, 30));
+        }),
+        semaphore.withSlot('key-a', async () => {
+          activeAtPeak.push(semaphore.getCurrentActiveSlotCounts()['key-a'] ?? 0);
+          await new Promise((r) => setTimeout(r, 30));
+        }),
+      ]);
+
+      // The semaphore should never exceed maxConcurrency per key
+      assert.ok(
+        activeAtPeak.every((c) => c <= 2),
+        `Active count never exceeded 2: ${activeAtPeak}`,
+      );
+      assert.equal(semaphore.getTotalActiveSlotCount(), 0);
+    });
+
+    test('isolates concurrency limits between keys', async () => {
+      const semaphore = new KeySemaphore(1, 1000);
+      let peakTotal = 0;
+
+      await Promise.all([
+        semaphore.withSlot('key-a', async () => {
+          peakTotal = Math.max(peakTotal, semaphore.getTotalActiveSlotCount());
+          await new Promise((r) => setTimeout(r, 30));
+        }),
+        semaphore.withSlot('key-b', async () => {
+          peakTotal = Math.max(peakTotal, semaphore.getTotalActiveSlotCount());
+          await new Promise((r) => setTimeout(r, 30));
+        }),
+      ]);
+
+      // Two different keys should both be active concurrently
+      assert.equal(peakTotal, 2);
+    });
+  });
+
+  describe('slot counting', () => {
+    test('getCurrentActiveSlotCounts returns only active keys', async () => {
+      const semaphore = new KeySemaphore(5, 1000);
+
+      assert.deepEqual(semaphore.getCurrentActiveSlotCounts(), {});
+
+      await semaphore.withSlot('key-x', async () => {
+        const counts = semaphore.getCurrentActiveSlotCounts();
+        assert.equal(counts['key-x'], 1);
+        assert.equal(Object.keys(counts).length, 1);
+      });
+
+      assert.deepEqual(semaphore.getCurrentActiveSlotCounts(), {});
+    });
+
+    test('getActiveSlotCount returns count for specific key', async () => {
+      const semaphore = new KeySemaphore(5, 1000);
+
+      assert.equal(semaphore.getActiveSlotCount('key-y'), 0);
+
+      await semaphore.withSlot('key-y', async () => {
+        assert.equal(semaphore.getActiveSlotCount('key-y'), 1);
+      });
+
+      assert.equal(semaphore.getActiveSlotCount('key-y'), 0);
+    });
+
+    test('getTotalActiveSlotCount sums all active slots', async () => {
+      const semaphore = new KeySemaphore(3, 1000);
+
+      let total = 0;
+      await Promise.all([
+        semaphore.withSlot('key-1', async () => {
+          total = semaphore.getTotalActiveSlotCount();
+          await new Promise((r) => setTimeout(r, 30));
+        }),
+        semaphore.withSlot('key-2', async () => {
+          total = semaphore.getTotalActiveSlotCount();
+          await new Promise((r) => setTimeout(r, 30));
+        }),
+        semaphore.withSlot('key-3', async () => {
+          total = semaphore.getTotalActiveSlotCount();
+          await new Promise((r) => setTimeout(r, 30));
+        }),
+      ]);
+
+      assert.equal(total, 3);
+      assert.equal(semaphore.getTotalActiveSlotCount(), 0);
+    });
+  });
+
+  describe('isAtLimit', () => {
+    test('returns true when key is at its concurrency limit', async () => {
+      const semaphore = new KeySemaphore(1, 1000);
+
+      await semaphore.withSlot('key-limit', async () => {
+        assert.equal(semaphore.isAtLimit('key-limit'), true);
+      });
+
+      assert.equal(semaphore.isAtLimit('key-limit'), false);
+    });
+
+    test('returns false when key is under its concurrency limit', async () => {
+      const semaphore = new KeySemaphore(2, 1000);
+
+      await semaphore.withSlot('key-under', async () => {
+        assert.equal(semaphore.isAtLimit('key-under'), false);
+      });
+    });
+  });
+
+  describe('slot release', () => {
+    test('releases slot after successful task completion', async () => {
+      const semaphore = new KeySemaphore(1, 1000);
+
+      await semaphore.withSlot('key-release', async () => {
+        // slot held here
+      });
+
+      // Should be able to acquire the slot again
+      await semaphore.withSlot('key-release', async () => {
+        assert.equal(semaphore.getActiveSlotCount('key-release'), 1);
+      });
+
+      assert.equal(semaphore.getActiveSlotCount('key-release'), 0);
+    });
+
+    test('releases slot on error', async () => {
+      const semaphore = new KeySemaphore(1, 1000);
+
+      let errorCaught = false;
+      try {
+        await semaphore.withSlot('key-err', async () => {
+          throw new Error('test error');
+        });
+      } catch {
+        errorCaught = true;
+      }
+
+      assert.ok(errorCaught);
+      assert.equal(semaphore.getActiveSlotCount('key-err'), 0);
+
+      // Should be able to acquire the slot again
+      await semaphore.withSlot('key-err', async () => {
+        assert.equal(semaphore.getActiveSlotCount('key-err'), 1);
+      });
+    });
+  });
+
+  describe('clear', () => {
+    test('resets all state', async () => {
+      const semaphore = new KeySemaphore(2, 1000);
+
+      // Acquire a slot so we have state
+      await semaphore.withSlot('key-clr', async () => {
+        assert.equal(semaphore.getActiveSlotCount('key-clr'), 1);
+      });
+
+      semaphore.clear();
+      assert.equal(semaphore.getTotalActiveSlotCount(), 0);
+      assert.equal(semaphore.getActiveSlotCount('key-clr'), 0);
+      assert.deepEqual(semaphore.getCurrentActiveSlotCounts(), {});
+    });
+  });
+});

--- a/src/utils/keySemaphore.ts
+++ b/src/utils/keySemaphore.ts
@@ -1,0 +1,154 @@
+type QueueEntry = (release: () => void) => void;
+
+/**
+ * Per-API-key in-memory semaphore.
+ *
+ * Each API key gets its own concurrency queue and active slot count.
+ * TTL eviction removes state for idle keys automatically, preventing
+ * unbounded memory growth for one-off or inactive key IDs.
+ *
+ * This mirrors {@link DeveloperSemaphore} but keys on API key identity
+ * instead of developer identity, enabling per-key concurrency limits
+ * and observability via the admin concurrency endpoint.
+ */
+interface KeyState {
+  activeCount: number;
+  queue: QueueEntry[];
+  evictionTimer?: NodeJS.Timeout;
+}
+
+export class KeySemaphore {
+  private readonly keys = new Map<string, KeyState>();
+
+  constructor(
+    private readonly maxConcurrencyPerKey = 1,
+    private readonly ttlMs = 300_000,
+  ) {}
+
+  /**
+   * Execute `fn` while holding a concurrency slot for the given API key.
+   * The slot is automatically released when the returned promise settles.
+   */
+  async withSlot<T>(keyId: string, fn: () => Promise<T>): Promise<T> {
+    const release = await this.acquireSlot(keyId);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Returns a snapshot of active slot counts per key.
+   * Keys with zero active slots are omitted.
+   */
+  getCurrentActiveSlotCounts(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const [keyId, state] of this.keys.entries()) {
+      if (state.activeCount > 0) {
+        counts[keyId] = state.activeCount;
+      }
+    }
+    return counts;
+  }
+
+  /** Returns the total number of active slots across all keys. */
+  getTotalActiveSlotCount(): number {
+    let total = 0;
+    for (const state of this.keys.values()) {
+      total += state.activeCount;
+    }
+    return total;
+  }
+
+  /** Returns the active slot count for a specific key, or 0 if not tracked. */
+  getActiveSlotCount(keyId: string): number {
+    return this.keys.get(keyId)?.activeCount ?? 0;
+  }
+
+  /** Returns whether the key has reached its concurrency limit. */
+  isAtLimit(keyId: string): boolean {
+    const active = this.getActiveSlotCount(keyId);
+    return active >= this.maxConcurrencyPerKey;
+  }
+
+  private acquireSlot(keyId: string): Promise<() => void> {
+    const state = this.getOrCreateState(keyId);
+
+    // Preserve FIFO fairness: if there are waiting requests, new requests
+    // must join the queue behind them, even when capacity is available.
+    if (state.queue.length === 0 && state.activeCount < this.maxConcurrencyPerKey) {
+      this.clearEvictionTimer(state);
+      state.activeCount += 1;
+      return Promise.resolve(() => this.releaseSlot(keyId));
+    }
+
+    return new Promise<() => void>((resolve) => {
+      state.queue.push((release) => {
+        this.clearEvictionTimer(state);
+        resolve(release);
+      });
+    });
+  }
+
+  private releaseSlot(keyId: string): void {
+    const state = this.keys.get(keyId);
+    if (!state) {
+      return;
+    }
+
+    if (state.queue.length > 0) {
+      const next = state.queue.shift()!;
+      next(() => this.releaseSlot(keyId));
+      return;
+    }
+
+    state.activeCount -= 1;
+
+    if (state.activeCount === 0) {
+      this.scheduleEviction(keyId, state);
+    }
+  }
+
+  /** Clears all state. Primarily for testing. */
+  clear(): void {
+    for (const state of this.keys.values()) {
+      this.clearEvictionTimer(state);
+    }
+    this.keys.clear();
+  }
+
+  private getOrCreateState(keyId: string): KeyState {
+    let state = this.keys.get(keyId);
+    if (!state) {
+      state = { activeCount: 0, queue: [] };
+      this.keys.set(keyId, state);
+    }
+    return state;
+  }
+
+  private scheduleEviction(keyId: string, state: KeyState): void {
+    this.clearEvictionTimer(state);
+    state.evictionTimer = setTimeout(() => {
+      const current = this.keys.get(keyId);
+      if (current && current.activeCount === 0 && current.queue.length === 0) {
+        this.keys.delete(keyId);
+      }
+    }, this.ttlMs);
+    state.evictionTimer.unref?.();
+  }
+
+  private clearEvictionTimer(state: KeyState): void {
+    if (state.evictionTimer) {
+      clearTimeout(state.evictionTimer);
+      state.evictionTimer = undefined;
+    }
+  }
+}
+
+/**
+ * Shared singleton KeySemaphore instance used across the gateway middleware
+ * and the admin concurrency stats route. Tests should create isolated
+ * instances via the class constructor directly.
+ */
+export const sharedKeySemaphore = new KeySemaphore();


### PR DESCRIPTION
Adds admin endpoints to view live per-API-key concurrency counts:
- GET /api/admin/keys/concurrency — snapshot of all active key counts
- GET /api/admin/keys/concurrency/:keyId — detail for a specific key

Introduces KeySemaphore (src/utils/keySemaphore.ts), an in-memory per-key concurrency semaphore with FIFO fairness and TTL eviction.

The shared singleton is ready for wiring into the gateway/proxy middleware to make stats reflect live traffic.

closes #620