### PR TITLE
feat: add API rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Stamp `Deprecation: true` and `Sunset: 2026-12-31T00:00:00.000Z` on legacy `/v1` responses and emit a structured warning log with the request correlation ID whenever a legacy endpoint is used.
+- Added per-user and per-IP rate limiting for the public API routes under `/api/apis`, returning a standard `429 TOO_MANY_REQUESTS` envelope with `Retry-After` and request correlation details.
 
 ### Fixed
 

--- a/src/middleware/rateLimit.test.ts
+++ b/src/middleware/rateLimit.test.ts
@@ -1,0 +1,80 @@
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from './errorHandler.js';
+import { createRateLimitMiddleware } from './rateLimit.js';
+import { requireAuth, type AuthenticatedLocals } from './requireAuth.js';
+import { TEST_JWT_SECRET, signTestToken } from '../../tests/helpers/jwt.js';
+
+function buildProtectedApp() {
+  const app = express();
+  const rateLimit = createRateLimitMiddleware({
+    windowMs: 60_000,
+    maxRequests: 2,
+  });
+
+  app.get(
+    '/protected',
+    rateLimit,
+    requireAuth,
+    (_req, res: express.Response<unknown, AuthenticatedLocals>) => {
+      res.json({ ok: true, userId: res.locals.authenticatedUser?.id });
+    },
+  );
+
+  app.use(errorHandler);
+  return app;
+}
+
+describe('rateLimit middleware', () => {
+  const originalSecret = process.env.JWT_SECRET;
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret !== undefined) {
+      process.env.JWT_SECRET = originalSecret;
+    } else {
+      delete process.env.JWT_SECRET;
+    }
+  });
+
+  it('returns 429 after the per-user limit is exceeded', async () => {
+    const app = buildProtectedApp();
+
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    const response = await request(app).get('/protected').set('x-user-id', 'user-1');
+
+    expect(response.status).toBe(429);
+    expect(response.body.code).toBe('TOO_MANY_REQUESTS');
+    expect(response.headers['retry-after']).toBe('60');
+    expect(response.body.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('tracks requests separately for different users', async () => {
+    const app = buildProtectedApp();
+
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-2').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-2').expect(200);
+
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(429);
+    await request(app).get('/protected').set('x-user-id', 'user-2').expect(429);
+  });
+
+  it('uses the authenticated user id when a bearer token is present', async () => {
+    const app = buildProtectedApp();
+    const token = signTestToken({ userId: 'user-1', walletAddress: 'GDTEST123STELLAR' });
+
+    await request(app).get('/protected').set('Authorization', `Bearer ${token}`).expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+
+    const response = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(429);
+    expect(response.headers['retry-after']).toBe('60');
+  });
+});

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,97 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import { getClientIp } from '../lib/clientIp.js';
+import { logger } from '../logger.js';
+import { resolveRequestUserId } from './requireAuth.js';
+
+export interface RateLimitOptions {
+  windowMs: number;
+  maxRequests: number;
+}
+
+interface RateLimitBucket {
+  count: number;
+  resetAt: number;
+}
+
+export interface RateLimitCheckResult {
+  allowed: boolean;
+  retryAfterMs?: number;
+}
+
+export class InMemoryRateLimiter {
+  private readonly buckets = new Map<string, RateLimitBucket>();
+
+  constructor(
+    private readonly windowMs: number,
+    private readonly maxRequests: number,
+  ) {}
+
+  check(key: string, now = Date.now()): RateLimitCheckResult {
+    const bucket = this.buckets.get(key);
+
+    if (!bucket || now >= bucket.resetAt) {
+      this.buckets.set(key, {
+        count: 1,
+        resetAt: now + this.windowMs,
+      });
+      return { allowed: true };
+    }
+
+    if (bucket.count >= this.maxRequests) {
+      return {
+        allowed: false,
+        retryAfterMs: Math.max(bucket.resetAt - now, 0),
+      };
+    }
+
+    bucket.count += 1;
+    return { allowed: true };
+  }
+
+  reset(): void {
+    this.buckets.clear();
+  }
+}
+
+export function getRateLimitKey(req: Request): string {
+  const { userId } = resolveRequestUserId(req);
+  if (userId) {
+    return `user:${userId}`;
+  }
+
+  const clientIp = getClientIp(req);
+  return `ip:${clientIp}`;
+}
+
+export function createRateLimitMiddleware(
+  options: RateLimitOptions,
+  limiter = new InMemoryRateLimiter(options.windowMs, options.maxRequests),
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = getRateLimitKey(req);
+    const result = limiter.check(key);
+
+    if (!result.allowed) {
+      const retryAfterMs = result.retryAfterMs ?? options.windowMs;
+      const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+      const requestId = (req as Request & { id?: string }).id ?? 'unknown';
+
+      logger.warn('[rateLimit] request limit exceeded', {
+        requestId,
+        key,
+        retryAfterMs,
+      });
+
+      res.set('Retry-After', String(retryAfterSeconds));
+      res.status(429).json({
+        code: 'TOO_MANY_REQUESTS',
+        message: 'Too Many Requests',
+        requestId,
+        retryAfterMs,
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/routes/apis.test.ts
+++ b/src/routes/apis.test.ts
@@ -15,6 +15,7 @@ import { InMemoryApiRepository } from '../repositories/apiRepository.js';
 import type { Api, Developer } from '../db/schema.js';
 import type { DeveloperRepository } from '../repositories/developerRepository.js';
 import { createApisRouter } from './apis.js';
+import { createRateLimitMiddleware } from '../middleware/rateLimit.js';
 
 const developerProfile: Developer = {
   id: 11,
@@ -170,6 +171,43 @@ describe('createApisRouter', () => {
     expect(res.status).toBe(200);
     expect(res.body.meta).toEqual({ total: 1, limit: 1, offset: 0 });
     expect(res.body.data).toHaveLength(1);
+  });
+
+  it('returns 429 once the per-user limit for the API router is exceeded', async () => {
+    const repo = new InMemoryApiRepository(
+      [
+        {
+          id: 1,
+          name: 'Weather API',
+          description: 'Provides weather data',
+          base_url: 'https://api.weather.test',
+          logo_url: null,
+          category: 'weather',
+          status: 'active',
+          developer: {
+            name: 'Acme Corp',
+            website: 'https://acme.test',
+            description: 'Leading data provider',
+          },
+        },
+      ],
+      new Map(),
+    );
+
+    const app = express();
+    app.use('/api/apis', createApisRouter({
+      apiRepository: repo,
+      developerRepository,
+      rateLimitMiddleware: createRateLimitMiddleware({ windowMs: 60_000, maxRequests: 1 }),
+    }));
+    app.use(errorHandler);
+
+    await request(app).get('/api/apis').set('x-user-id', 'user-1').expect(200);
+    const res = await request(app).get('/api/apis').set('x-user-id', 'user-1');
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('TOO_MANY_REQUESTS');
+    expect(res.headers['retry-after']).toBe('60');
   });
 });
 

--- a/src/routes/apis.ts
+++ b/src/routes/apis.ts
@@ -15,12 +15,15 @@ import {
   type DeveloperRepository,
 } from '../repositories/developerRepository.js';
 import { apiRegistrationSchema, bulkEndpointsSchema } from '../validators/apiRegistration.js';
+import { createRateLimitMiddleware } from '../middleware/rateLimit.js';
 
 export interface ApisRouterDeps {
   apiRepository?: ApiRepository;
   developerRepository?: DeveloperRepository;
   /** Inject a custom cache instance (useful in tests). Defaults to the shared singleton. */
   cache?: ListingsCache;
+  /** Optional rate limit middleware for the public API routes. */
+  rateLimitMiddleware?: ReturnType<typeof createRateLimitMiddleware>;
 }
 
 export function createApisRouter(deps: ApisRouterDeps = {}): Router {
@@ -28,6 +31,12 @@ export function createApisRouter(deps: ApisRouterDeps = {}): Router {
   const apiRepository = deps.apiRepository ?? defaultApiRepository;
   const developerRepository = deps.developerRepository ?? defaultDeveloperRepository;
   const cache = deps.cache ?? listingsCache;
+  const rateLimitMiddleware = deps.rateLimitMiddleware ?? createRateLimitMiddleware({
+    windowMs: 60_000,
+    maxRequests: 60,
+  });
+
+  router.use(rateLimitMiddleware);
 
   router.get('/', etagMiddleware, async (req, res, next) => {
     try {


### PR DESCRIPTION
# feat: add per-user rate limiting for public API routes

## Summary
- add per-user and per-IP rate limiting for the public /api/apis router
- return 429 responses with Retry-After metadata when the limit is exceeded
- keep the change scoped to the public API routes and reuse existing auth/request identity handling
- add focused regression tests for the middleware and router behavior

## Why
This protects the public API endpoints from excessive requests from a single user or client IP and provides clearer feedback when the limit is reached.

Closes: #642 