### PR TITLE
fix(billing): add 4 USDC buffer top-up for GrantFox FWC26

### DIFF
--- a/src/routes/admin/billing/credits/grant.test.ts
+++ b/src/routes/admin/billing/credits/grant.test.ts
@@ -54,10 +54,10 @@ describe('POST /api/admin/billing/credits/grant', () => {
       .send({ user_id: 'user_123', amount_usdc: '25.50' });
 
     expect(response.status).toBe(201);
-    expect(repository.grant).toHaveBeenCalledWith('user_123', '25.50');
+    expect(repository.grant).toHaveBeenCalledWith('user_123', '29.50');
     expect(response.body.data).toMatchObject({
       user_id: 'user_123',
-      amount_usdc: '25.50',
+      amount_usdc: '29.50',
       balance_usdc: '25.50',
       campaign: 'GrantFox FWC26',
     });

--- a/src/routes/admin/billing/credits/grant.ts
+++ b/src/routes/admin/billing/credits/grant.ts
@@ -38,12 +38,17 @@ export function createAdminCreditGrantsRouter(
   router.post('/grant', validate({ body: grantBodySchema }), async (req, res, next) => {
     try {
       const { user_id: userId, amount_usdc: amountUsdc } = req.body as GrantBody;
-      const credits = await creditsRepository.grant(userId, amountUsdc);
+
+      // Add a 4 USDC small buffer top-up as requested by the FWC26 campaign
+      const [whole, fraction = ''] = amountUsdc.split('.');
+      const amountWithBuffer = `${BigInt(whole) + 4n}${fraction ? `.${fraction}` : ''}`;
+
+      const credits = await creditsRepository.grant(userId, amountWithBuffer);
 
       logger.audit('GRANT_PREPAID_CREDITS', res.locals.adminActor, {
         campaign: GRANTFOX_FWC26_CAMPAIGN,
         userId,
-        amountUsdc,
+        amountUsdc: amountWithBuffer,
         balanceUsdc: credits.balance_usdc,
         clientIp: getClientIp(req, TRUST_PROXY),
         userAgent: req.get('User-Agent'),
@@ -53,7 +58,7 @@ export function createAdminCreditGrantsRouter(
       res.status(201).json({
         data: {
           user_id: credits.user_id,
-          amount_usdc: amountUsdc,
+          amount_usdc: amountWithBuffer,
           balance_usdc: credits.balance_usdc,
           campaign: GRANTFOX_FWC26_CAMPAIGN,
           updated_at: credits.updated_at.toISOString(),


### PR DESCRIPTION
Closes #727 
What changed?
This PR addresses the "Small buffer top-up polish task" for the GrantFox FWC26 campaign (Stellar Wave).

Added Buffer: Appends a +4 (USDC) top-up buffer to the requested grant amount in src/routes/admin/billing/credits/grant.ts for the POST /api/admin/billing/credits/grant endpoint.
Audit Trails: Ensures the amountWithBuffer is accurately tracked within the logger.audit middleware and appropriately returned in the HTTP 201 JSON response body.
Tests: Adjusted the grant.test.ts suite to reflect the new +4 buffer addition (e.g., verifying that a base requested grant of 25.50 triggers a 29.50 transaction via the repository correctly).
Checklist
 Implemented the +4 buffer top-up on FWC26 credit grants.
 Passed the augmented value safely down to the creditsRepository.
 Updated unit tests to prevent regression.