### PR TITLE
Add per-route request-timing histogram

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -72,6 +72,30 @@ const httpRequestDuration = new client.Histogram({
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
 });
 
+// ── HTTP request duration summary ─────────────────────────────────────────────
+//
+// Client-side computed quantiles with a `quantile` label exposing p50 / p95 / p99
+// directly in the Prometheus scrape output. Complements the histogram above:
+//   - Histogram  → server-side aggregation via histogram_quantile() in PromQL
+//   - Summary    → direct percentile labels for dashboards that want precomputed
+//                  p50/p95/p99 per (method, route, status_code, route_group)
+//
+// Security / cardinality notes:
+//   - `maxAgeSeconds` and `ageBuckets` cap memory and prevent unbounded growth
+//     of the internal quantile estimator per label combination.
+//   - Label set is identical to the histogram (method / route / status_code /
+//     route_group), which is already bounded by route-normalisation rules.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const httpRequestDurationSummary = new client.Summary({
+  name: 'http_request_duration_summary_seconds',
+  help: 'Duration of HTTP requests in seconds with precomputed p50 / p95 / p99 percentiles per route',
+  labelNames: ['method', 'route', 'status_code', 'route_group'],
+  percentiles: [0.5, 0.95, 0.99],
+  maxAgeSeconds: 5 * 60,
+  ageBuckets: 5,
+});
+
 // ── HTTP request counter ──────────────────────────────────────────────────────
 
 const httpRequestsTotal = new client.Counter({
@@ -81,6 +105,7 @@ const httpRequestsTotal = new client.Counter({
 });
 
 register.registerMetric(httpRequestDuration);
+register.registerMetric(httpRequestDurationSummary);
 register.registerMetric(httpRequestsTotal);
 
 // ── Gateway upstream profiling ─────────────────────────────────────────────
@@ -234,7 +259,8 @@ export function normalizeRouteForMetrics(
  *   - This prevents cardinality explosion from dynamic path segments, bots, or attacks
  */
 export const metricsMiddleware = (req: Request, res: Response, next: NextFunction): void => {
-  const endTimer = httpRequestDuration.startTimer();
+  const endHistogramTimer = httpRequestDuration.startTimer();
+  const endSummaryTimer = httpRequestDurationSummary.startTimer();
 
   res.on('finish', () => {
     // Normalize the route to a safe cardinality label
@@ -254,7 +280,8 @@ export const metricsMiddleware = (req: Request, res: Response, next: NextFunctio
     };
 
     httpRequestsTotal.inc(labels);
-    endTimer(labels);
+    endHistogramTimer(labels);
+    endSummaryTimer(labels);
   });
 
   next();
@@ -415,6 +442,7 @@ export function resetUpstreamMetrics(): void {
 /** Exposed for testing — reset all HTTP metrics. */
 export function resetHttpMetrics(): void {
   httpRequestDuration.reset();
+  httpRequestDurationSummary.reset();
   httpRequestsTotal.reset();
 }
 


### PR DESCRIPTION
Close: #697 
## Summary
I have successfully implemented the per-route request-duration histogram with p50/p95/p99 percentile labels exposed via /api/metrics . All changes were made to a single file:

### Changes in metrics.ts
1. New Summary metric http_request_duration_summary_seconds ( L90-L97 )

Added a Prometheus Summary metric alongside the existing Histogram, configured with:

- Percentiles : [0.5, 0.95, 0.99] → emits quantile="0.5" , quantile="0.95" , quantile="0.99" labels in the scrape output
- Labels : method , route , status_code , route_group (identical to the histogram for consistency)
- Memory capping : maxAgeSeconds: 300 (5 min) + ageBuckets: 5 to prevent unbounded growth of the internal quantile estimator per label combination
- Registered with the global Registry at L108
Example output from /api/metrics :

2. Updated metricsMiddleware ( L261-L288 )

The middleware now starts two timers ( endHistogramTimer + endSummaryTimer ) on every request, and records both on the finish event using the exact same label set. This ensures:

- Histogram buckets are still populated (for histogram_quantile() in PromQL)
- Summary quantiles are populated (for direct p50/p95/p99 label reads)
3. Updated resetHttpMetrics ( L442-L447 )

The reset function now also calls httpRequestDurationSummary.reset() , ensuring test isolation is maintained for the new metric. resetAllMetrics() automatically inherits this fix since it delegates to resetHttpMetrics() .

### Design rationale (why Summary + Histogram together)
Approach Use case Histogram http_request_duration_seconds Server-side aggregation via PromQL histogram_quantile() across pods/time ranges Summary http_request_duration_summary_seconds ✨ new Direct p50/p95/p99 labels per-route in the scrape output, without requiring PromQL computation

Both metrics share the same cardinality-bounded label set ( method / route / status_code / route_group ), which is already protected by the existing normalizeRouteForMetrics() sanitizer — UUIDs, numeric IDs, and pathological paths are all collapsed before reaching either metric.

### Security notes
- Cardinality protection : Labels are derived from the parameterised route template ( req.route.path ) or normalised fallback — never from raw URL segments. The _unknown sentinel caps pathologically segmented routes.
- Memory bounds : Summary uses maxAgeSeconds=300 + ageBuckets=5 to ensure the sliding-window quantile estimator doesn't grow indefinitely for stale label combinations.
- No PII leakage : Routes are normalised through exactly the same normalizeRouteForMetrics() pipeline used for the existing histogram/counter, so user IDs, API keys, UUIDs and numeric IDs are replaced with :id / :uuid placeholders before being committed to any label.
### Verification
- GetDiagnostics reports zero TypeScript errors across both metrics.ts and app.ts .
- The existing /api/metrics endpoint at app.ts L299 automatically exposes the new Summary time series alongside all existing metrics with no wiring changes required.