### PR TITLE
feat: add cursor pagination on /api/gateway (closes #781)

### DIFF
--- a/src/data/apiRegistry.test.ts
+++ b/src/data/apiRegistry.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 
 import { InMemoryApiRegistry, resolveEndpointPrice } from './apiRegistry.js';
 import type { ApiRegistryEntry, EndpointPricing } from '../types/gateway.js';
+import { encodeCursor } from '../lib/cursorPagination.js';
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -103,6 +104,123 @@ describe('InMemoryApiRegistry', () => {
       () => registry.register({ ...ENTRY_A, base_url: 'http://169.254.169.254/latest' }),
       /private or loopback IP range/i,
     );
+  });
+});
+
+// ── Cursor pagination (list) ────────────────────────────────────────────────
+
+describe('InMemoryApiRegistry.list (cursor pagination)', () => {
+  const now = new Date('2026-07-01T00:00:00.000Z');
+
+  const mkEntry = (
+    id: string,
+    slug: string,
+    created_at: Date,
+  ): ApiRegistryEntry => ({
+    id,
+    slug,
+    base_url: `http://localhost:${id.split('_')[1] ?? 8000}`,
+    developerId: 'dev_test',
+    endpoints: [{ endpointId: 'ep', path: '*', priceUsdc: 0.01 }],
+    created_at,
+  });
+
+  test('returns all entries when no cursor is provided', () => {
+    const entries = [
+      mkEntry('api_1', 'slug-1', new Date(now.getTime() - 3000)),
+      mkEntry('api_2', 'slug-2', new Date(now.getTime() - 2000)),
+      mkEntry('api_3', 'slug-3', new Date(now.getTime() - 1000)),
+    ];
+    const registry = new InMemoryApiRegistry(entries);
+
+    const result = registry.list(null, 10);
+
+    assert.equal(result.entries.length, 3);
+    // Sorted by created_at DESC, so most recent first
+    assert.equal(result.entries[0].id, 'api_3');
+    assert.equal(result.entries[1].id, 'api_2');
+    assert.equal(result.entries[2].id, 'api_1');
+    assert.equal(result.nextCursor, null);
+  });
+
+  test('returns a nextCursor when there are more entries than the limit', () => {
+    const entries = [
+      mkEntry('api_1', 'slug-1', new Date(now.getTime() - 3000)),
+      mkEntry('api_2', 'slug-2', new Date(now.getTime() - 2000)),
+      mkEntry('api_3', 'slug-3', new Date(now.getTime() - 1000)),
+      mkEntry('api_4', 'slug-4', now),
+    ];
+    const registry = new InMemoryApiRegistry(entries);
+
+    const result = registry.list(null, 2);
+
+    assert.equal(result.entries.length, 2);
+    assert.equal(result.entries[0].id, 'api_4');
+    assert.equal(result.entries[1].id, 'api_3');
+    assert.notEqual(result.nextCursor, null);
+    assert.ok(typeof result.nextCursor === 'string');
+  });
+
+  test('correctly pages through results using a cursor', () => {
+    const entries = [
+      mkEntry('api_1', 'slug-1', new Date(now.getTime() - 3000)),
+      mkEntry('api_2', 'slug-2', new Date(now.getTime() - 2000)),
+      mkEntry('api_3', 'slug-3', new Date(now.getTime() - 1000)),
+      mkEntry('api_4', 'slug-4', now),
+    ];
+    const registry = new InMemoryApiRegistry(entries);
+
+    // Page 1: most recent 2 entries
+    const page1 = registry.list(null, 2);
+    assert.equal(page1.entries.length, 2);
+    assert.equal(page1.entries[0].id, 'api_4');
+    assert.equal(page1.entries[1].id, 'api_3');
+    assert.notEqual(page1.nextCursor, null);
+
+    // Page 2: resume from cursor
+    const page2 = registry.list(page1.nextCursor, 2);
+    assert.equal(page2.entries.length, 2);
+    assert.equal(page2.entries[0].id, 'api_2');
+    assert.equal(page2.entries[1].id, 'api_1');
+    assert.equal(page2.nextCursor, null);
+  });
+
+  test('handles entries without created_at (stable by id)', () => {
+    const e1: ApiRegistryEntry = {
+      id: 'api_z', slug: 'slug-z', base_url: 'http://localhost:9001',
+      developerId: 'dev_test', endpoints: [],
+    };
+    const e2: ApiRegistryEntry = {
+      id: 'api_a', slug: 'slug-a', base_url: 'http://localhost:9002',
+      developerId: 'dev_test', endpoints: [],
+    };
+    const registry = new InMemoryApiRegistry([e1, e2]);
+
+    const result = registry.list(null, 10);
+
+    assert.equal(result.entries.length, 2);
+    // Same created_at (both 0), so sorted by id DESC
+    assert.equal(result.entries[0].id, 'api_z');
+    assert.equal(result.entries[1].id, 'api_a');
+  });
+
+  test('returns empty list when registry is empty', () => {
+    const registry = new InMemoryApiRegistry();
+
+    const result = registry.list(null, 10);
+
+    assert.equal(result.entries.length, 0);
+    assert.equal(result.nextCursor, null);
+  });
+
+  test('clamps limit to available entries', () => {
+    const entries = [mkEntry('api_1', 'slug-1', now)];
+    const registry = new InMemoryApiRegistry(entries);
+
+    const result = registry.list(null, 50);
+
+    assert.equal(result.entries.length, 1);
+    assert.equal(result.nextCursor, null);
   });
 });
 

--- a/src/data/apiRegistry.ts
+++ b/src/data/apiRegistry.ts
@@ -1,5 +1,6 @@
-import { ApiRegistry, ApiRegistryEntry, EndpointPricing } from '../types/gateway.js';
+import { ApiRegistry, ApiRegistryEntry, EndpointPricing, PaginatedApiList } from '../types/gateway.js';
 import { validateUpstreamBaseUrl } from '../lib/upstreamTarget.js';
+import { decodeCursor, encodeCursor } from '../lib/cursorPagination.js';
 
 /**
  * In-memory API registry.
@@ -27,6 +28,45 @@ export class InMemoryApiRegistry implements ApiRegistry {
 
   resolve(slugOrId: string): ApiRegistryEntry | undefined {
     return this.byId.get(slugOrId) ?? this.bySlug.get(slugOrId);
+  }
+
+  list(cursor?: string | null, limit = 20): PaginatedApiList {
+    // Collect all entries sorted by created_at (desc), then id for stability
+    const sorted = [...this.byId.values()].sort((a, b) => {
+      const aTime = a.created_at?.getTime() ?? 0;
+      const bTime = b.created_at?.getTime() ?? 0;
+      if (bTime !== aTime) return bTime - aTime;
+      return b.id.localeCompare(a.id);
+    });
+
+    // If cursor is provided, skip entries until we find the cursor position
+    let startIndex = 0;
+    if (cursor) {
+      const decoded = decodeCursor(cursor);
+      if (decoded) {
+        startIndex = sorted.findIndex(
+          (e) =>
+            (e.created_at?.getTime() ?? 0) === decoded.timestamp.getTime() &&
+            e.id === decoded.id,
+        );
+        if (startIndex === -1) startIndex = 0;
+        else startIndex += 1; // skip past the cursor entry
+      }
+    }
+
+    const page = sorted.slice(startIndex, startIndex + limit);
+
+    // Compute next cursor from the last entry in the page
+    let nextCursor: string | null = null;
+    if (page.length === limit && startIndex + limit < sorted.length) {
+      const lastEntry = page[page.length - 1];
+      nextCursor = encodeCursor(
+        lastEntry.created_at ?? new Date(0),
+        lastEntry.id,
+      );
+    }
+
+    return { entries: page, nextCursor };
   }
 }
 

--- a/src/routes/gatewayRoutes.ts
+++ b/src/routes/gatewayRoutes.ts
@@ -8,6 +8,7 @@ import type { GatewayDeps, ApiKey } from '../types/gateway.js';
 import { buildHopByHopSet } from '../lib/hopByHop.js';
 import { defaultUsageSseBroadcaster } from './usage/sse.js';
 import { getDefaultBreakerRegistry, CircuitBreakerState } from '../lib/circuitBreaker.js';
+
 import {
   BadGatewayError,
   ForbiddenError,
@@ -131,6 +132,37 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
   // as 413 via the app-level error handler.
   router.use(express.json({ limit: maxBodySize }));
   router.use(express.urlencoded({ extended: false, limit: maxBodySize }));
+
+  // ── Gateway cursor-paginated listing endpoint ─────────────────────────────
+  //
+  // GET /
+  //
+  // Returns registered APIs with cursor-based pagination over (created_at, id).
+  // Query params:
+  //   cursor  - Opaque base64 cursor from a previous response
+  //   limit   - Page size (default: 20, max: 100)
+  //
+  // Stable ordering prevents duplicates under concurrent writes.
+  // ──────────────────────────────────────────────────────────────────────────
+  router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!registry) {
+        res.json({ entries: [], nextCursor: null });
+        return;
+      }
+
+      const cursor = typeof req.query.cursor === 'string' ? req.query.cursor : undefined;
+      const rawLimit = Number(req.query.limit);
+      const limit = Number.isFinite(rawLimit) && rawLimit > 0
+        ? Math.min(rawLimit, 100)
+        : 20;
+
+      const result = registry.list(cursor ?? null, limit);
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  });
 
   // ── Gateway health endpoint ──────────────────────────────────────────────
   //

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -91,11 +91,20 @@ export interface ApiRegistryEntry {
   base_url: string;
   developerId: string;
   endpoints: EndpointPricing[];
+  created_at?: Date;
+}
+
+/** Paginated listing result for cursor-based API browsing. */
+export interface PaginatedApiList {
+  entries: ApiRegistryEntry[];
+  nextCursor: string | null;
 }
 
 /** Registry for resolving API slugs / IDs to their upstream entries. */
 export interface ApiRegistry {
   resolve(slugOrId: string): ApiRegistryEntry | undefined;
+  /** List registered APIs with cursor-based pagination over (created_at, id). */
+  list(cursor?: string | null, limit?: number): PaginatedApiList;
 }
 
 /** Configuration for proxy behaviour. */


### PR DESCRIPTION
## Summary
Adds cursor-based pagination to `/api/gateway` for stable ordering under concurrent writes.

### Changes
- Added `created_at` field to `ApiRegistryEntry` and `PaginatedApiList` type
- Added `list()` method to `ApiRegistry` interface with cursor pagination over (created_at, id)
- Implemented `InMemoryApiRegistry.list()` using existing encodeCursor/decodeCursor helpers
- Added GET / endpoint on the gateway router with ?cursor= and ?limit= query params
- Added 6 comprehensive unit tests for cursor pagination

### Testing
- 21/21 apiRegistry tests pass
- TypeScript compiles cleanly (0 errors)

Closes #781