### PR TITLE
feat(apis): persist audit rows for state-changing /api/apis calls

### DIFF
--- a/src/routes/apis.audit.test.ts
+++ b/src/routes/apis.audit.test.ts
@@ -1,0 +1,120 @@
+jest.mock('better-sqlite3', () => {
+  return class MockDatabase {
+    prepare() { return { get: () => null }; }
+    exec() { return undefined; }
+    close() { return undefined; }
+  };
+});
+
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { InMemoryApiRepository } from '../repositories/apiRepository.js';
+import type { Api, Developer } from '../db/schema.js';
+import type { DeveloperRepository } from '../repositories/developerRepository.js';
+import type { AuditService } from '../services/auditService.js';
+import { createApisRouter } from './apis.js';
+
+const developerProfile: Developer = {
+  id: 11,
+  user_id: 'dev-1',
+  name: 'Test Developer',
+  website: null,
+  description: null,
+  category: null,
+  plan_overrides: null,
+  created_at: new Date(1000),
+  updated_at: new Date(1000),
+};
+
+const developerRepository: DeveloperRepository = {
+  async findByUserId(userId: string) {
+    return userId === 'dev-1' ? developerProfile : undefined;
+  },
+  async getOrCreateByUserId() { return developerProfile; },
+  async upsertProfile() { return developerProfile; },
+};
+
+function buildApp(auditService: AuditService, repo = new InMemoryApiRepository([], new Map())) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/apis', createApisRouter({ apiRepository: repo, developerRepository, auditService }));
+  app.use(errorHandler);
+  return app;
+}
+
+const createBody = {
+  name: 'Audit API',
+  base_url: 'https://audit.example.com',
+  category: 'search',
+  endpoints: [{ path: '/x', method: 'GET', price_per_call_usdc: '0.01' }],
+};
+
+describe('/api/apis audit logging (issue #777)', () => {
+  it('records an API_CREATE audit row on successful creation', async () => {
+    const record = jest.fn().mockResolvedValue(undefined);
+    const app = buildApp({ record });
+
+    const res = await request(app).post('/api/apis').set('x-user-id', 'dev-1').send(createBody);
+
+    expect(res.status).toBe(201);
+    expect(record).toHaveBeenCalledTimes(1);
+    const entry = record.mock.calls[0][0];
+    expect(entry).toEqual(expect.objectContaining({ event: 'API_CREATE', actor: 'dev-1' }));
+    expect(entry.details).toEqual(
+      expect.objectContaining({
+        before: null,
+        after: expect.objectContaining({ name: 'Audit API', category: 'search', endpointCount: 1 }),
+      }),
+    );
+  });
+
+  it('records an API_ENDPOINTS_BULK_CREATE audit row on bulk endpoint creation', async () => {
+    const ownedApi: Api = {
+      id: 101,
+      developer_id: 11,
+      name: 'Search API',
+      description: null,
+      base_url: 'https://search.example.com',
+      logo_url: null,
+      category: 'search',
+      status: 'active',
+      created_at: new Date(1000),
+      updated_at: new Date(1000),
+      deleted_at: null,
+    };
+    const repo = new InMemoryApiRepository([ownedApi], new Map([[101, []]]));
+    const record = jest.fn().mockResolvedValue(undefined);
+    const app = buildApp({ record }, repo);
+
+    const res = await request(app)
+      .post('/api/apis/101/endpoints/bulk')
+      .set('x-user-id', 'dev-1')
+      .send({ endpoints: [{ path: '/new', method: 'POST', price_per_call_usdc: '0.02' }] });
+
+    expect(res.status).toBe(201);
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'API_ENDPOINTS_BULK_CREATE', actor: 'dev-1' }),
+    );
+  });
+
+  it('does not fail the request when audit persistence throws', async () => {
+    const record = jest.fn().mockRejectedValue(new Error('db down'));
+    const app = buildApp({ record });
+
+    const res = await request(app).post('/api/apis').set('x-user-id', 'dev-1').send(createBody);
+
+    expect(res.status).toBe(201);
+    expect(record).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write an audit row when creation is rejected (unauthenticated)', async () => {
+    const record = jest.fn().mockResolvedValue(undefined);
+    const app = buildApp({ record });
+
+    const res = await request(app).post('/api/apis').send(createBody);
+
+    expect(res.status).toBe(401);
+    expect(record).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/apis.ts
+++ b/src/routes/apis.ts
@@ -16,6 +16,10 @@ import {
 } from '../repositories/developerRepository.js';
 import { apiRegistrationSchema, bulkEndpointsSchema } from '../validators/apiRegistration.js';
 import { createRateLimitMiddleware } from '../middleware/rateLimit.js';
+import { defaultAuditService, type AuditService } from '../services/auditService.js';
+import type { AuditContext } from '../middleware/auditEnrich.js';
+import { logger } from '../middleware/logging.js';
+import type { Request } from 'express';
 
 export interface ApisRouterDeps {
   apiRepository?: ApiRepository;
@@ -24,13 +28,45 @@ export interface ApisRouterDeps {
   cache?: ListingsCache;
   /** Optional rate limit middleware for the public API routes. */
   rateLimitMiddleware?: ReturnType<typeof createRateLimitMiddleware>;
+  /** Persists audit rows for state-changing calls. Defaults to the pg-backed service. */
+  auditService?: AuditService;
 }
 
 export function createApisRouter(deps: ApisRouterDeps = {}): Router {
   const router = Router();
   const apiRepository = deps.apiRepository ?? defaultApiRepository;
   const developerRepository = deps.developerRepository ?? defaultDeveloperRepository;
+  const auditService = deps.auditService ?? defaultAuditService;
   const cache = deps.cache ?? listingsCache;
+
+  // Persist an audit row for a state-changing call. Best-effort: a failed audit
+  // write is logged but never fails the underlying request, which has already
+  // committed by the time this runs.
+  async function recordApiAudit(
+    req: Request,
+    event: string,
+    actor: string,
+    details: Record<string, unknown>,
+  ): Promise<void> {
+    const ctx = (req as Request & { auditContext?: AuditContext }).auditContext;
+    try {
+      await auditService.record({
+        event,
+        actor,
+        tenantId: ctx?.tenantId ?? null,
+        clientIp: ctx?.clientIp ?? null,
+        userAgent: ctx?.userAgent ?? null,
+        correlationId: ctx?.correlationId ?? null,
+        bodyHash: ctx?.bodyHash ?? null,
+        details,
+      });
+    } catch (error) {
+      logger.error(
+        { event, actor, correlationId: ctx?.correlationId, err: error },
+        'Failed to persist audit log for API mutation',
+      );
+    }
+  }
   const rateLimitMiddleware = deps.rateLimitMiddleware ?? createRateLimitMiddleware({
     windowMs: 60_000,
     maxRequests: 60,
@@ -137,6 +173,18 @@ export function createApisRouter(deps: ApisRouterDeps = {}): Router {
           })),
         });
 
+        await recordApiAudit(req, 'API_CREATE', user.id, {
+          apiId: api.id,
+          before: null,
+          after: {
+            name: payload.name,
+            base_url: payload.base_url,
+            category: payload.category,
+            status: 'active',
+            endpointCount: payload.endpoints.length,
+          },
+        });
+
         res.status(201).json(api);
       } catch (error) {
         next(error);
@@ -190,6 +238,18 @@ export function createApisRouter(deps: ApisRouterDeps = {}): Router {
             description: ep.description ?? null,
           })),
         );
+
+        await recordApiAudit(req, 'API_ENDPOINTS_BULK_CREATE', user.id, {
+          apiId,
+          before: null,
+          after: {
+            addedEndpointCount: payload.endpoints.length,
+            addedEndpoints: payload.endpoints.map((ep) => ({
+              path: ep.path,
+              method: ep.method,
+            })),
+          },
+        });
 
         res.status(201).json({ endpoints });
       } catch (error) {

--- a/src/services/auditService.test.ts
+++ b/src/services/auditService.test.ts
@@ -1,0 +1,48 @@
+import { writeQuery } from '../db.js';
+
+jest.mock('../db.js', () => ({ writeQuery: jest.fn() }));
+const writeQueryMock = writeQuery as jest.MockedFunction<typeof writeQuery>;
+
+import { defaultAuditService } from './auditService.js';
+
+describe('auditService.record', () => {
+  beforeEach(() => {
+    writeQueryMock.mockReset();
+    writeQueryMock.mockResolvedValue({ rows: [] });
+  });
+
+  it('inserts one row into audit_logs with a generated id and all fields', async () => {
+    await defaultAuditService.record({
+      event: 'API_CREATE',
+      actor: 'dev-1',
+      tenantId: 'dev-1',
+      clientIp: '1.2.3.4',
+      userAgent: 'jest-UA',
+      correlationId: 'req-1',
+      bodyHash: 'deadbeef',
+      details: { before: null, after: { name: 'X' } },
+    });
+
+    expect(writeQueryMock).toHaveBeenCalledTimes(1);
+    const [sql, params] = writeQueryMock.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO audit_logs');
+    expect(params).toHaveLength(9);
+    expect(typeof params[0]).toBe('string');
+    expect(params.slice(1)).toEqual([
+      'API_CREATE',
+      'dev-1',
+      'dev-1',
+      '1.2.3.4',
+      'jest-UA',
+      'req-1',
+      'deadbeef',
+      JSON.stringify({ before: null, after: { name: 'X' } }),
+    ]);
+  });
+
+  it('nulls optional forensic fields and details when omitted', async () => {
+    await defaultAuditService.record({ event: 'E', actor: 'a' });
+    const [, params] = writeQueryMock.mock.calls[0] as [string, unknown[]];
+    expect(params.slice(3)).toEqual([null, null, null, null, null, null]);
+  });
+});

--- a/src/services/auditService.ts
+++ b/src/services/auditService.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from 'node:crypto';
+import { writeQuery } from '../db.js';
+
+/**
+ * A single audit entry to persist. `event` is the action taken, `actor` is the
+ * authenticated caller, and `details` carries the state change (before/after)
+ * plus any extra context. Forensic fields (tenant, ip, user-agent, correlation
+ * id, body hash) come from the request's `auditContext` when available.
+ */
+export interface AuditRecordInput {
+  event: string;
+  actor: string;
+  tenantId?: string | null;
+  clientIp?: string | null;
+  userAgent?: string | null;
+  correlationId?: string | null;
+  bodyHash?: string | null;
+  details?: Record<string, unknown> | null;
+}
+
+export interface AuditService {
+  record(input: AuditRecordInput): Promise<void>;
+}
+
+class PgAuditService implements AuditService {
+  async record(input: AuditRecordInput): Promise<void> {
+    await writeQuery(
+      `INSERT INTO audit_logs (
+         id, event, actor, tenant_id, client_ip, user_agent,
+         correlation_id, body_hash, details
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [
+        randomUUID(),
+        input.event,
+        input.actor,
+        input.tenantId ?? null,
+        input.clientIp ?? null,
+        input.userAgent ?? null,
+        input.correlationId ?? null,
+        input.bodyHash ?? null,
+        input.details ? JSON.stringify(input.details) : null,
+      ],
+    );
+  }
+}
+
+export const defaultAuditService: AuditService = new PgAuditService();


### PR DESCRIPTION
## What
Persists an audit trail for state-changing calls on `/api/apis`, as the issue asks (actor, action, before/after).

- New `src/services/auditService.ts` (`PgAuditService`) writes an `audit_logs` row: `event` (action), `actor` (authenticated caller), and a `details` blob holding `before`/`after`, plus the forensic context already computed by `auditEnrichMiddleware` (tenant, client ip, user-agent, correlation id, body hash). It reuses the existing `audit_logs` table and `writeQuery`, and is injectable via `ApisRouterDeps` for testing.
- Wired into the two `/api/apis` mutations in `src/routes/apis.ts`:
  - `API_CREATE` on `POST /api/apis`
  - `API_ENDPOINTS_BULK_CREATE` on `POST /api/apis/:id/endpoints/bulk`
- Audit writes are **best-effort**: a failure is logged (with the correlation id, via the structured logger) but never fails the underlying request, which has already committed by then.

## Testing
- `auditService.test.ts`: asserts the exact `INSERT INTO audit_logs` shape (generated id + all fields, and that omitted optional fields/details are nulled).
- `apis.audit.test.ts`: asserts an audit row is recorded on create and on bulk-create with the right `event`/`actor`/`details`, that a rejected (unauthenticated) request records nothing, and that a throwing audit write still returns `201`.
- All 6 new tests pass; `tsc --noEmit` and eslint are clean on the changed files. (The 4 pre-existing failures in `apis.test.ts` are GET/pagination tests unrelated to this change — they fail identically on `main`.)

Closes #777
