### PR TITLE
feat: add cursor pagination on GET /api/refresh-token

### DIFF
--- a/docs/refresh-token-endpoint.md
+++ b/docs/refresh-token-endpoint.md
@@ -1,0 +1,104 @@
+# Refresh Token Listing
+
+`GET /api/refresh-token` returns refresh tokens for the authenticated user. Results are ordered by **newest first** using stable keyset (cursor) pagination over `(created_at, id)`, ensuring consistent ordering even under concurrent writes.
+
+## Authentication
+
+Requires a valid authentication token:
+
+- `Authorization: Bearer <JWT>` (access token), or
+- `x-user-id` header (for server-to-server calls)
+
+Only tokens belonging to the authenticated user are returned.
+
+## Query parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | `20` | Page size (1–100) |
+| `cursor` | string | — | Opaque cursor from a previous response's `meta.nextCursor` |
+
+## Response shape
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "expiresAt": "2026-12-31T23:59:59.999Z",
+      "createdAt": "2026-06-01T10:00:00.000Z",
+      "lastUsedAt": "2026-06-02T10:00:00.000Z",
+      "isRevoked": false,
+      "familyId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    }
+  ],
+  "meta": {
+    "limit": 20,
+    "hasMore": true,
+    "nextCursor": "eyJ0aW1lc3RhbXAiOiIyMDI2LTA2LTAxVDEwOjAwOjAwLjAwMFoiLCJpZCI6IjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCJ9"
+  },
+  "requestId": "req-abc123",
+  "timestamp": "2026-06-28T14:22:01.123Z"
+}
+```
+
+### Field descriptions
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique identifier for the refresh token record |
+| `expiresAt` | ISO-8601 timestamp when the token expires |
+| `createdAt` | ISO-8601 timestamp when the token was created |
+| `lastUsedAt` | ISO-8601 timestamp of last use, or `null` if never used |
+| `isRevoked` | Whether the token has been revoked |
+| `familyId` | Token family identifier for rotation tracking |
+
+**Note:** The `token_hash` column is never exposed in the API response.
+
+## Cursor format
+
+Cursors are opaque base64-encoded JSON objects:
+
+```json
+{"timestamp":"2026-06-01T10:00:00.000Z","id":"550e8400-e29b-41d4-a716-446655440000"}
+```
+
+Pass `meta.nextCursor` as the `cursor` query parameter to fetch the next page. When `hasMore` is `false`, there are no additional pages.
+
+## Error responses
+
+Invalid query parameters return the standard error envelope:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": [
+      { "field": "query.cursor", "message": "Invalid cursor format", "code": "INVALID_VALUE" }
+    ]
+  },
+  "requestId": "…",
+  "timestamp": "2026-06-28T14:22:01.123Z"
+}
+```
+
+## Example
+
+```bash
+# First page
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+  "https://api.example.com/api/refresh-token?limit=50"
+
+# Next page
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+  "https://api.example.com/api/refresh-token?limit=50&cursor=$NEXT_CURSOR"
+```
+
+## Notes
+
+- Cursor pagination avoids offset scans and remains stable when new rows are inserted during paging, making it suitable for concurrent write environments.
+- Each request is logged with structured logging including correlation ID, user ID, and pagination parameters.
+- Data is sourced from the `refresh_tokens` table.

--- a/src/repositories/refreshTokenRepository.ts
+++ b/src/repositories/refreshTokenRepository.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import type { RefreshToken } from '../types/auth.js';
+import type { CursorPayload } from '../lib/cursorPagination.js';
 import { readQuery, writeQuery } from '../db.js';
 
 /** Injectable queryable for tests. */
@@ -52,6 +53,22 @@ export interface RefreshTokenRepository {
    * Count active refresh tokens for a user
    */
   countActiveTokens(userId: string): Promise<number>;
+
+  /**
+   * List refresh tokens for a user with cursor-based pagination.
+   * Uses stable keyset ordering over (created_at DESC, id DESC) to
+   * guarantee consistent results under concurrent writes.
+   *
+   * @param userId     - The user whose tokens to list
+   * @param limit      - Maximum number of tokens to return (clamped to 1..100)
+   * @param afterCursor - Optional cursor encoding the last seen (created_at, id)
+   * @returns          - Array of refresh tokens and a hasMore flag
+   */
+  listRefreshTokens(
+    userId: string,
+    limit: number,
+    afterCursor?: CursorPayload,
+  ): Promise<{ tokens: RefreshToken[]; hasMore: boolean }>;
 }
 
 /**
@@ -205,5 +222,62 @@ export class DatabaseRefreshTokenRepository implements RefreshTokenRepository {
     );
     const row = result.rows[0] as Record<string, unknown> | undefined;
     return parseInt(String(row?.['count'] ?? '0'), 10);
+  }
+
+  async listRefreshTokens(
+    userId: string,
+    limit: number,
+    afterCursor?: CursorPayload,
+  ): Promise<{ tokens: RefreshToken[]; hasMore: boolean }> {
+    // Fetch one extra row to determine if there are more results beyond the limit.
+    const fetchLimit = limit + 1;
+
+    let query: string;
+    let params: unknown[];
+
+    if (afterCursor) {
+      // Keyset pagination: rows strictly after the cursor position.
+      // Ordering is (created_at DESC, id DESC) so we fetch rows that are
+      // either created earlier, or same timestamp with a smaller id.
+      query = `
+        SELECT id, user_id, token_hash, expires_at, created_at, last_used_at, is_revoked, family_id
+        FROM refresh_tokens
+        WHERE user_id = $1
+          AND (created_at, id) < ($2, $3)
+        ORDER BY created_at DESC, id DESC
+        LIMIT $4`;
+      params = [userId, afterCursor.timestamp.toISOString(), afterCursor.id, fetchLimit];
+    } else {
+      query = `
+        SELECT id, user_id, token_hash, expires_at, created_at, last_used_at, is_revoked, family_id
+        FROM refresh_tokens
+        WHERE user_id = $1
+        ORDER BY created_at DESC, id DESC
+        LIMIT $2`;
+      params = [userId, fetchLimit];
+    }
+
+    const result = await this.readDb.query(query, params);
+
+    const tokens: RefreshToken[] = result.rows.map((row) => {
+      const r = row as Record<string, unknown>;
+      return {
+        id: r['id'] as string,
+        userId: r['user_id'] as string,
+        tokenHash: r['token_hash'] as string,
+        expiresAt: new Date(r['expires_at'] as string),
+        createdAt: new Date(r['created_at'] as string),
+        lastUsedAt: r['last_used_at'] ? new Date(r['last_used_at'] as string) : undefined,
+        isRevoked: r['is_revoked'] as boolean,
+        familyId: r['family_id'] as string,
+      };
+    });
+
+    const hasMore = tokens.length > limit;
+    if (hasMore) {
+      tokens.length = limit;
+    }
+
+    return { tokens, hasMore };
   }
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -15,6 +15,7 @@ import { createUsageByEndpointRouter } from './usage/byEndpoint.js';
 import { createExportSchedulesRouter } from './exports/schedules.js';
 import type { ScheduledExportsService } from '../services/scheduledExports.js';
 import { createSubscriptionRouter } from './subscriptionRoutes.js';
+import { createRefreshTokenRouter } from './refresh-token.js';
 import type { SubscriptionRepository } from '../repositories/subscriptionRepository.js';
 import type { DeveloperRepository } from '../repositories/developerRepository.js';
 import type { ApiRepository } from '../repositories/apiRepository.js';
@@ -70,6 +71,9 @@ export function createApiRouter(deps: ApiRouterDeps = {}): Router {
       }),
     );
   }
+
+  // Refresh token listing with cursor pagination — authenticated users list their tokens.
+  router.use('/refresh-token', createRefreshTokenRouter());
 
   // Per-developer concurrency middleware for billing routes — applied BEFORE
   // the rate limiter so concurrency rejections are fast-fail and don't consume

--- a/src/routes/refresh-token.test.ts
+++ b/src/routes/refresh-token.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests for GET /api/refresh-token — cursor-paginated refresh token listing.
+ */
+
+jest.mock('better-sqlite3', () => {
+  return class MockDatabase {
+    prepare() {
+      return { get: () => null };
+    }
+    exec() {}
+    close() {}
+  };
+});
+
+jest.mock('../config/env', () => ({
+  env: {
+    PORT: 3000,
+    NODE_ENV: 'test',
+    DATABASE_URL: 'postgresql://localhost/callora_test',
+    DB_HOST: 'localhost',
+    DB_PORT: 5432,
+    DB_USER: 'postgres',
+    DB_PASSWORD: 'postgres',
+    DB_NAME: 'callora_test',
+    DB_POOL_MAX: 1,
+    DB_IDLE_TIMEOUT_MS: 1000,
+    DB_CONN_TIMEOUT_MS: 1000,
+    JWT_SECRET: 'test-jwt-secret',
+    ADMIN_API_KEY: 'test-admin-api-key',
+    METRICS_API_KEY: 'test-metrics-api-key',
+    UPSTREAM_URL: 'http://localhost:4000',
+    PROXY_TIMEOUT_MS: 30000,
+    CORS_ALLOWED_ORIGINS: 'http://localhost:5173',
+    SOROBAN_RPC_ENABLED: false,
+    HORIZON_ENABLED: false,
+    STELLAR_TESTNET_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+    STELLAR_MAINNET_HORIZON_URL: 'https://horizon.stellar.org',
+    SOROBAN_TESTNET_RPC_URL: 'https://soroban-testnet.stellar.org',
+    SOROBAN_MAINNET_RPC_URL: 'https://soroban-mainnet.stellar.org',
+    STELLAR_BASE_FEE: 100,
+    HEALTH_CHECK_DB_TIMEOUT: 2000,
+    APP_VERSION: '1.0.0',
+    LOG_LEVEL: 'info',
+    GATEWAY_PROFILING_ENABLED: false,
+  },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { requestIdMiddleware } from '../middleware/requestId.js';
+import { createRefreshTokenRouter } from './refresh-token.js';
+import { encodeCursor } from '../lib/cursorPagination.js';
+import type {
+  RefreshToken,
+  RefreshTokenRepository,
+} from '../repositories/refreshTokenRepository.js';
+
+jest.mock('../logger', () => {
+  const actual = jest.requireActual('../logger');
+  return {
+    ...actual,
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      audit: jest.fn(),
+    },
+  };
+});
+
+import { logger } from '../logger.js';
+
+const USER_ID = 'test-user-123';
+
+function makeToken(overrides: Partial<RefreshToken> = {}): RefreshToken {
+  return {
+    id: 'token-1',
+    userId: USER_ID,
+    tokenHash: 'hash-1',
+    expiresAt: new Date('2026-12-31T23:59:59.999Z'),
+    createdAt: new Date('2026-06-01T10:00:00.000Z'),
+    lastUsedAt: undefined,
+    isRevoked: false,
+    familyId: 'family-1',
+    ...overrides,
+  };
+}
+
+class MockRefreshTokenRepository implements RefreshTokenRepository {
+  private tokens: RefreshToken[] = [];
+
+  constructor(tokens: RefreshToken[] = []) {
+    this.tokens = tokens;
+  }
+
+  setTokens(tokens: RefreshToken[]): void {
+    this.tokens = tokens;
+  }
+
+  async createRefreshToken(token: Omit<RefreshToken, 'id'> & { id?: string }): Promise<RefreshToken> {
+    const stored = { id: token.id || 'new-id', ...token } as RefreshToken;
+    this.tokens.push(stored);
+    return stored;
+  }
+
+  async findRefreshTokenById(tokenId: string, userId: string): Promise<RefreshToken | null> {
+    return this.tokens.find((t) => t.id === tokenId && t.userId === userId) ?? null;
+  }
+
+  async findRefreshTokenByHash(tokenHash: string, userId: string): Promise<RefreshToken | null> {
+    return this.tokens.find((t) => t.tokenHash === tokenHash && t.userId === userId) ?? null;
+  }
+
+  async updateLastUsed(tokenId: string, userId: string): Promise<void> {
+    const token = this.tokens.find((t) => t.id === tokenId && t.userId === userId);
+    if (token) token.lastUsedAt = new Date();
+  }
+
+  async revokeRefreshToken(tokenId: string, userId: string): Promise<void> {
+    const token = this.tokens.find((t) => t.id === tokenId && t.userId === userId);
+    if (token) token.isRevoked = true;
+  }
+
+  async revokeFamily(familyId: string, userId: string): Promise<void> {
+    for (const token of this.tokens) {
+      if (token.familyId === familyId && token.userId === userId) {
+        token.isRevoked = true;
+      }
+    }
+  }
+
+  async revokeAllUserTokens(userId: string): Promise<void> {
+    for (const token of this.tokens) {
+      if (token.userId === userId) token.isRevoked = true;
+    }
+  }
+
+  async cleanupExpiredTokens(): Promise<number> {
+    const before = this.tokens.length;
+    this.tokens = this.tokens.filter(
+      (t) => t.expiresAt > new Date() && !t.isRevoked,
+    );
+    return before - this.tokens.length;
+  }
+
+  async countActiveTokens(userId: string): Promise<number> {
+    return this.tokens.filter(
+      (t) => t.userId === userId && t.expiresAt > new Date() && !t.isRevoked,
+    ).length;
+  }
+
+  async listRefreshTokens(
+    userId: string,
+    limit: number,
+    afterCursor?: { timestamp: Date; id: string },
+  ): Promise<{ tokens: RefreshToken[]; hasMore: boolean }> {
+    const userTokens = this.tokens
+      .filter((t) => t.userId === userId)
+      .sort((a, b) => {
+        const timeDiff = b.createdAt.getTime() - a.createdAt.getTime();
+        if (timeDiff !== 0) return timeDiff;
+        return b.id.localeCompare(a.id);
+      });
+
+    let filtered = userTokens;
+    if (afterCursor) {
+      filtered = userTokens.filter((t) => {
+        const timeDiff = t.createdAt.getTime() - afterCursor.timestamp.getTime();
+        if (timeDiff < 0) return true;
+        if (timeDiff > 0) return false;
+        return t.id < afterCursor.id;
+      });
+    }
+
+    const fetchLimit = limit + 1;
+    const sliced = filtered.slice(0, fetchLimit);
+    const hasMore = sliced.length > limit;
+    if (hasMore) sliced.length = limit;
+
+    return { tokens: sliced, hasMore };
+  }
+}
+
+function buildApp(repository: RefreshTokenRepository) {
+  const app = express();
+  app.use(requestIdMiddleware);
+  app.use(express.json());
+  app.use('/api/refresh-token', createRefreshTokenRouter({ refreshTokenRepository: repository }));
+  app.use(errorHandler);
+  return app;
+}
+
+const authHeader = { 'x-user-id': USER_ID };
+
+describe('GET /api/refresh-token', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the first page with nextCursor when more results exist', async () => {
+    const tokens = [
+      makeToken({ id: 'token-3', createdAt: new Date('2026-06-03T10:00:00.000Z') }),
+      makeToken({ id: 'token-2', createdAt: new Date('2026-06-02T10:00:00.000Z') }),
+      makeToken({ id: 'token-1', createdAt: new Date('2026-06-01T10:00:00.000Z') }),
+    ];
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token?limit=2').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.meta).toEqual({
+      limit: 2,
+      hasMore: true,
+      nextCursor: encodeCursor(new Date('2026-06-02T10:00:00.000Z'), 'token-2'),
+    });
+  });
+
+  it('returns an empty page without nextCursor when no tokens exist', async () => {
+    const repo = new MockRefreshTokenRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.meta).toEqual({ limit: 20, hasMore: false });
+    expect(res.body.meta.nextCursor).toBeUndefined();
+  });
+
+  it('returns last page without nextCursor when all results fit', async () => {
+    const tokens = [
+      makeToken({ id: 'token-2', createdAt: new Date('2026-06-02T10:00:00.000Z') }),
+      makeToken({ id: 'token-1', createdAt: new Date('2026-06-01T10:00:00.000Z') }),
+    ];
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token?limit=5').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.meta).toEqual({ limit: 5, hasMore: false });
+    expect(res.body.meta.nextCursor).toBeUndefined();
+  });
+
+  it('passes decoded cursor to the repository for subsequent pages', async () => {
+    const tokens = [
+      makeToken({ id: 'token-4', createdAt: new Date('2026-06-04T10:00:00.000Z') }),
+      makeToken({ id: 'token-3', createdAt: new Date('2026-06-03T10:00:00.000Z') }),
+      makeToken({ id: 'token-2', createdAt: new Date('2026-06-02T10:00:00.000Z') }),
+      makeToken({ id: 'token-1', createdAt: new Date('2026-06-01T10:00:00.000Z') }),
+    ];
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    // First page
+    const firstRes = await request(app).get('/api/refresh-token?limit=2').set(authHeader);
+    expect(firstRes.status).toBe(200);
+    expect(firstRes.body.meta.hasMore).toBe(true);
+    const cursor = firstRes.body.meta.nextCursor;
+
+    // Second page using the cursor
+    const secondRes = await request(app).get(`/api/refresh-token?limit=2&cursor=${cursor}`).set(authHeader);
+    expect(secondRes.status).toBe(200);
+    expect(secondRes.body.data).toHaveLength(2);
+    expect(secondRes.body.data.map((t: { id: string }) => t.id)).toEqual(['token-2', 'token-1']);
+    expect(secondRes.body.meta.hasMore).toBe(false);
+    expect(secondRes.body.meta.nextCursor).toBeUndefined();
+  });
+
+  it('does not expose token_hash in the response', async () => {
+    const tokens = [makeToken({ id: 'token-1', tokenHash: 'secret-hash-value' })];
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0]).not.toHaveProperty('tokenHash');
+    expect(res.body.data[0]).not.toHaveProperty('token_hash');
+  });
+
+  it('requires authentication', async () => {
+    const repo = new MockRefreshTokenRepository([]);
+    const app = express();
+    app.use(requestIdMiddleware);
+    app.use(express.json());
+    app.use('/api/refresh-token', createRefreshTokenRouter({ refreshTokenRepository: repo }));
+    app.use(errorHandler);
+
+    const res = await request(app).get('/api/refresh-token');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an invalid cursor with a standardized validation error', async () => {
+    const repo = new MockRefreshTokenRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token?cursor=not-a-valid-cursor').set(authHeader);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'query.cursor' }),
+      ]),
+    );
+  });
+
+  it('rejects a non-numeric limit', async () => {
+    const repo = new MockRefreshTokenRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token?limit=abc').set(authHeader);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'query.limit' }),
+      ]),
+    );
+  });
+
+  it('rejects a limit below 1', async () => {
+    const repo = new MockRefreshTokenRepository([]);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token?limit=0').set(authHeader);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('clamps limit to maximum of 100', async () => {
+    const tokens: RefreshToken[] = [];
+    for (let i = 0; i < 150; i++) {
+      const month = Math.floor(i / 28) + 6;
+      const day = (i % 28) + 1;
+      tokens.push(
+        makeToken({
+          id: `token-${i}`,
+          createdAt: new Date(`2026-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T10:00:00.000Z`),
+        }),
+      );
+    }
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token?limit=1000').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(100);
+    expect(res.body.meta.limit).toBe(100);
+  });
+
+  it('uses default limit of 20 when not specified', async () => {
+    const tokens: RefreshToken[] = [];
+    for (let i = 0; i < 25; i++) {
+      const month = Math.floor(i / 28) + 6;
+      const day = (i % 28) + 1;
+      tokens.push(
+        makeToken({
+          id: `token-${i}`,
+          createdAt: new Date(`2026-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T10:00:00.000Z`),
+        }),
+      );
+    }
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(20);
+    expect(res.body.meta.limit).toBe(20);
+    expect(res.body.meta.hasMore).toBe(true);
+  });
+
+  it('returns correct token fields in the response', async () => {
+    const tokens = [
+      makeToken({
+        id: 'token-1',
+        expiresAt: new Date('2026-12-31T23:59:59.999Z'),
+        createdAt: new Date('2026-06-01T10:00:00.000Z'),
+        lastUsedAt: new Date('2026-06-02T10:00:00.000Z'),
+        isRevoked: false,
+        familyId: 'family-abc',
+      }),
+    ];
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0]).toEqual({
+      id: 'token-1',
+      expiresAt: '2026-12-31T23:59:59.999Z',
+      createdAt: '2026-06-01T10:00:00.000Z',
+      lastUsedAt: '2026-06-02T10:00:00.000Z',
+      isRevoked: false,
+      familyId: 'family-abc',
+    });
+  });
+
+  it('handles tokens with null lastUsedAt', async () => {
+    const tokens = [
+      makeToken({
+        id: 'token-1',
+        lastUsedAt: undefined,
+      }),
+    ];
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].lastUsedAt).toBeNull();
+  });
+
+  it('only returns tokens for the authenticated user', async () => {
+    const tokens = [
+      makeToken({ id: 'token-1', userId: USER_ID }),
+      makeToken({ id: 'token-2', userId: 'other-user' }),
+      makeToken({ id: 'token-3', userId: USER_ID }),
+    ];
+    const repo = new MockRefreshTokenRepository(tokens);
+    const app = buildApp(repo);
+
+    const res = await request(app).get('/api/refresh-token').set(authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data.map((t: { id: string }) => t.id)).toEqual(['token-3', 'token-1']);
+  });
+
+  it('logs the request with correlation ID', async () => {
+    const repo = new MockRefreshTokenRepository([makeToken()]);
+    const app = buildApp(repo);
+
+    await request(app).get('/api/refresh-token?limit=5').set(authHeader);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'LIST_REFRESH_TOKENS',
+      expect.objectContaining({
+        userId: USER_ID,
+        limit: 5,
+        count: 1,
+        hasMore: false,
+      }),
+    );
+  });
+});

--- a/src/routes/refresh-token.ts
+++ b/src/routes/refresh-token.ts
@@ -1,0 +1,162 @@
+/**
+ * Refresh token listing endpoint with cursor-based pagination.
+ *
+ * Route:
+ *   GET /api/refresh-token
+ *
+ * Pagination uses stable keyset ordering over (created_at DESC, id DESC).
+ * The opaque `cursor` query param encodes the last row's timestamp and id,
+ * ensuring consistent results even under concurrent writes.
+ *
+ * Security:
+ *   - Requires authentication (Bearer JWT or x-user-id header)
+ *   - Only returns tokens belonging to the authenticated user
+ *   - Token hashes are never exposed in the response
+ */
+
+import { Router } from 'express';
+import { requireAuth } from '../middleware/requireAuth.js';
+import { getClientIp, DEFAULT_PROXY_HEADERS } from '../lib/clientIp.js';
+import { encodeCursor, parseCursor } from '../lib/cursorPagination.js';
+import {
+  cursorPaginatedResponse,
+  parseCursorPagination,
+} from '../lib/pagination.js';
+import {
+  AppError,
+  InternalServerError,
+  UnauthorizedError,
+} from '../errors/index.js';
+import { ValidationError } from '../middleware/validate.js';
+import { logger } from '../logger.js';
+import { getRequestId } from '../utils/asyncContext.js';
+import type { RefreshTokenRepository } from '../repositories/refreshTokenRepository.js';
+import { DatabaseRefreshTokenRepository } from '../repositories/refreshTokenRepository.js';
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+export interface RefreshTokenRouterDeps {
+  refreshTokenRepository?: RefreshTokenRepository;
+}
+
+export function createRefreshTokenRouter(deps: RefreshTokenRouterDeps = {}): Router {
+  const router = Router();
+  const refreshTokenRepository = deps.refreshTokenRepository ?? new DatabaseRefreshTokenRepository();
+
+  /**
+   * GET /api/refresh-token
+   *
+   * Lists refresh tokens for the authenticated user with cursor-based pagination.
+   *
+   * Query parameters:
+   *   limit  - Page size (1-100, default 20)
+   *   cursor - Opaque cursor from a previous response's `meta.nextCursor`
+   *
+   * Response shape:
+   *   {
+   *     "success": true,
+   *     "data": [
+   *       {
+   *         "id": "uuid",
+   *         "expiresAt": "2026-...",
+   *         "createdAt": "2026-...",
+   *         "lastUsedAt": "2026-..." | null,
+   *         "isRevoked": false,
+   *         "familyId": "uuid"
+   *       }
+   *     ],
+   *     "meta": {
+   *       "limit": 20,
+   *       "hasMore": true,
+   *       "nextCursor": "..."
+   *     },
+   *     "requestId": "...",
+   *     "timestamp": "2026-..."
+   *   }
+   */
+  router.get('/', requireAuth, async (req, res, next) => {
+    const requestId = getRequestId();
+    const userId = req.developerId || res.locals.authenticatedUser?.id;
+
+    if (!userId) {
+      next(new UnauthorizedError('User not authenticated', 'NOT_AUTHENTICATED'));
+      return;
+    }
+
+    try {
+      const { limit, cursor: rawCursor } = parseCursorPagination(
+        req.query as Record<string, string>,
+      );
+
+      let afterCursor;
+      if (rawCursor !== undefined) {
+        afterCursor = parseCursor(rawCursor);
+        if (!afterCursor) {
+          throw new ValidationError([
+            {
+              field: 'query.cursor',
+              message: 'Invalid cursor format. Must be a base64-encoded cursor from a previous response.',
+              code: 'INVALID_VALUE',
+            },
+          ]);
+        }
+      }
+
+      const { tokens, hasMore } = await refreshTokenRepository.listRefreshTokens(
+        userId,
+        limit,
+        afterCursor,
+      );
+
+      const nextCursor =
+        hasMore && tokens.length > 0
+          ? encodeCursor(
+              new Date(tokens[tokens.length - 1]!.createdAt),
+              tokens[tokens.length - 1]!.id,
+            )
+          : undefined;
+
+      // Map to response DTO — never expose token_hash
+      const data = tokens.map((token) => ({
+        id: token.id,
+        expiresAt: token.expiresAt.toISOString(),
+        createdAt: token.createdAt.toISOString(),
+        lastUsedAt: token.lastUsedAt ? token.lastUsedAt.toISOString() : null,
+        isRevoked: token.isRevoked,
+        familyId: token.familyId,
+      }));
+
+      logger.info('LIST_REFRESH_TOKENS', {
+        userId,
+        clientIp: getClientIp(req, TRUST_PROXY, DEFAULT_PROXY_HEADERS),
+        userAgent: req.get('User-Agent'),
+        correlationId: requestId,
+        limit,
+        cursorProvided: rawCursor !== undefined,
+        count: data.length,
+        hasMore,
+      });
+
+      res.json(
+        cursorPaginatedResponse(data, {
+          limit,
+          hasMore,
+          nextCursor,
+        }),
+      );
+    } catch (error) {
+      if (error instanceof AppError || error instanceof ValidationError) {
+        next(error);
+        return;
+      }
+      logger.error('Failed to list refresh tokens', {
+        error,
+        userId,
+        correlationId: requestId,
+      });
+      next(new InternalServerError('Failed to list refresh tokens'));
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
Closes #766

## Summary

This PR implements cursor-based pagination on the `GET /api/refresh-token` endpoint using stable keyset ordering over `(created_at, id)` for consistent results under concurrent writes.

This is a backend issue for the GrantFox FWC26 campaign (Stellar Wave).

## Changes

### New endpoint: `GET /api/refresh-token`

Lists refresh tokens for the authenticated user with cursor-based pagination.

**Query parameters:**
- `limit` (integer, 1-100, default 20): Page size
- `cursor` (string): Opaque cursor from a previous response's `meta.nextCursor`

**Response shape:**
```json
{
  success: true,
  data: [
    {
      id: uuid,
      expiresAt: 2026-12-31T23:59:59.999Z,
      createdAt: 2026-06-01T10:00:00.000Z,
      lastUsedAt: 2026-06-02T10:00:00.000Z | null,
      isRevoked: false,
      familyId: uuid
    }
  ],
  meta: {
    limit: 20,
    hasMore: true,
    nextCursor: ...
  },
  requestId: ...,
  timestamp: 2026-...
}
```

### Repository changes

- Added `listRefreshTokens` method to `RefreshTokenRepository` interface and `DatabaseRefreshTokenRepository` implementation
- Uses PostgreSQL row value comparison `(created_at, id) < (, )` for stable keyset pagination
- Fetches one extra row to determine if there are more results

### Security

- Requires authentication (Bearer JWT or x-user-id header)
- Only returns tokens belonging to the authenticated user
- Token hashes (`token_hash`) are never exposed in the response
- Input validation at the boundary with standardized error envelope
- Structured logging with correlation IDs

### Tests

15 focused tests covering:
- First page with nextCursor when more results exist
- Empty page without nextCursor when no tokens exist
- Last page without nextCursor when all results fit
- Cursor-based pagination across multiple pages
- Token hash never exposed in response
- Authentication required
- Invalid cursor validation error
- Non-numeric limit validation error
- Limit below 1 validation error
- Limit clamping to maximum of 100
- Default limit of 20
- Correct token fields in response
- Null lastUsedAt handling
- User isolation (only returns tokens for authenticated user)
- Structured logging with correlation ID

### Documentation

- API documentation in `docs/refresh-token-endpoint.md`
- Inline documentation in route file

## Testing

All 15 tests pass. Lint passes with no errors.

```bash
npx jest --runInBand --forceExit src/routes/refresh-token.test.ts
npx eslint src/routes/refresh-token.ts src/routes/refresh-token.test.ts
```

## Files changed

- `src/routes/refresh-token.ts` (new) - Route implementation
- `src/routes/refresh-token.test.ts` (new) - Test suite
- `src/repositories/refreshTokenRepository.ts` (modified) - Added `listRefreshTokens` method
- `src/routes/index.ts` (modified) - Mounted the new route
- `docs/refresh-token-endpoint.md` (new) - API documentation