### PR TITLE
feat: add admin bulk quota update endpoint and docs

### DIFF
--- a/docs/quota-self-service.md
+++ b/docs/quota-self-service.md
@@ -166,6 +166,56 @@ Content-Type: application/json
 - The developer's plan is **not** modified.
 - Returns `409 QUOTA_REQUEST_ALREADY_RESOLVED` if already resolved.
 
+### Bulk update developer quotas (admin)
+
+```
+POST /api/admin/quotas/bulk-update
+x-admin-api-key: <key>
+Content-Type: application/json
+
+{
+  "items": [
+    {
+      "developer_id": "dev-123",
+      "plan_tier": "pro",
+      "monthly_call_limit": 250000,
+      "rate_limit_max_requests": 2000
+    },
+    {
+      "developer_id": "dev-456",
+      "plan_tier": "enterprise"
+    }
+  ]
+}
+```
+
+- Atomically updates `plan_overrides` for multiple developers in a single
+  transaction.
+- Validates each item and rejects the entire batch if any item is invalid.
+- Returns `404 NOT_FOUND` if any referenced developer does not exist.
+
+**Request fields**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `developer_id` | string | yes | Developer user ID to update |
+| `plan_tier` | `freeul`, `pro`, `enterprise` | yes | New subscription tier |
+| `monthly_call_limit` | integer | no | Optional monthly call quota override |
+| `rate_limit_max_requests` | integer | no | Optional per-minute rate limit override |
+
+**Response (200 OK)**
+
+```json
+{
+  "data": {
+    "updated": 2
+  }
+}
+```
+
+- The response reports the number of developers updated.
+- Structured audit logging is emitted for the bulk operation.
+
 ---
 
 ## QuotaRequest schema

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -17,6 +17,7 @@ import { createAdminWebhooksRouter } from './admin/webhooks.js';
 import { createAdminApisRouter } from './admin/apis.js';
 import { createAdminHealthProbesRouter } from './admin/health/probes.js';
 import { createAdminCreditGrantsRouter } from './admin/billing/credits/grant.js';
+import { createAdminQuotaBulkRouter } from './admin/quotas/bulk.js';
 import { createAdminUsageExportRouter } from './admin/usage/export.js';
 import { createAdminKeyConcurrencyRouter } from './admin/keys/concurrency.js';
 
@@ -229,6 +230,12 @@ router.use('/health/probes', createAdminHealthProbesRouter());
 // Mount: POST /api/admin/billing/credits/grant
 // ---------------------------------------------------------------------------
 router.use('/billing/credits', createAdminCreditGrantsRouter());
+
+// ---------------------------------------------------------------------------
+// Admin quota bulk updates
+// Mount: POST /api/admin/quotas/bulk-update
+// ---------------------------------------------------------------------------
+router.use('/quotas', createAdminQuotaBulkRouter());
 
 // ---------------------------------------------------------------------------
 // GrantFox FWC26 per-key concurrency stats

--- a/src/routes/admin/quotas/bulk.test.ts
+++ b/src/routes/admin/quotas/bulk.test.ts
@@ -1,0 +1,128 @@
+import express from 'express';
+import request from 'supertest';
+
+import { errorHandler } from '../../../middleware/errorHandler.js';
+import { createAdminQuotaBulkRouter } from './bulk.js';
+
+const ADMIN_KEY = 'test-admin-key';
+
+function createMockDb(rows: Array<{ plan_overrides: string | null }>) {
+  const queuedRows = [...rows];
+
+  const tx = {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => ({
+          limit: jest.fn(async () => {
+            const row = queuedRows.shift();
+            return row ? [{ plan_overrides: row.plan_overrides }] : [];
+          }),
+        })),
+      })),
+    })),
+    update: jest.fn(() => ({
+      set: jest.fn(() => ({
+        where: jest.fn(() => Promise.resolve()),
+      })),
+    })),
+  };
+
+  return {
+    transaction: async (cb: (tx: typeof tx) => Promise<unknown>) => cb(tx),
+  };
+}
+
+type MockTx = typeof createMockDb extends (rows: Array<{ plan_overrides: string | null }>) => infer R
+  ? R extends { transaction: (cb: (tx: infer T) => Promise<unknown>) => Promise<unknown> }
+    ? T
+    : never
+  : never;
+
+type MockDb = {
+  transaction: (cb: (tx: MockTx) => Promise<unknown>) => Promise<unknown>;
+};
+
+function buildApp(db: MockDb) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    if (req.headers['x-admin-api-key'] !== ADMIN_KEY) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    res.locals.adminActor = 'admin-api-key';
+    next();
+  });
+  app.use('/api/admin/quotas', createAdminQuotaBulkRouter({ db }));
+  app.use(errorHandler);
+  return app;
+}
+
+describe('POST /api/admin/quotas/bulk-update', () => {
+  it('updates plan overrides for multiple developers atomically', async () => {
+    const db = createMockDb([
+      { plan_overrides: JSON.stringify({ plan_tier: 'free', monthly_call_limit: 50000 }) },
+      { plan_overrides: JSON.stringify({ plan_tier: 'free', rate_limit_max_requests: 1000 }) },
+    ]);
+    const app = buildApp(db);
+
+    const response = await request(app)
+      .post('/api/admin/quotas/bulk-update')
+      .set('x-admin-api-key', ADMIN_KEY)
+      .send({
+        items: [
+          { developer_id: 'dev-1', plan_tier: 'pro', monthly_call_limit: 100000 },
+          { developer_id: 'dev-2', plan_tier: 'enterprise', rate_limit_max_requests: 5000 },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual({ updated: 2 });
+  });
+
+  it('rejects requests with invalid items', async () => {
+    const db = createMockDb([]);
+    const app = buildApp(db);
+
+    const response = await request(app)
+      .post('/api/admin/quotas/bulk-update')
+      .set('x-admin-api-key', ADMIN_KEY)
+      .send({ items: [] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    expect(response.body.error.details[0].field).toBe('body.items');
+  });
+
+  it('returns 404 when a developer does not exist', async () => {
+    const db = createMockDb([]);
+    const app = buildApp(db);
+
+    const response = await request(app)
+      .post('/api/admin/quotas/bulk-update')
+      .set('x-admin-api-key', ADMIN_KEY)
+      .send({
+        items: [
+          { developer_id: 'missing-dev', plan_tier: 'pro' },
+        ],
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('requires admin authentication', async () => {
+    const db = createMockDb([]);
+    const app = buildApp(db);
+
+    const response = await request(app)
+      .post('/api/admin/quotas/bulk-update')
+      .send({
+        items: [
+          { developer_id: 'dev-1', plan_tier: 'pro' },
+        ],
+      });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/routes/admin/quotas/bulk.ts
+++ b/src/routes/admin/quotas/bulk.ts
@@ -1,0 +1,106 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { db as defaultDb, schema } from '../../../db/index.js';
+import { logger } from '../../../logger.js';
+import { validate } from '../../../middleware/validate.js';
+import { getClientIp } from '../../../lib/clientIp.js';
+import { AppError, InternalServerError, NotFoundError } from '../../../errors/index.js';
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+const quotaBulkItemSchema = z.object({
+  developer_id: z.string().trim().min(1, 'developer_id is required').max(255, 'developer_id must not exceed 255 characters'),
+  plan_tier: z.enum(['free', 'pro', 'enterprise'], {
+    message: 'plan_tier must be one of: free, pro, enterprise',
+  }),
+  monthly_call_limit: z.number().int().positive().optional(),
+  rate_limit_max_requests: z.number().int().positive().optional(),
+}).strict();
+
+const quotaBulkUpdateSchema = z.object({
+  items: z.array(quotaBulkItemSchema)
+    .min(1, 'At least one item is required')
+    .max(100, 'Batch size limit of 100 items exceeded'),
+}).strict();
+
+export interface AdminQuotaBulkRouterDeps {
+  db?: typeof defaultDb;
+}
+
+export function createAdminQuotaBulkRouter(deps: AdminQuotaBulkRouterDeps = {}): Router {
+  const router = Router();
+  const db = deps.db ?? defaultDb;
+
+  router.post(
+    '/bulk-update',
+    validate({ body: quotaBulkUpdateSchema }),
+    async (req, res, next) => {
+      try {
+        const { items } = req.body as z.infer<typeof quotaBulkUpdateSchema>;
+
+        await db.transaction(async (tx) => {
+          for (const item of items) {
+            const rows = await tx
+              .select({ plan_overrides: schema.developers.plan_overrides })
+              .from(schema.developers)
+              .where(eq(schema.developers.user_id, item.developer_id))
+              .limit(1);
+
+            const developer = rows[0];
+            if (!developer) {
+              throw new NotFoundError(`Developer not found: ${item.developer_id}`);
+            }
+
+            const currentOverrides = developer.plan_overrides
+              ? JSON.parse(developer.plan_overrides)
+              : {};
+
+            const mergedOverrides = {
+              ...currentOverrides,
+              plan_tier: item.plan_tier,
+              ...(item.monthly_call_limit !== undefined
+                ? { monthly_call_limit: item.monthly_call_limit }
+                : {}),
+              ...(item.rate_limit_max_requests !== undefined
+                ? { rate_limit_max_requests: item.rate_limit_max_requests }
+                : {}),
+              updated_at: new Date().toISOString(),
+            };
+
+            await tx
+              .update(schema.developers)
+              .set({ plan_overrides: JSON.stringify(mergedOverrides) })
+              .where(eq(schema.developers.user_id, item.developer_id));
+          }
+        });
+
+        logger.audit('BULK_UPDATE_QUOTAS', res.locals.adminActor, {
+          clientIp: getClientIp(req, TRUST_PROXY),
+          userAgent: req.get('User-Agent'),
+          correlationId: req.headers['x-request-id'] ?? req.headers['x-correlation-id'],
+          requestedItems: items.length,
+          developerIds: items.map((item) => item.developer_id),
+        });
+
+        res.status(200).json({
+          data: {
+            updated: items.length,
+          },
+        });
+      } catch (error) {
+        if (error instanceof AppError) {
+          next(error);
+          return;
+        }
+
+        logger.error('Failed to bulk update quotas:', error);
+        next(new InternalServerError());
+      }
+    },
+  );
+
+  return router;
+}
+
+export default createAdminQuotaBulkRouter;


### PR DESCRIPTION
# Close #547

## PR: Add admin bulk quota update endpoint

### Summary
Adds a new admin-only endpoint for atomic bulk quota updates across multiple developers.

### What changed
- Implemented `POST /api/admin/quotas/bulk-update`
- Added request validation with Zod schema
- Applied atomic database transaction semantics
- Added focused tests for success, validation failure, missing developer, and auth
- Documented the endpoint in quota-self-service.md

### Testing
- `npx jest --runInBand --forceExit --no-cache src/routes/admin/quotas/bulk.test.ts`

### Notes
- Uses existing admin auth + IP allowlist protection
- Emits structured audit logs for bulk update actions
- Returns standardized error envelope responses for validation and not-found cases