### PR TITLE
feat: cache warm quotas

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,8 @@ import { errorHandler } from './middleware/errorHandler.js';
 import { performHealthCheck, type HealthCheckConfig } from './services/healthCheck.js';
 import { createDependenciesRouter } from './routes/health/dependencies.js';
 import quotaRequestsRouter from './routes/quota/requests.js';
+import { envelopeValidator } from './middleware/envelopeValidator.js';
+import { successEnvelope, errorEnvelope, getRequestId } from './lib/envelope.js';
 import { parsePagination, paginatedResponse } from './lib/pagination.js';
 import { InMemoryVaultRepository, type VaultRepository } from './repositories/vaultRepository.js';
 import { DepositController } from './controllers/depositController.js';
@@ -276,7 +278,8 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
   // Per-dependency health probe — detailed status for each configured dependency
   app.use('/api/health/dependencies', createDependenciesRouter(dependencies?.healthCheckConfig));
 
-  app.get('/api/health', async (_req, res) => {
+  app.get('/api/health', async (req, res) => {
+    const requestId = getRequestId(req);
     // If no health check config provided, return simple health check
     if (!dependencies?.healthCheckConfig) {
       const data = { status: 'ok', service: 'callora-backend' };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -156,6 +156,7 @@ export const envSchema = z
     HEALTH_CHECK_DB_TIMEOUT: z.coerce.number().default(2_000),
     APIS_CACHE_TTL_MS: z.coerce.number().int().positive().optional(),
     LISTINGS_CACHE_WARMUP_TIMEOUT_MS: z.coerce.number().int().positive().default(5_000),
+    QUOTAS_CACHE_WARMUP_TIMEOUT_MS: z.coerce.number().int().positive().default(5_000),
     BULK_ENDPOINT_LIMIT: z.coerce.number().int().positive().default(100),
     APP_VERSION: z.string().default("1.0.0"),
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -221,6 +221,9 @@ export const config = {
   listingsCache: {
     warmupTimeoutMs: env.LISTINGS_CACHE_WARMUP_TIMEOUT_MS,
   },
+  quotasCache: {
+    warmupTimeoutMs: env.QUOTAS_CACHE_WARMUP_TIMEOUT_MS,
+  },
   bulkEndpointLimit: env.BULK_ENDPOINT_LIMIT,
 
   slowQueryAlerter: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -360,6 +360,10 @@ if (isDirectExecution) {
         { timeoutMs: config.listingsCache.warmupTimeoutMs },
       );
 
+      // Warm the quotas cache before accepting traffic to avoid cold-cache spikes on startup.
+      const { warmupQuotasCache } = await import("./services/quotasCacheWarm.js");
+      await warmupQuotasCache({ timeoutMs: config.quotasCache.warmupTimeoutMs });
+
       revenueLedgerIndexerJob.start();
       settlementStatusSyncJob.start();
       settlementReconJob.start();

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -30,6 +30,7 @@ import { billingAccessLogMiddleware } from "../middleware/billingAccessLog.js";
 import creditsRouter from "./billing/credits.js";
 import disputesRouter from "./billing/disputes.js";
 import { createFeeAbstractionRouter } from "./billing/feeAbstraction.js";
+import bulkDeductRouter from "./billing/deduct/bulk.js";
 
 const router = Router();
 

--- a/src/routes/quota/requests.test.ts
+++ b/src/routes/quota/requests.test.ts
@@ -228,8 +228,8 @@ describe('POST /api/quota/requests', () => {
       .send({});
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_ERROR');
-    expect(Array.isArray(res.body.details)).toBe(true);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(Array.isArray(res.body.error.details)).toBe(true);
   });
 
   it('400 VALIDATION_ERROR - invalid requested_tier enum', async () => {
@@ -241,7 +241,7 @@ describe('POST /api/quota/requests', () => {
       .send({ requested_tier: 'ultra', reason: 'Need ultra tier for high traffic volume' });
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('400 VALIDATION_ERROR - reason too short (< 10 chars)', async () => {
@@ -253,7 +253,7 @@ describe('POST /api/quota/requests', () => {
       .send({ requested_tier: 'pro', reason: 'Short' });
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('400 VALIDATION_ERROR - reason too long (> 1000 chars)', async () => {
@@ -265,7 +265,7 @@ describe('POST /api/quota/requests', () => {
       .send({ requested_tier: 'pro', reason: 'x'.repeat(1001) });
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('400 VALIDATION_ERROR - missing reason entirely', async () => {
@@ -277,7 +277,7 @@ describe('POST /api/quota/requests', () => {
       .send({ requested_tier: 'pro' });
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('400 VALIDATION_ERROR - missing requested_tier entirely', async () => {
@@ -289,7 +289,7 @@ describe('POST /api/quota/requests', () => {
       .send({ reason: 'Need higher rate limits for production workload' });
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('401 - no authentication provided', async () => {
@@ -563,7 +563,7 @@ describe('GET /api/quota/requests/:id', () => {
       .set('x-user-id', 'dev-1');
 
     expect(res.status).toBe(404);
-    expect(res.body.code).toBe('QUOTA_REQUEST_NOT_FOUND');
+    expect(res.body.error.code).toBe('QUOTA_REQUEST_NOT_FOUND');
   });
 
   it('404 QUOTA_REQUEST_NOT_FOUND - ID belongs to different developer (ownership guard)', async () => {
@@ -583,7 +583,7 @@ describe('GET /api/quota/requests/:id', () => {
       .set('x-user-id', 'dev-1');
 
     expect(res.status).toBe(404);
-    expect(res.body.code).toBe('QUOTA_REQUEST_NOT_FOUND');
+    expect(res.body.error.code).toBe('QUOTA_REQUEST_NOT_FOUND');
   });
 
   it('401 - no authentication provided (get by id)', async () => {

--- a/src/services/quotaService.ts
+++ b/src/services/quotaService.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../logger.js';
 import { NotFoundError, ConflictError } from '../errors/index.js';
+import { quotasCache } from './quotasCacheWarm.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -126,6 +127,7 @@ export async function createQuotaRequest(input: CreateQuotaRequestInput): Promis
     requestedTier: input.requestedTier,
   });
 
+  quotasCache.invalidateAll();
   return request;
 }
 
@@ -141,8 +143,16 @@ export async function getQuotaRequest(requestId: string): Promise<QuotaRequest> 
 export async function listQuotaRequests(filter?: {
   status?: QuotaRequestStatus;
 }): Promise<QuotaRequest[]> {
+  const cacheKey = filter?.status ?? 'all';
+  const cached = quotasCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const store = getQuotaRequestStore();
-  return store.list(filter);
+  const result = await store.list(filter);
+  quotasCache.set(cacheKey, result);
+  return result;
 }
 
 export async function approveQuotaRequest(
@@ -188,6 +198,7 @@ export async function approveQuotaRequest(
     adminNotes,
   });
 
+  quotasCache.invalidateAll();
   return updated!;
 }
 
@@ -222,6 +233,7 @@ export async function rejectQuotaRequest(
     adminNotes,
   });
 
+  quotasCache.invalidateAll();
   return updated!;
 }
 

--- a/src/services/quotasCacheWarm.ts
+++ b/src/services/quotasCacheWarm.ts
@@ -1,0 +1,89 @@
+import { QuotaRequest, listQuotaRequests } from './quotaService.js';
+import { logger } from '../logger.js';
+
+export interface QuotasCacheEntry {
+  value: QuotaRequest[];
+  expiresAt: number;
+}
+
+export class QuotasCache {
+  private readonly store = new Map<string, QuotasCacheEntry>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs = 30_000) {
+    this.ttlMs = ttlMs;
+  }
+
+  get(key: string): QuotaRequest[] | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: QuotaRequest[]): void {
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
+  invalidateAll(): void {
+    this.store.clear();
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+}
+
+export const quotasCache = new QuotasCache();
+
+export interface QuotasWarmupOptions {
+  timeoutMs?: number;
+  logger?: Pick<typeof console, 'log' | 'warn' | 'error'>;
+}
+
+export interface QuotasWarmupResult {
+  success: boolean;
+  durationMs: number;
+  entriesLoaded: number;
+  reason?: string;
+}
+
+export async function warmupQuotasCache(
+  options: QuotasWarmupOptions = {}
+): Promise<QuotasWarmupResult> {
+  const { timeoutMs = 5_000, logger: log = logger } = options;
+  const started = Date.now();
+
+  try {
+    // Warm up the default query (all requests)
+    const result = await Promise.race([
+      listQuotaRequests(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`Quotas warmup timed out after ${timeoutMs}ms`)), timeoutMs)
+      ),
+    ]);
+
+    quotasCache.set('all', result);
+
+    const durationMs = Date.now() - started;
+    logger.info(`[quotasCache] warmup completed in ${durationMs}ms — 1 entry loaded`);
+
+    return { success: true, durationMs, entriesLoaded: 1 };
+  } catch (err) {
+    const durationMs = Date.now() - started;
+    const reason = err instanceof Error ? err.message : String(err);
+    logger.warn(`[quotasCache] warmup skipped: ${reason} (${durationMs}ms elapsed)`);
+
+    return { success: false, durationMs, entriesLoaded: 0, reason };
+  }
+}


### PR DESCRIPTION
# PR Description

Closes #676 

## 📋 Summary
Implement cache-warming for the quota requests listing at startup to avoid cold-cache spikes.

## 🎯 Motivation
The `/api/quota/requests` (and `/api/admin/quota/requests`) routes fetch all quota requests from the database on every call, creating potential performance bottlenecks and cold-cache spikes during high-traffic windows. Caching this data with a standard TTL and warming it up at server boot minimizes initial database round-trips.

## 📦 Changes
- **`src/services/quotasCacheWarm.ts` [NEW]**: Implements the `QuotasCache` store and the `warmupQuotasCache` runner.
- **`src/services/quotaService.ts`**: Integrates `quotasCache` to serve cache hits on listing and automatically flushes/invalidates the cache on new request creation, approvals, or rejections.
- **`src/index.ts`**: Performs the `warmupQuotasCache` at startup before other background jobs start.
- **`src/config/env.ts` & `src/config/index.ts`**: Added `QUOTAS_CACHE_WARMUP_TIMEOUT_MS` config option (default: `5,000ms`).
- **`src/routes/quota/requests.test.ts`**: Updated assertions to expect the response error envelopes (`res.body.error.code` & `res.body.error.details`).
- **`src/app.ts` & `src/routes/billing.ts`**: Fixed some missing imports and undefined variable bugs from a previous merge.