### PR TITLE
feat: cache warm refunds

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,8 @@ import { errorHandler } from './middleware/errorHandler.js';
 import { performHealthCheck, type HealthCheckConfig } from './services/healthCheck.js';
 import { createDependenciesRouter } from './routes/health/dependencies.js';
 import quotaRequestsRouter from './routes/quota/requests.js';
+import { envelopeValidator } from './middleware/envelopeValidator.js';
+import { successEnvelope, errorEnvelope, getRequestId } from './lib/envelope.js';
 import { parsePagination, paginatedResponse } from './lib/pagination.js';
 import { InMemoryVaultRepository, type VaultRepository } from './repositories/vaultRepository.js';
 import { DepositController } from './controllers/depositController.js';
@@ -276,7 +278,8 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
   // Per-dependency health probe — detailed status for each configured dependency
   app.use('/api/health/dependencies', createDependenciesRouter(dependencies?.healthCheckConfig));
 
-  app.get('/api/health', async (_req, res) => {
+  app.get('/api/health', async (req, res) => {
+    const requestId = getRequestId(req);
     // If no health check config provided, return simple health check
     if (!dependencies?.healthCheckConfig) {
       const data = { status: 'ok', service: 'callora-backend' };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -156,6 +156,7 @@ export const envSchema = z
     HEALTH_CHECK_DB_TIMEOUT: z.coerce.number().default(2_000),
     APIS_CACHE_TTL_MS: z.coerce.number().int().positive().optional(),
     LISTINGS_CACHE_WARMUP_TIMEOUT_MS: z.coerce.number().int().positive().default(5_000),
+    REFUNDS_CACHE_WARMUP_TIMEOUT_MS: z.coerce.number().int().positive().default(5_000),
     BULK_ENDPOINT_LIMIT: z.coerce.number().int().positive().default(100),
     APP_VERSION: z.string().default("1.0.0"),
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -221,6 +221,9 @@ export const config = {
   listingsCache: {
     warmupTimeoutMs: env.LISTINGS_CACHE_WARMUP_TIMEOUT_MS,
   },
+  refundsCache: {
+    warmupTimeoutMs: env.REFUNDS_CACHE_WARMUP_TIMEOUT_MS,
+  },
   bulkEndpointLimit: env.BULK_ENDPOINT_LIMIT,
 
   slowQueryAlerter: {

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -4,6 +4,7 @@ import type { RefreshTokenRepository } from '../repositories/refreshTokenReposit
 import { logger } from '../logger.js';
 import { UnauthorizedError } from '../errors/index.js';
 import { getClientIp, DEFAULT_PROXY_HEADERS } from '../lib/clientIp.js';
+import { successEnvelope, getRequestId } from '../lib/envelope.js';
 
 export interface AuthControllerOptions {
   refreshTokenService: RefreshTokenService;
@@ -146,7 +147,7 @@ export class AuthController {
         familyId: storedToken.familyId
       });
 
-      res.json({
+      res.json(successEnvelope({
         accessToken: newTokenPair.accessToken,
         refreshToken: newTokenPair.refreshToken,
         tokenType: 'Bearer'
@@ -267,7 +268,7 @@ export class AuthController {
       res.json(successEnvelope({
         activeRefreshTokens: activeTokenCount,
         maxAllowedTokens: 5
-      });
+      }, requestId));
 
     } catch (error) {
       logger.error('[AuthController] Error getting token info', { error });

--- a/src/controllers/depositController.ts
+++ b/src/controllers/depositController.ts
@@ -16,6 +16,7 @@ import {
 import type { VaultRepository } from '../repositories/vaultRepository.js';
 import { config } from '../config/index.js';
 import { redactSimulationDetails } from '../lib/simulationDiagnostics.js';
+import { successEnvelope, errorEnvelope, getRequestId } from '../lib/envelope.js';
 
 export interface DepositPrepareRequest {
   amount_usdc: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { createGatewayRouter } from "./routes/gatewayRoutes.js";
 import { createProxyRouter } from "./routes/proxyRoutes.js";
 import adminRouter from "./routes/admin.js";
 import { createUsageAnomaliesRouter } from "./routes/admin/usage/anomalies.js";
+import refundsRouter from "./routes/refunds.js";
 import { defaultDeveloperRepository } from "./repositories/developerRepository.js";
 import { createBillingService } from "./services/billingService.js";
 import { createRateLimiter } from "./services/rateLimiter.js";
@@ -230,6 +231,7 @@ if (isDirectExecution) {
   // adminRouter's `/usage/:developerId` route.
   app.use("/api/admin/usage/anomalies", createUsageAnomaliesRouter({ pool }));
   app.use("/api/admin", adminRouter);
+  app.use("/api/refunds", refundsRouter);
 
   // Legacy gateway route (existing)
   const gatewayRouter = createGatewayRouter({
@@ -359,6 +361,10 @@ if (isDirectExecution) {
           }),
         { timeoutMs: config.listingsCache.warmupTimeoutMs },
       );
+
+      // Warm the refunds cache before accepting traffic to avoid cold-cache spikes on startup.
+      const { warmupRefundsCache } = await import("./services/refundsCacheWarm.js");
+      await warmupRefundsCache({ timeoutMs: config.refundsCache.warmupTimeoutMs });
 
       revenueLedgerIndexerJob.start();
       settlementStatusSyncJob.start();

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -30,6 +30,7 @@ import { billingAccessLogMiddleware } from "../middleware/billingAccessLog.js";
 import creditsRouter from "./billing/credits.js";
 import disputesRouter from "./billing/disputes.js";
 import { createFeeAbstractionRouter } from "./billing/feeAbstraction.js";
+import bulkDeductRouter from "./billing/deduct/bulk.js";
 
 const router = Router();
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import billingRouter from './billing.js';
 import { createBillingPortalRouter } from './billing/portal.js';
 import healthRouter from './health.js';
+import refundsRouter from './refunds.js';
 import { createApisRouter, type ApisRouterDeps } from './apis.js';
 import { createUsageRouter, type UsageRouterDeps } from './usage.js';
 import { createLimitsRouter } from './limits.js';
@@ -94,6 +95,8 @@ export function createApiRouter(deps: ApiRouterDeps = {}): Router {
   if (deps.restRateLimiter) {
     router.use('/limits', createLimitsRouter(deps.restRateLimiter).router);
   }
+
+  router.use('/refunds', refundsRouter);
 
   // Serve OpenAPI 3.1 JSON contract
   router.get('/openapi.json', (_req, res) => {

--- a/src/routes/refunds.ts
+++ b/src/routes/refunds.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import { defaultDisputeService } from '../services/disputeService.js';
+import { refundsCache } from '../services/refundsCacheWarm.js';
+import { successEnvelope, getRequestId } from '../lib/envelope.js';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  const requestId = getRequestId(req);
+  const cached = refundsCache.get('all');
+  if (cached !== undefined) {
+    res.json(successEnvelope(cached, requestId));
+    return;
+  }
+
+  const all = defaultDisputeService.listAll();
+  const refunds = all.filter((d) => d.status === 'REFUNDED');
+  refundsCache.set('all', refunds);
+
+  res.json(successEnvelope(refunds, requestId));
+});
+
+export default router;

--- a/src/services/disputeService.ts
+++ b/src/services/disputeService.ts
@@ -12,6 +12,7 @@
 
 import { z } from 'zod';
 import { ConflictError, NotFoundError, ForbiddenError } from '../errors/index.js';
+import { refundsCache } from './refundsCacheWarm.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -189,6 +190,9 @@ export class DisputeService {
       action: 'RESOLVED',
       details: { resolution: input.resolution, notes: input.notes },
     });
+    if (input.resolution === 'REFUNDED') {
+      refundsCache.invalidateAll();
+    }
     return dispute;
   }
 

--- a/src/services/refundsCacheWarm.ts
+++ b/src/services/refundsCacheWarm.ts
@@ -1,0 +1,91 @@
+import { defaultDisputeService } from './disputeService.js';
+import { logger } from '../logger.js';
+
+export interface RefundsCacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export class RefundsCache<T = unknown> {
+  private readonly store = new Map<string, RefundsCacheEntry<T>>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs = 30_000) {
+    this.ttlMs = ttlMs;
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
+  invalidateAll(): void {
+    this.store.clear();
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+}
+
+export const refundsCache = new RefundsCache();
+
+export interface RefundsWarmupOptions {
+  timeoutMs?: number;
+  logger?: Pick<typeof console, 'log' | 'warn' | 'error'>;
+}
+
+export interface RefundsWarmupResult {
+  success: boolean;
+  durationMs: number;
+  entriesLoaded: number;
+  reason?: string;
+}
+
+export async function warmupRefundsCache(
+  options: RefundsWarmupOptions = {}
+): Promise<RefundsWarmupResult> {
+  const { timeoutMs = 5_000, logger: log = logger } = options;
+  const started = Date.now();
+
+  try {
+    const result = await Promise.race([
+      Promise.resolve().then(() => {
+        const all = defaultDisputeService.listAll();
+        return all.filter((d) => d.status === 'REFUNDED');
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`Refunds warmup timed out after ${timeoutMs}ms`)), timeoutMs)
+      ),
+    ]);
+
+    refundsCache.set('all', result);
+
+    const durationMs = Date.now() - started;
+    logger.info(`[refundsCache] warmup completed in ${durationMs}ms — 1 entry loaded`);
+
+    return { success: true, durationMs, entriesLoaded: 1 };
+  } catch (err) {
+    const durationMs = Date.now() - started;
+    const reason = err instanceof Error ? err.message : String(err);
+    logger.warn(`[refundsCache] warmup skipped: ${reason} (${durationMs}ms elapsed)`);
+
+    return { success: false, durationMs, entriesLoaded: 0, reason };
+  }
+}


### PR DESCRIPTION
# PR Description

Closes #679 

## 📋 Summary
Implement cache-warming for the refunds (`/api/refunds`) endpoint at startup to avoid cold-cache spikes.

## 🎯 Motivation
Caches list responses from the `/api/refunds` route, which reads from the dispute service/repository where resolved disputes with status `REFUNDED` represent the active refund list. Warming this cache at startup prevents initial cold database/memory hits and potential latency spikes.

## 📦 Changes
- **`src/services/refundsCacheWarm.ts` [NEW]**: Implements `RefundsCache` and the `warmupRefundsCache` function.
- **`src/routes/refunds.ts` [NEW]**: Declares the `GET /api/refunds` endpoint returning enveloped, cached resolved disputes with status `REFUNDED`.
- **`src/services/disputeService.ts`**: Integrates cache invalidation whenever a dispute is resolved as `REFUNDED`.
- **`src/routes/index.ts` & `src/index.ts` & `src/app.ts`**: Imports, mounts, and registers the refunds route, and runs the cache warmup routine inside server initialization.
- **`src/config/env.ts` & `src/config/index.ts`**: Added `REFUNDS_CACHE_WARMUP_TIMEOUT_MS` configuration option (default: `5,000ms`).
- **Build & Syntax Fixes**: Resolved pre-existing compilation errors in `authController.ts`, `depositController.ts`, and `app.ts` (restored envelope helpers, fixed incorrect parentheses, and imported missing controllers/routers).