### PR TITLE
feat: add per-route request body size caps

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -49,6 +49,7 @@ import { InMemoryRestRateLimiter, createRestRateLimitMiddleware } from './middle
 import type { RestRateLimitOptions } from './middleware/restRateLimit.js';
 import { createPerDevConcurrencyMiddleware } from './middleware/perDevConcurrency.js';
 import { auditEnrichMiddleware } from './middleware/auditEnrich.js';
+import { createRouteBodyLimitMiddleware } from './middleware/routeBodyLimit.js';
 import { metricsMiddleware, metricsEndpoint } from './metrics.js';
 import { config } from './config/index.js';
 import {
@@ -220,6 +221,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     }),
   );
   const requestBodyLimit = process.env.REQUEST_BODY_LIMIT ?? '100kb';
+  app.use(createRouteBodyLimitMiddleware(config.routeBodyLimits));
   app.use(express.json({ limit: requestBodyLimit }));
   app.use(express.urlencoded({ extended: false, limit: requestBodyLimit }));
   // Attach req.auditContext (IP, UA, tenantId, correlationId, bodyHash) for all routes.

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -187,6 +187,45 @@ export const envSchema = z
     // Body size limits
     REQUEST_BODY_LIMIT: z.string().default('100kb'),
     GATEWAY_BODY_LIMIT: z.string().default('1mb'),
+    ROUTE_BODY_LIMITS: z
+      .string()
+      .optional()
+      .transform((value, ctx) => {
+        if (!value || value.trim().length === 0) {
+          return [];
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(value);
+        } catch (error) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `ROUTE_BODY_LIMITS must be valid JSON: ${(error as Error).message}`,
+          });
+          return z.NEVER;
+        }
+
+        if (!Array.isArray(parsed)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'ROUTE_BODY_LIMITS must be a JSON array of route body-limit objects',
+          });
+          return z.NEVER;
+        }
+
+        return parsed.filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object');
+      })
+      .pipe(
+        z.array(
+          z.object({
+            method: z.string().min(1),
+            route: z.string().min(1),
+            limit: z.string().min(1),
+          }),
+        ),
+      )
+      .default([]),
 
     // Security
     BCRYPT_COST_FACTOR: z.coerce.number().int().min(10).max(31).default(12),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -221,6 +221,7 @@ export const config = {
     warmupTimeoutMs: env.LISTINGS_CACHE_WARMUP_TIMEOUT_MS,
   },
   bulkEndpointLimit: env.BULK_ENDPOINT_LIMIT,
+  routeBodyLimits: env.ROUTE_BODY_LIMITS,
 
   slowQueryAlerter: {
     webhookUrl: env.SLOW_QUERY_ALERT_WEBHOOK_URL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { errorHandler } from "./middleware/errorHandler.js";
 import { createGatewayIpAllowlist } from "./middleware/ipAllowlist.js";
 import { createAccessLogMiddleware } from "./middleware/accessLog.js";
 import { requestIdMiddleware, responseEnrichMiddleware } from "./middleware/requestId.js";
+import { createRouteBodyLimitMiddleware } from "./middleware/routeBodyLimit.js";
 import { metricsEndpoint } from "./metrics.js";
 import {
   awaitWebhookDispatcherIdle,
@@ -84,6 +85,8 @@ initSloRecorder({
   observationWindowMs: config.sloAlert.observationWindowMs,
 });
 app.use(sloRecorderMiddleware);
+
+app.use(createRouteBodyLimitMiddleware(config.routeBodyLimits));
 
 // Standard JSON middleware for non-webhook routes
 app.use((req, res, next) => {

--- a/src/middleware/routeBodyLimit.test.ts
+++ b/src/middleware/routeBodyLimit.test.ts
@@ -1,0 +1,59 @@
+import express from 'express';
+import request from 'supertest';
+import { createRouteBodyLimitMiddleware } from './routeBodyLimit.js';
+
+describe('createRouteBodyLimitMiddleware', () => {
+  const createTestApp = (limit: string) => {
+    const app = express();
+
+    app.use(createRouteBodyLimitMiddleware([{ method: 'POST', route: '/upload', limit }]));
+    app.use(express.json());
+    app.post('/upload', (_req, res) => {
+      res.status(201).json({ ok: true });
+    });
+    app.use(
+      (
+        err: unknown,
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+      ) => {
+        const status = typeof err === 'object' && err && 'status' in err && typeof (err as { status?: number }).status === 'number'
+          ? (err as { status: number }).status
+          : 500;
+
+        res.status(status).json({
+          code: status === 413 ? 'REQUEST_BODY_TOO_LARGE' : 'INTERNAL_SERVER_ERROR',
+          message: status === 413 ? 'Request body too large' : 'Internal server error',
+        });
+      },
+    );
+
+    return app;
+  };
+
+  it('returns 413 for oversized bodies on a configured route', async () => {
+    const app = createTestApp('10kb');
+
+    const response = await request(app)
+      .post('/upload')
+      .send({ payload: 'x'.repeat(12000) });
+
+    expect(response.status).toBe(413);
+    expect(response.body).toEqual({
+      code: 'REQUEST_BODY_TOO_LARGE',
+      message: 'Request body too large',
+    });
+  });
+
+  it('allows bodies that stay within the configured route limit', async () => {
+    const app = createTestApp('20kb');
+
+    const response = await request(app)
+      .post('/upload')
+      .send({ payload: 'x'.repeat(12000) });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({ ok: true });
+  });
+});

--- a/src/middleware/routeBodyLimit.ts
+++ b/src/middleware/routeBodyLimit.ts
@@ -1,0 +1,85 @@
+import express, { type NextFunction, type Request, type RequestHandler, type Response } from 'express';
+
+export interface RouteBodyLimitRule {
+  method: string;
+  route: string;
+  limit: string;
+}
+
+function normalizeRoute(route: string): string {
+  if (!route || route === '/') {
+    return '/';
+  }
+
+  return route.startsWith('/') ? route : `/${route}`;
+}
+
+function isRouteMatch(pathname: string, pattern: string): boolean {
+  const normalizedPath = normalizeRoute(pathname);
+  const normalizedPattern = normalizeRoute(pattern);
+
+  const pathSegments = normalizedPath.split('/').filter(Boolean);
+  const patternSegments = normalizedPattern.split('/').filter(Boolean);
+
+  if (patternSegments.length === 0) {
+    return true;
+  }
+
+  if (pathSegments.length < patternSegments.length) {
+    return false;
+  }
+
+  for (let index = 0; index < patternSegments.length; index += 1) {
+    const patternSegment = patternSegments[index];
+    const pathSegment = pathSegments[index];
+
+    if (patternSegment === '*') {
+      return true;
+    }
+
+    if (patternSegment.startsWith(':')) {
+      continue;
+    }
+
+    if (patternSegment !== pathSegment) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isMethodMatch(requestMethod: string, ruleMethod: string): boolean {
+  return requestMethod.toUpperCase() === ruleMethod.toUpperCase();
+}
+
+export function createRouteBodyLimitMiddleware(rules: RouteBodyLimitRule[] = []): RequestHandler {
+  const normalizedRules = rules.map((rule) => ({
+    method: rule.method.toUpperCase(),
+    route: normalizeRoute(rule.route),
+    limit: rule.limit,
+  }));
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const matchingRule = normalizedRules.find((rule) =>
+      isMethodMatch(req.method, rule.method) && isRouteMatch(req.path, rule.route),
+    );
+
+    if (!matchingRule) {
+      next();
+      return;
+    }
+
+    const jsonParser = express.json({ limit: matchingRule.limit });
+    const urlEncodedParser = express.urlencoded({ extended: false, limit: matchingRule.limit });
+
+    jsonParser(req, res, (jsonError) => {
+      if (jsonError) {
+        next(jsonError);
+        return;
+      }
+
+      urlEncodedParser(req, res, next);
+    });
+  };
+}


### PR DESCRIPTION
# Add per-route request-body size cap policy

## Summary
This PR adds a per-route request-body size cap policy so selected routes can enforce tighter body-size limits than the global default.

## What changed
- Added route-aware body-limit middleware that matches requests by HTTP method and route pattern.
- Wired the middleware into the main Express app entrypoints before the existing JSON and URL-encoded parsers.
- Added environment-based configuration for per-route limits via `ROUTE_BODY_LIMITS`.
- Added regression tests for oversized and within-limit request bodies on a configured route.

## Why
This allows the API to return consistent `413 Payload Too Large` responses for specific routes while preserving the existing global request-body handling.

## Validation
- Added targeted Jest regression tests for oversized and allowed request bodies.
- Verified locally with:
  - `npx jest --runInBand --forceExit src/middleware/routeBodyLimit.test.ts`

Closes: #719