### PR TITLE
fix(deposit): validate source_account with StrKey; restore envelope import

### DIFF
--- a/src/controllers/depositController.test.ts
+++ b/src/controllers/depositController.test.ts
@@ -469,29 +469,5 @@ describe('DepositController', () => {
       );
     });
 
-    it('should validate Stellar public key format correctly', async () => {
-      // Test valid keys — exactly G + 55 uppercase alphanumeric = 56 chars
-      const validKeys = [
-        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-        'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
-      ];
-
-      validKeys.forEach((key) => {
-        expect(depositController['isValidStellarPublicKey'](key)).toBe(true);
-      });
-
-      // Test invalid keys
-      const invalidKeys = [
-        'invalid',
-        'XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', // Wrong prefix
-        'GAAAAAAAAA', // Too short
-        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', // Too long (58)
-        'gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', // Lowercase
-      ];
-
-      invalidKeys.forEach((key) => {
-        expect(depositController['isValidStellarPublicKey'](key)).toBe(false);
-      });
-    });
   });
 });

--- a/src/controllers/depositController.ts
+++ b/src/controllers/depositController.ts
@@ -1,6 +1,8 @@
 import type { Request, Response } from 'express';
 import type { AuthenticatedLocals } from '../middleware/requireAuth.js';
 import { AmountValidator } from '../validators/amountValidator.js';
+import { isValidStellarPublicKey } from '../validators/stellarAddress.js';
+import { successEnvelope, errorEnvelope, getRequestId } from '../lib/envelope.js';
 import {
   TransactionBuilderService,
   type StellarNetwork,
@@ -137,7 +139,7 @@ export class DepositController {
 
       // Step 5: Validate source account if provided
       if (requestBody.source_account) {
-        if (!this.isValidStellarPublicKey(requestBody.source_account)) {
+        if (!isValidStellarPublicKey(requestBody.source_account)) {
           res.status(400).json(
             errorEnvelope(
               'INVALID_SOURCE_ACCOUNT',
@@ -193,11 +195,6 @@ export class DepositController {
     } catch (error) {
       this.handleError(error, res, getRequestId(req));
     }
-  }
-
-  private isValidStellarPublicKey(key: string): boolean {
-    // Stellar public keys start with 'G' and are 56 characters long
-    return /^G[A-Z0-9]{55}$/.test(key);
   }
 
   private handleError(error: unknown, res: Response, requestId: string): void {

--- a/src/validators/stellarAddress.test.ts
+++ b/src/validators/stellarAddress.test.ts
@@ -1,0 +1,47 @@
+import { isValidStellarPublicKey } from './stellarAddress.js';
+
+describe('isValidStellarPublicKey', () => {
+  it('accepts a checksum-valid ed25519 public key', () => {
+    expect(
+      isValidStellarPublicKey('GCLH2SNM5MTV4TGNNOADLYOZJYIFBXTIDVSNW4XP3LEI2UQV2MZ46OD7')
+    ).toBe(true);
+  });
+
+  it('rejects a key with the wrong prefix', () => {
+    expect(
+      isValidStellarPublicKey('XCLH2SNM5MTV4TGNNOADLYOZJYIFBXTIDVSNW4XP3LEI2UQV2MZ46OD7')
+    ).toBe(false);
+  });
+
+  it('rejects keys that are too short or too long', () => {
+    expect(isValidStellarPublicKey('GAAAAAAAAA')).toBe(false);
+    expect(
+      isValidStellarPublicKey('GCLH2SNM5MTV4TGNNOADLYOZJYIFBXTIDVSNW4XP3LEI2UQV2MZ46OD7AA')
+    ).toBe(false);
+  });
+
+  it('rejects a lowercased key', () => {
+    expect(
+      isValidStellarPublicKey('gclh2snm5mtv4tgnnoadlyozjyifbxtidvsnw4xp3lei2uqv2mz46od7')
+    ).toBe(false);
+  });
+
+  it('rejects a key using characters outside the strkey base32 alphabet', () => {
+    // 0, 1, 8, 9 are not part of the RFC 4648 base32 alphabet strkey uses.
+    expect(
+      isValidStellarPublicKey('G01890189018901890189018901890189018901890189018901890')
+    ).toBe(false);
+  });
+
+  it('rejects a well-formed key with a bad checksum', () => {
+    // Valid alphabet and length, wrong final checksum bytes.
+    expect(
+      isValidStellarPublicKey('GCLH2SNM5MTV4TGNNOADLYOZJYIFBXTIDVSNW4XP3LEI2UQV2MZ46AAA')
+    ).toBe(false);
+  });
+
+  it('rejects empty and obviously non-key strings', () => {
+    expect(isValidStellarPublicKey('')).toBe(false);
+    expect(isValidStellarPublicKey('invalid')).toBe(false);
+  });
+});

--- a/src/validators/stellarAddress.ts
+++ b/src/validators/stellarAddress.ts
@@ -1,0 +1,12 @@
+import { StrKey } from '@stellar/stellar-sdk';
+
+/**
+ * True if `key` is a checksum-valid Stellar ed25519 public key (starts with G).
+ *
+ * This performs full strkey validation (base32 alphabet plus CRC16 checksum),
+ * not just a G-prefix/length shape check, so malformed keys are rejected at the
+ * boundary instead of reaching the transaction builder.
+ */
+export function isValidStellarPublicKey(key: string): boolean {
+  return StrKey.isValidEd25519PublicKey(key);
+}


### PR DESCRIPTION
## What
Hardens Stellar public-key validation on the deposit prepare path and fixes a broken import in the deposit controller.

`prepareDeposit` validated `source_account` with a shape-only regex `/^G[A-Z0-9]{55}$/`. That uses the wrong base32 alphabet (strkey is `A-Z2-7`, so `0/1/8/9` should be rejected) and does no CRC16 checksum check, so a malformed but G-shaped key passed validation and reached the transaction builder, surfacing as a 500 on a money path instead of a clean 400.

- Adds `src/validators/stellarAddress.ts` (`isValidStellarPublicKey`) backed by the SDK's `StrKey.isValidEd25519PublicKey`, with a full unit suite. This follows the existing `src/validators/` convention and is reusable elsewhere.
- `depositController` now uses it for `source_account` (removing the inline regex; the redundant inline key-format unit test moves into the validator suite).

## Also fixed
`depositController.ts` referenced `getRequestId`, `errorEnvelope`, and `successEnvelope` but never imported them (`vaultController.ts` imports them from `../lib/envelope.js`). The file did not compile as-is; the missing import is restored.

## Testing
- New `stellarAddress.test.ts`: 7/7 pass, covering a checksum-valid key, wrong prefix, wrong length, lowercase, out-of-alphabet chars (`0/1/8/9`), and a bad-checksum key.
- `tsc --noEmit` is clean on the changed files.

Scope note: `depositController.test.ts` has pre-existing failures unrelated to this change (its integration assertions expect an older flat error shape, e.g. `{ error, code }`, rather than the current `errorEnvelope` structure `{ success, error: { code, message }, requestId, timestamp }`). Those predate this PR and were already red on main since the controller did not import its envelope helpers. Rewriting that suite to the current envelope shape is a separate change; this PR keeps the validation logic covered via the new validator suite.

Closes #777
