### PR TITLE
feat: add per-route request body size caps

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -28,6 +28,7 @@ module.exports = {
       },
     ],
   },
+  setupFiles: ["<rootDir>/jest.env-setup.cjs"],
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -49,6 +49,7 @@ import { InMemoryRestRateLimiter, createRestRateLimitMiddleware } from './middle
 import type { RestRateLimitOptions } from './middleware/restRateLimit.js';
 import { createPerDevConcurrencyMiddleware } from './middleware/perDevConcurrency.js';
 import { auditEnrichMiddleware } from './middleware/auditEnrich.js';
+import { createRouteBodyLimitMiddleware } from './middleware/routeBodyLimit.js';
 import { metricsMiddleware, metricsEndpoint } from './metrics.js';
 import { config } from './config/index.js';
 import {
@@ -220,6 +221,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     }),
   );
   const requestBodyLimit = process.env.REQUEST_BODY_LIMIT ?? '100kb';
+  app.use(createRouteBodyLimitMiddleware(config.routeBodyLimits));
   app.use(express.json({ limit: requestBodyLimit }));
   app.use(express.urlencoded({ extended: false, limit: requestBodyLimit }));
   // Attach req.auditContext (IP, UA, tenantId, correlationId, bodyHash) for all routes.

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -186,6 +186,45 @@ export const envSchema = z
 
     // Body size limits
     REQUEST_BODY_LIMIT: z.string().default('100kb'),
+    ROUTE_BODY_LIMITS: z
+      .string()
+      .optional()
+      .transform((val, ctx) => {
+        if (!val || val.trim().length === 0) {
+          return [];
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(val);
+        } catch (error) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `ROUTE_BODY_LIMITS must be valid JSON: ${(error as Error).message}`,
+          });
+          return z.NEVER;
+        }
+
+        if (!Array.isArray(parsed)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'ROUTE_BODY_LIMITS must be a JSON array of route body-limit objects',
+          });
+          return z.NEVER;
+        }
+
+        return parsed as Array<unknown>;
+      })
+      .pipe(
+        z.array(
+          z.object({
+            method: z.string().min(1, 'method is required'),
+            route: z.string().min(1, 'route is required').startsWith('/', 'route must start with "/"'),
+            limit: z.string().min(1, 'limit is required'),
+          }),
+        ),
+      )
+      .default([]),
     GATEWAY_BODY_LIMIT: z.string().default('1mb'),
 
     // Security

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -213,6 +213,7 @@ export const config = {
     maxPerDeveloper: env.BILLING_MAX_CONCURRENCY_PER_DEV,
     semaphoreTtlMs: env.BILLING_SEMAPHORE_TTL_MS,
   },
+  routeBodyLimits: env.ROUTE_BODY_LIMITS,
   idempotency: {
     retentionWindowSeconds: env.IDEMPOTENCY_RETENTION_WINDOW_SECONDS,
     sweeperIntervalMs: env.IDEMPOTENCY_SWEEPER_INTERVAL_MS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { errorHandler } from "./middleware/errorHandler.js";
 import { createGatewayIpAllowlist } from "./middleware/ipAllowlist.js";
 import { createAccessLogMiddleware } from "./middleware/accessLog.js";
 import { requestIdMiddleware, responseEnrichMiddleware } from "./middleware/requestId.js";
+import { createRouteBodyLimitMiddleware } from "./middleware/routeBodyLimit.js";
 import { metricsEndpoint } from "./metrics.js";
 import {
   awaitWebhookDispatcherIdle,
@@ -84,6 +85,8 @@ initSloRecorder({
   observationWindowMs: config.sloAlert.observationWindowMs,
 });
 app.use(sloRecorderMiddleware);
+
+app.use(createRouteBodyLimitMiddleware(config.routeBodyLimits));
 
 // Standard JSON middleware for non-webhook routes
 app.use((req, res, next) => {

--- a/src/middleware/routeBodyLimit.test.ts
+++ b/src/middleware/routeBodyLimit.test.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from './errorHandler.js';
+import { createRouteBodyLimitMiddleware } from './routeBodyLimit.js';
+
+describe('createRouteBodyLimitMiddleware', () => {
+  test('returns 413 for oversized bodies on a configured route', async () => {
+    const app = express();
+    app.use(
+      createRouteBodyLimitMiddleware([
+        { method: 'POST', route: '/checkout', limit: '10b' },
+      ]),
+    );
+    app.use(express.json());
+    app.post('/checkout', (_req, res) => {
+      res.json({ ok: true });
+    });
+    app.use(errorHandler);
+
+    const largeBody = { data: 'x'.repeat(64) };
+    const res = await request(app).post('/checkout').send(largeBody);
+
+    expect(res.status).toBe(413);
+    expect(res.body).toMatchObject({
+      code: 'REQUEST_BODY_TOO_LARGE',
+      message: 'Request body too large',
+    });
+  });
+
+  test('allows bodies that stay within the configured route limit', async () => {
+    const app = express();
+    app.use(
+      createRouteBodyLimitMiddleware([
+        { method: 'POST', route: '/checkout', limit: '100b' },
+      ]),
+    );
+    app.use(express.json());
+    app.post('/checkout', (_req, res) => {
+      res.status(201).json({ ok: true });
+    });
+    app.use(errorHandler);
+
+    const smallBody = { data: 'x'.repeat(20) };
+    const res = await request(app).post('/checkout').send(smallBody);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/src/middleware/routeBodyLimit.ts
+++ b/src/middleware/routeBodyLimit.ts
@@ -1,0 +1,85 @@
+import express, { type NextFunction, type Request, type RequestHandler, type Response } from 'express';
+
+export interface RouteBodyLimitRule {
+  method: string;
+  route: string;
+  limit: string;
+}
+
+function normalizeRoute(route: string): string {
+  if (!route || route === '/') {
+    return '/';
+  }
+
+  return route.startsWith('/') ? route : `/${route}`;
+}
+
+function isRouteMatch(pathname: string, pattern: string): boolean {
+  const normalizedPath = normalizeRoute(pathname);
+  const normalizedPattern = normalizeRoute(pattern);
+
+  const pathSegments = normalizedPath.split('/').filter(Boolean);
+  const patternSegments = normalizedPattern.split('/').filter(Boolean);
+
+  if (patternSegments.length === 0) {
+    return true;
+  }
+
+  if (pathSegments.length < patternSegments.length) {
+    return false;
+  }
+
+  for (let index = 0; index < patternSegments.length; index += 1) {
+    const patternSegment = patternSegments[index];
+    const pathSegment = pathSegments[index];
+
+    if (patternSegment === '*') {
+      return true;
+    }
+
+    if (patternSegment.startsWith(':')) {
+      continue;
+    }
+
+    if (patternSegment !== pathSegment) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isMethodMatch(requestMethod: string, ruleMethod: string): boolean {
+  return requestMethod.toUpperCase() === ruleMethod.toUpperCase();
+}
+
+export function createRouteBodyLimitMiddleware(rules: RouteBodyLimitRule[] = []): RequestHandler {
+  const normalizedRules = rules.map((rule) => ({
+    method: rule.method.toUpperCase(),
+    route: normalizeRoute(rule.route),
+    limit: rule.limit,
+  }));
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const matchingRule = normalizedRules.find((rule) =>
+      isMethodMatch(req.method, rule.method) && isRouteMatch(req.path, rule.route),
+    );
+
+    if (!matchingRule) {
+      next();
+      return;
+    }
+
+    const jsonParser = express.json({ limit: matchingRule.limit });
+    const urlEncodedParser = express.urlencoded({ extended: false, limit: matchingRule.limit });
+
+    jsonParser(req, res, (jsonError) => {
+      if (jsonError) {
+        next(jsonError);
+        return;
+      }
+
+      urlEncodedParser(req, res, next);
+    });
+  };
+}


### PR DESCRIPTION
# Add per-route request-body size cap policy
This PR adds a per-route request-body size cap policy so specific routes can enforce tighter body-size limits than the global default.

### What changed
- Added route-aware body limit middleware that matches requests by method and route pattern.
- Wired the middleware into the app before the existing body parsers.
- Added environment-based configuration for route-specific limits via `ROUTE_BODY_LIMITS`.
- Added regression tests covering oversized and within-limit requests on a configured route.

### Why
This allows the API to reject overly large request bodies on selected endpoints with consistent `413 Payload Too Large` behavior, while preserving the existing global handling.

### Validation
- Added targeted middleware tests for oversized and allowed request bodies.
- Verified locally with Jest for the new middleware test suite.

Closes: #716 