### PR TITLE
feat: structured access logs for apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@
 ### Fixed
 
 - Return `400 BAD_REQUEST` from `POST /api/billing/deduct` when a client provides a null or empty `developerId` instead of allowing the request to proceed into billing logic.
+
+### Changed
+
+- Structured access logs now preserve `x-correlation-id` values for API requests so downstream tracing can correlate requests across services.

--- a/src/middleware/accessLog.test.ts
+++ b/src/middleware/accessLog.test.ts
@@ -112,6 +112,49 @@ describe('createAccessLogMiddleware', () => {
     }
   });
 
+  test('uses a correlation id from request headers when present', () => {
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => logger);
+    const middleware = createAccessLogMiddleware({ random: () => 0 });
+
+    try {
+      const req = Object.assign(new EventEmitter(), {
+        method: 'GET',
+        path: '/api/apis',
+        headers: { 'x-correlation-id': 'corr-123' },
+        id: undefined,
+      }) as unknown as EventEmitter & Request & { id?: string };
+
+      const res = Object.assign(new EventEmitter(), {
+        statusCode: 200,
+        writableEnded: true,
+        setHeader: jest.fn(),
+        write: jest.fn(() => true),
+        end: jest.fn(() => true),
+      }) as unknown as EventEmitter &
+        Response & {
+          statusCode: number;
+          write: jest.Mock;
+          end: jest.Mock;
+          setHeader: jest.Mock;
+          writableEnded: boolean;
+        };
+
+      middleware(req, res, jest.fn());
+      res.end();
+      res.emit('finish');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          correlationId: 'corr-123',
+          requestId: expect.any(String),
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
   test('skips logging when sample rate is zero', () => {
     const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => logger);
     const middleware = createAccessLogMiddleware({ sampleRate: 0, random: () => 0 });

--- a/src/middleware/accessLog.ts
+++ b/src/middleware/accessLog.ts
@@ -60,6 +60,14 @@ const REDACTABLE_FIELD_LOOKUP = new Map<string, AccessLogField>(
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 
+const getHeaderValue = (headers: Request['headers'], headerName: string): string | undefined => {
+  const value = headers[headerName];
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return typeof value === 'string' ? value : undefined;
+};
+
 const byteLength = (chunk: unknown, encoding?: BufferEncoding): number => {
   if (chunk === null || chunk === undefined) {
     return 0;
@@ -122,13 +130,14 @@ export function createAccessLogMiddleware(options: AccessLogOptions = {}) {
     const requestHeaders = req.headers ?? {};
     const requestId =
       sanitizeRequestId(req.id) ??
-      getRequestId() ??
-      sanitizeRequestId(
-        Array.isArray(requestHeaders['x-request-id'])
-          ? requestHeaders['x-request-id'][0]
-          : requestHeaders['x-request-id'],
-      ) ??
+      sanitizeRequestId(getRequestId()) ??
+      sanitizeRequestId(getHeaderValue(requestHeaders, 'x-request-id')) ??
+      sanitizeRequestId(getHeaderValue(requestHeaders, 'x-correlation-id')) ??
       uuidv4();
+    const correlationId =
+      sanitizeRequestId(getHeaderValue(requestHeaders, 'x-correlation-id')) ??
+      sanitizeRequestId(getHeaderValue(requestHeaders, 'x-request-id')) ??
+      requestId;
 
     if (typeof res.setHeader === 'function') {
       res.setHeader('x-request-id', requestId);
@@ -195,7 +204,7 @@ export function createAccessLogMiddleware(options: AccessLogOptions = {}) {
       const elapsedMs = Number(process.hrtime.bigint() - startAt) / 1_000_000;
       const status = res.statusCode;
       const payload: AccessLogPayload = {
-        correlationId: requestId,
+        correlationId,
         requestId,
         method: req.method,
         path: req.path,

--- a/src/routes/apis.test.ts
+++ b/src/routes/apis.test.ts
@@ -8,7 +8,9 @@ jest.mock('better-sqlite3', () => {
 
 import express from 'express';
 import request from 'supertest';
+import { createAccessLogMiddleware } from '../middleware/accessLog.js';
 import { errorHandler } from '../middleware/errorHandler.js';
+import { logger } from '../middleware/logging.js';
 import { InMemoryApiRepository } from '../repositories/apiRepository.js';
 import type { Api, Developer } from '../db/schema.js';
 import type { DeveloperRepository } from '../repositories/developerRepository.js';
@@ -126,6 +128,29 @@ describe('createApisRouter', () => {
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].id).toBe(2);
     expect(res.body.data[0].status).toBe('draft');
+  });
+
+  it('uses the request correlation id in access logs for API routes', async () => {
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => logger);
+    const repo = new InMemoryApiRepository([], new Map());
+    const app = express();
+    app.use(createAccessLogMiddleware({ random: () => 0 }));
+    app.use('/api/apis', createApisRouter({ apiRepository: repo, developerRepository }));
+    app.use(errorHandler);
+
+    try {
+      const res = await request(app).get('/api/apis').set('x-correlation-id', 'corr-route-123');
+
+      expect(res.status).toBe(200);
+      expect(infoSpy).toHaveBeenCalled();
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          correlationId: 'corr-route-123',
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 
   it('rejects unknown status filters with 400', async () => {


### PR DESCRIPTION
## Summary
Adds structured access logging for API routes with correlation IDs so requests can be traced end-to-end across services.

## What changed
- Updated access-log middleware to preserve `x-correlation-id` values and emit them as the structured `correlationId` field.
- Added focused regression coverage for correlation-id handling in access logs and API-route logging.
- Documented the behavior change in the changelog.

## Testing
- Verified with:
  ./node_modules/.bin/jest --runInBand --config jest.config.cjs --testNamePattern='correlation id|structured JSON|redacts configured|sample rate' src/middleware/accessLog.test.ts src/routes/apis.test.ts
 
 Closes: #640