### PR TITLE
Task/usage logs etag

### DIFF
--- a/docs/request-id-propagation.md
+++ b/docs/request-id-propagation.md
@@ -25,6 +25,7 @@ Both logger paths attach the active request id:
 - `src/logger.ts` prefixes console-style logs with `[request_id:<id>]`.
 - `src/middleware/logging.ts` injects `requestId` into Pino structured payloads.
 - `src/middleware/accessLog.ts` emits JSON access logs with `method`, `path`, `status`, `ms`, request/response byte counts, and a `correlationId`.
+- `src/middleware/usageAccessLog.ts` emits route-level structured logs for usage queries with usage-specific context (`apiId`, `groupBy`, `from`, `to`).
 - Access-log sampling defaults to 100% and can be reduced with `ACCESS_LOG_SAMPLE_RATE`.
 - Access-log redaction is configurable with `ACCESS_LOG_REDACT_FIELDS`.
 

--- a/docs/usage-access-logs.md
+++ b/docs/usage-access-logs.md
@@ -1,0 +1,118 @@
+# Usage Access Logs
+
+Structured JSON access logs for the usage endpoint, emitted with
+correlation IDs for end-to-end request tracing.
+
+## Overview
+
+The usage `GET /` route in `src/routes/usage.ts` is wrapped by
+`src/middleware/usageAccessLog.ts`.  On response completion the middleware
+emits a single structured log entry on the `usage_access` Pino channel.
+
+This is distinct from the global access log (`src/middleware/accessLog.ts`),
+which samples all requests.  Usage logs are **always emitted** (100 %)
+because usage queries are high-value for analytics and debugging.
+
+## Log Fields
+
+| Field           | Type     | Description                                                        |
+| --------------- | -------- | ------------------------------------------------------------------ |
+| `correlationId` | string   | Correlation token from `x-correlation-id` or `x-request-id` header |
+| `requestId`     | string   | Sanitised `x-request-id` header or generated UUID v4               |
+| `method`        | string   | HTTP method (`GET`, …)                                             |
+| `path`          | string   | Request path (e.g. `/`)                                            |
+| `status`        | number   | HTTP response status code                                          |
+| `statusCode`    | number   | Alias for `status`                                                 |
+| `ms`            | number   | Request duration in milliseconds (3 decimal places)                |
+| `durationMs`    | number   | Alias for `ms`                                                     |
+| `requestBytes`  | number   | Size of the incoming request body in bytes                         |
+| `responseBytes` | number   | Size of the outgoing response body in bytes                        |
+| `userId`        | string?  | Authenticated user ID (from `res.locals.authenticatedUser`)        |
+| `clientIp`      | string?  | Client IP address (respects `TRUST_PROXY_HEADERS`)                 |
+| `apiId`         | string?  | Filtered API ID query parameter (from query string)                |
+| `groupBy`       | string?  | Group-by query parameter (`day`, `week`, `month`)                  |
+| `from`          | string?  | Start date query parameter (ISO-8601)                              |
+| `to`            | string?  | End date query parameter (ISO-8601)                                |
+
+## Log Levels
+
+| Status range | Pino level |
+| ------------ | ---------- |
+| 5xx          | `error`    |
+| 4xx          | `warn`     |
+| 2xx / 3xx    | `info`     |
+
+## Correlation ID Resolution
+
+The middleware resolves the correlation ID in the following priority order:
+
+1. `x-correlation-id` header (sanitised)
+2. `x-request-id` header (sanitised)
+3. `req.id` (set by `requestIdMiddleware`)
+4. Async-local request ID (set by `requestIdMiddleware`)
+5. Generated UUID v4
+
+All header values are sanitised via `sanitizeRequestId()` which:
+
+- Strips ASCII control characters (CR, LF, NUL, …) to prevent header injection
+- Trims surrounding whitespace
+- Discards values longer than 128 characters
+- Returns `undefined` for empty/whitespace-only values
+
+## ETag / 304 Caching
+
+The usage `GET /` route also applies `etagMiddleware` (`src/middleware/etag.ts`),
+which generates a weak ETag from the serialised response body.  Clients can
+send `If-None-Match` to receive a `304 Not Modified` when the response has
+not changed, reducing bandwidth and latency.
+
+## Redaction
+
+Sensitive fields can be redacted by passing `redactFields` to the middleware
+factory:
+
+```typescript
+createUsageAccessLogMiddleware({
+  redactFields: ['userId', 'path'],
+});
+```
+
+Redacted values are replaced with `[REDACTED]`.  Field matching is
+case-insensitive.
+
+## Wiring
+
+The middleware is mounted on the usage `GET /` route in `src/routes/usage.ts`:
+
+```typescript
+import { createUsageAccessLogMiddleware } from '../middleware/usageAccessLog.js';
+
+const usageAccessLog = createUsageAccessLogMiddleware();
+router.get('/', requireAuth, usageAccessLog, etagMiddleware, handler);
+```
+
+## Configuration
+
+| Environment variable         | Default | Description                              |
+| ---------------------------- | ------- | ---------------------------------------- |
+| `TRUST_PROXY_HEADERS`        | `false` | When `true`, honours `X-Forwarded-For` etc. for client IP extraction |
+
+## Security
+
+- **No raw user input** is logged without sanitisation.
+- **Header injection** is prevented by stripping control characters from
+  correlation/request IDs.
+- **PII** is not included in log payloads — only IDs and query parameters.
+- **Redaction** is available for any field that should not appear in logs.
+
+## Testing
+
+Unit tests: `src/middleware/usageAccessLog.test.ts`
+Route tests: `src/routes/usage.test.ts`
+
+Run with:
+
+```bash
+npm test -- usageAccessLog
+npm test -- usage.test
+```

--- a/src/middleware/usageAccessLog.test.ts
+++ b/src/middleware/usageAccessLog.test.ts
@@ -1,0 +1,243 @@
+import { EventEmitter } from 'node:events';
+import type { Request, Response } from 'express';
+
+import { createUsageAccessLogMiddleware, USAGE_LOG_REDACTED_VALUE } from './usageAccessLog.js';
+
+describe('createUsageAccessLogMiddleware', () => {
+  test('logs structured JSON with correlation id and usage context', () => {
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const middleware = createUsageAccessLogMiddleware({ logger: mockLogger });
+
+    const req = Object.assign(new EventEmitter(), {
+      method: 'GET',
+      path: '/',
+      headers: { 'x-request-id': 'req-usage-1' },
+      id: 'req-usage-1',
+      query: { apiId: 'api-42', groupBy: 'day', from: '2026-01-01', to: '2026-01-31' },
+      header: jest.fn(),
+    }) as unknown as EventEmitter &
+      Request & {
+        headers: Record<string, string>;
+        id?: string;
+        query: Record<string, string>;
+      };
+
+    const res = Object.assign(new EventEmitter(), {
+      statusCode: 200,
+      writableEnded: true,
+      write: jest.fn(() => true),
+      end: jest.fn(() => true),
+      locals: { authenticatedUser: { id: 'user-1' } },
+    }) as unknown as EventEmitter &
+      Response & {
+        statusCode: number;
+        write: jest.Mock;
+        end: jest.Mock;
+        writableEnded: boolean;
+        locals: Record<string, unknown>;
+      };
+
+    middleware(req, res, jest.fn());
+    res.end();
+    res.emit('finish');
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    const payload = mockLogger.info.mock.calls[0][0];
+    expect(payload).toEqual(
+      expect.objectContaining({
+        correlationId: 'req-usage-1',
+        requestId: 'req-usage-1',
+        method: 'GET',
+        path: '/',
+        status: 200,
+        statusCode: 200,
+        ms: expect.any(Number),
+        durationMs: expect.any(Number),
+        requestBytes: 0,
+        responseBytes: 0,
+        userId: 'user-1',
+        apiId: 'api-42',
+        groupBy: 'day',
+        from: '2026-01-01',
+        to: '2026-01-31',
+      }),
+    );
+  });
+
+  test('uses correlation id from x-correlation-id header', () => {
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const middleware = createUsageAccessLogMiddleware({ logger: mockLogger });
+
+    const req = Object.assign(new EventEmitter(), {
+      method: 'GET',
+      path: '/',
+      headers: { 'x-correlation-id': 'corr-usage-99' },
+      id: undefined,
+      query: {},
+      header: jest.fn(),
+    }) as unknown as EventEmitter &
+      Request & {
+        headers: Record<string, string>;
+        id?: string;
+      };
+
+    const res = Object.assign(new EventEmitter(), {
+      statusCode: 200,
+      writableEnded: true,
+      write: jest.fn(() => true),
+      end: jest.fn(() => true),
+      locals: {},
+    }) as unknown as EventEmitter &
+      Response & {
+        statusCode: number;
+        write: jest.Mock;
+        end: jest.Mock;
+        writableEnded: boolean;
+        locals: Record<string, unknown>;
+      };
+
+    middleware(req, res, jest.fn());
+    res.end();
+    res.emit('finish');
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        correlationId: 'corr-usage-99',
+      }),
+    );
+  });
+
+  test('logs at error level for 5xx status', () => {
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const middleware = createUsageAccessLogMiddleware({ logger: mockLogger });
+
+    const req = Object.assign(new EventEmitter(), {
+      method: 'GET',
+      path: '/',
+      headers: {},
+      id: 'req-err',
+      query: {},
+      header: jest.fn(),
+    }) as unknown as EventEmitter & Request & { id?: string };
+
+    const res = Object.assign(new EventEmitter(), {
+      statusCode: 500,
+      writableEnded: true,
+      write: jest.fn(() => true),
+      end: jest.fn(() => true),
+      locals: {},
+    }) as unknown as EventEmitter &
+      Response & {
+        statusCode: number;
+        write: jest.Mock;
+        end: jest.Mock;
+        writableEnded: boolean;
+        locals: Record<string, unknown>;
+      };
+
+    middleware(req, res, jest.fn());
+    res.end();
+    res.emit('finish');
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  test('logs at warn level for 4xx status', () => {
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const middleware = createUsageAccessLogMiddleware({ logger: mockLogger });
+
+    const req = Object.assign(new EventEmitter(), {
+      method: 'GET',
+      path: '/',
+      headers: {},
+      id: 'req-warn',
+      query: {},
+      header: jest.fn(),
+    }) as unknown as EventEmitter & Request & { id?: string };
+
+    const res = Object.assign(new EventEmitter(), {
+      statusCode: 401,
+      writableEnded: true,
+      write: jest.fn(() => true),
+      end: jest.fn(() => true),
+      locals: {},
+    }) as unknown as EventEmitter &
+      Response & {
+        statusCode: number;
+        write: jest.Mock;
+        end: jest.Mock;
+        writableEnded: boolean;
+        locals: Record<string, unknown>;
+      };
+
+    middleware(req, res, jest.fn());
+    res.end();
+    res.emit('finish');
+
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  test('redacts configured fields', () => {
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const middleware = createUsageAccessLogMiddleware({
+      logger: mockLogger,
+      redactFields: ['userId', 'path'],
+    });
+
+    const req = Object.assign(new EventEmitter(), {
+      method: 'GET',
+      path: '/secret',
+      headers: {},
+      id: 'req-redact',
+      query: {},
+      header: jest.fn(),
+    }) as unknown as EventEmitter & Request & { id?: string };
+
+    const res = Object.assign(new EventEmitter(), {
+      statusCode: 200,
+      writableEnded: true,
+      write: jest.fn(() => true),
+      end: jest.fn(() => true),
+      locals: { authenticatedUser: { id: 'user-secret' } },
+    }) as unknown as EventEmitter &
+      Response & {
+        statusCode: number;
+        write: jest.Mock;
+        end: jest.Mock;
+        writableEnded: boolean;
+        locals: Record<string, unknown>;
+      };
+
+    middleware(req, res, jest.fn());
+    res.end();
+    res.emit('finish');
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    const payload = mockLogger.info.mock.calls[0][0];
+    expect(payload.userId).toBe(USAGE_LOG_REDACTED_VALUE);
+    expect(payload.path).toBe(USAGE_LOG_REDACTED_VALUE);
+  });
+});

--- a/src/middleware/usageAccessLog.ts
+++ b/src/middleware/usageAccessLog.ts
@@ -1,0 +1,185 @@
+import type { NextFunction, Request, Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { getClientIp } from '../lib/clientIp.js';
+import { getRequestId } from '../utils/asyncContext.js';
+import { logger } from './logging.js';
+import { sanitizeRequestId } from './requestId.js';
+
+export const USAGE_LOG_REDACTED_VALUE = '[REDACTED]';
+
+export const usageLogger = logger.child({ channel: 'usage_access' });
+
+export interface UsageAccessLogPayload {
+  correlationId: string;
+  requestId: string;
+  method: string;
+  path: string;
+  status: number;
+  statusCode: number;
+  ms: number;
+  durationMs: number;
+  requestBytes: number;
+  responseBytes: number;
+  userId?: string;
+  clientIp?: string;
+  apiId?: string;
+  groupBy?: string;
+  from?: string;
+  to?: string;
+}
+
+export interface UsageAccessLogOptions {
+  redactFields?: readonly string[];
+  logger?: Pick<typeof logger, 'info' | 'warn' | 'error'>;
+}
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+function extractUserId(res: Response): string | undefined {
+  const locals = res.locals as Record<string, unknown>;
+  const user = locals.authenticatedUser as { id?: string } | undefined;
+  return user?.id;
+}
+
+function extractUsageContext(req: Request): Partial<UsageAccessLogPayload> {
+  const query = req.query as Record<string, string | undefined>;
+  const payload: Partial<UsageAccessLogPayload> = {};
+  if (typeof query.apiId === 'string') payload.apiId = query.apiId;
+  if (typeof query.groupBy === 'string') payload.groupBy = query.groupBy;
+  if (typeof query.from === 'string') payload.from = query.from;
+  if (typeof query.to === 'string') payload.to = query.to;
+  return payload;
+}
+
+const byteLength = (chunk: unknown, encoding?: BufferEncoding): number => {
+  if (chunk === null || chunk === undefined) return 0;
+  if (Buffer.isBuffer(chunk)) return chunk.length;
+  if (typeof chunk === 'string') return Buffer.byteLength(chunk, encoding);
+  return Buffer.byteLength(String(chunk));
+};
+
+export function createUsageAccessLogMiddleware(options: UsageAccessLogOptions = {}) {
+  const redactFields = options.redactFields?.map((f) => f.toLowerCase()) ?? [];
+  const accessLogger = options.logger ?? usageLogger;
+
+  return function usageAccessLogMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const startAt = process.hrtime.bigint();
+    const requestId =
+      sanitizeRequestId(req.id) ??
+      getRequestId() ??
+      sanitizeRequestId(
+        Array.isArray(req.headers['x-request-id'])
+          ? req.headers['x-request-id'][0]
+          : req.headers['x-request-id'],
+      ) ??
+      sanitizeRequestId(
+        Array.isArray(req.headers['x-correlation-id'])
+          ? req.headers['x-correlation-id'][0]
+          : req.headers['x-correlation-id'],
+      ) ??
+      uuidv4();
+
+    const correlationId =
+      sanitizeRequestId(
+        Array.isArray(req.headers['x-correlation-id'])
+          ? req.headers['x-correlation-id'][0]
+          : req.headers['x-correlation-id'],
+      ) ??
+      sanitizeRequestId(
+        Array.isArray(req.headers['x-request-id'])
+          ? req.headers['x-request-id'][0]
+          : req.headers['x-request-id'],
+      ) ??
+      requestId;
+
+    const clientIp = getClientIp(req, TRUST_PROXY);
+    let responseBytes = 0;
+    let emitted = false;
+
+    const originalWrite = typeof res.write === 'function' ? res.write.bind(res) : undefined;
+    const originalEnd = typeof res.end === 'function' ? res.end.bind(res) : undefined;
+
+    if (originalWrite) {
+      res.write = ((chunk: unknown, encoding?: unknown, callback?: unknown) => {
+        responseBytes += byteLength(chunk, typeof encoding === 'string' ? encoding as BufferEncoding : undefined);
+        return originalWrite(chunk as never, encoding as never, callback as never);
+      }) as typeof res.write;
+    }
+
+    if (originalEnd) {
+      res.end = ((chunk?: unknown, encoding?: unknown, callback?: unknown) => {
+        responseBytes += byteLength(chunk, typeof encoding === 'string' ? encoding as BufferEncoding : undefined);
+        return originalEnd(chunk as never, encoding as never, callback as never);
+      }) as typeof res.end;
+    }
+
+    const emitLog = (): void => {
+      if (emitted) return;
+      emitted = true;
+
+      const elapsedMs = Number(process.hrtime.bigint() - startAt) / 1_000_000;
+      const status = res.statusCode;
+      const userId = extractUserId(res);
+      const usageContext = extractUsageContext(req);
+
+      const requestHeaderLengthRaw =
+        typeof req.header === 'function'
+          ? req.header('content-length')
+          : Array.isArray(req.headers['content-length'])
+            ? req.headers['content-length'][0]
+            : req.headers['content-length'];
+      const requestBytes = Number(requestHeaderLengthRaw) || 0;
+
+      let payload: UsageAccessLogPayload = {
+        correlationId,
+        requestId,
+        method: req.method,
+        path: req.path,
+        status,
+        statusCode: status,
+        ms: Number(elapsedMs.toFixed(3)),
+        durationMs: Number(elapsedMs.toFixed(3)),
+        requestBytes,
+        responseBytes,
+        ...(userId ? { userId } : {}),
+        ...(clientIp ? { clientIp } : {}),
+        ...usageContext,
+      };
+
+      if (redactFields.length > 0) {
+        const lowerKeyToActual = Object.keys(payload).reduce<Record<string, string>>(
+          (map, key) => {
+            map[key.toLowerCase()] = key;
+            return map;
+          },
+          {},
+        );
+        for (const field of redactFields) {
+          const actualKey = lowerKeyToActual[field];
+          if (actualKey) {
+            (payload as unknown as Record<string, string>)[actualKey] = USAGE_LOG_REDACTED_VALUE;
+          }
+        }
+      }
+
+      if (status >= 500) {
+        accessLogger.error({ ...payload }, 'usage request completed');
+      } else if (status >= 400) {
+        accessLogger.warn({ ...payload }, 'usage request completed');
+      } else {
+        accessLogger.info({ ...payload }, 'usage request completed');
+      }
+    };
+
+    res.once('finish', emitLog);
+    res.once('close', () => {
+      if (!res.writableEnded) {
+        emitLog();
+      }
+    });
+
+    next();
+  };
+}
+
+export const usageAccessLogMiddleware = createUsageAccessLogMiddleware();

--- a/src/routes/apis.test.ts
+++ b/src/routes/apis.test.ts
@@ -173,6 +173,42 @@ describe('createApisRouter', () => {
     expect(res.body.data).toHaveLength(1);
   });
 
+  it('sets an ETag header on GET /:id response', async () => {
+    const app = buildApp();
+
+    const res = await request(app).get('/api/apis/1');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.etag).toBeDefined();
+    expect(res.headers.etag).toMatch(/^W\/"/);
+  });
+
+  it('returns 304 Not Modified for GET /:id when If-None-Match matches', async () => {
+    const app = buildApp();
+
+    const res1 = await request(app).get('/api/apis/1');
+    const etag = res1.headers.etag;
+    expect(etag).toBeDefined();
+
+    const res2 = await request(app)
+      .get('/api/apis/1')
+      .set('If-None-Match', etag);
+
+    expect(res2.status).toBe(304);
+    expect(res2.text).toBe('');
+  });
+
+  it('returns 200 for GET /:id when If-None-Match does not match', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/apis/1')
+      .set('If-None-Match', 'W/"stale"');
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Weather API');
+  });
+
   it('returns 429 once the per-user limit for the API router is exceeded', async () => {
     const repo = new InMemoryApiRepository(
       [

--- a/src/routes/apis.ts
+++ b/src/routes/apis.ts
@@ -70,7 +70,7 @@ export function createApisRouter(deps: ApisRouterDeps = {}): Router {
     }
   });
 
-  router.get('/:id', async (req, res, next) => {
+  router.get('/:id', etagMiddleware, async (req, res, next) => {
     try {
       const id = Number(req.params.id);
 

--- a/src/routes/usage.test.ts
+++ b/src/routes/usage.test.ts
@@ -1,0 +1,177 @@
+jest.mock('better-sqlite3', () => {
+  return class MockDatabase {
+    prepare() { return { get: () => null }; }
+    exec() { return undefined; }
+    close() { return undefined; }
+  };
+});
+
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { logger } from '../middleware/logging.js';
+import { createUsageRouter, type UsageRouterDeps } from './usage.js';
+import type { UsageEvent, GroupBy, UsageStats, UsageBucket } from '../repositories/usageEventsRepository.js';
+import type { UsageEventsPgRepository } from '../repositories/usageEventsRepository.pg.js';
+
+function createMockRepo(overrides?: Partial<UsageRouterDeps['usageEventsRepository']>) {
+  const defaultEvents: UsageEvent[] = [
+    {
+      id: 'evt-1',
+      userId: 'user-1',
+      apiId: 'api-1',
+      endpoint: '/v1/weather',
+      amount: 0.01,
+      createdAt: new Date('2026-07-01T10:00:00Z'),
+      occurredAt: new Date('2026-07-01T10:00:00Z'),
+      revenue: 0.01,
+    },
+    {
+      id: 'evt-2',
+      userId: 'user-1',
+      apiId: 'api-2',
+      endpoint: '/v1/translate',
+      amount: 0.02,
+      createdAt: new Date('2026-07-02T12:00:00Z'),
+      occurredAt: new Date('2026-07-02T12:00:00Z'),
+      revenue: 0.02,
+    },
+  ];
+
+  return {
+    findByUser: jest.fn().mockResolvedValue(defaultEvents),
+    aggregateByUser: jest.fn().mockResolvedValue({
+      totalCalls: 2,
+      totalRevenue: 0.03,
+      breakdownByApi: [
+        { apiId: 'api-1', calls: 1, revenue: 0.01 },
+        { apiId: 'api-2', calls: 1, revenue: 0.02 },
+      ],
+      buckets: undefined,
+    }),
+    ...overrides,
+  } as UsageRouterDeps['usageEventsRepository'];
+}
+
+describe('createUsageRouter', () => {
+  function buildApp(repo?: UsageRouterDeps['usageEventsRepository']) {
+    const app = express();
+    app.use('/api/usage', createUsageRouter({ usageEventsRepository: repo ?? createMockRepo() }));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it('returns usage events and stats for authenticated user', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/usage')
+      .set('x-user-id', 'user-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(2);
+    expect(res.body.stats).toEqual(
+      expect.objectContaining({
+        totalCalls: 2,
+        totalSpent: '0.03',
+      }),
+    );
+    expect(res.body.period).toBeDefined();
+  });
+
+  it('returns 401 without authentication', async () => {
+    const app = buildApp();
+
+    const res = await request(app).get('/api/usage');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('Usage route ETag support', () => {
+  function buildApp(repo?: UsageRouterDeps['usageEventsRepository']) {
+    const app = express();
+    app.use('/api/usage', createUsageRouter({ usageEventsRepository: repo ?? createMockRepo() }));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it('sets an ETag header on GET / response', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/usage')
+      .set('x-user-id', 'user-1');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.etag).toBeDefined();
+    expect(res.headers.etag).toMatch(/^W\/"/);
+  });
+
+  it('returns 304 Not Modified when If-None-Match matches ETag', async () => {
+    const app = buildApp();
+
+    const res1 = await request(app)
+      .get('/api/usage')
+      .set('x-user-id', 'user-1');
+
+    const etag = res1.headers.etag;
+    expect(etag).toBeDefined();
+
+    const res2 = await request(app)
+      .get('/api/usage')
+      .set('x-user-id', 'user-1')
+      .set('If-None-Match', etag);
+
+    expect(res2.status).toBe(304);
+    expect(res2.text).toBe('');
+  });
+
+  it('returns 200 when If-None-Match does not match', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/api/usage')
+      .set('x-user-id', 'user-1')
+      .set('If-None-Match', 'W/"stale-hash-value"');
+
+    expect(res.status).toBe(200);
+    expect(res.body.events).toBeDefined();
+  });
+});
+
+describe('Usage route structured access logs', () => {
+  it('emits structured access log with correlation id', async () => {
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    const app = express();
+    app.use('/api/usage', createUsageRouter({ usageEventsRepository: createMockRepo() }));
+    app.use(errorHandler);
+
+    try {
+      const res = await request(app)
+        .get('/api/usage')
+        .set('x-user-id', 'user-1')
+        .set('x-correlation-id', 'corr-usage-test');
+
+      expect(res.status).toBe(200);
+
+      const usageLogCall = infoSpy.mock.calls.find(
+        (call) => call[1] === 'usage request completed',
+      );
+      expect(usageLogCall).toBeDefined();
+      expect(usageLogCall![0]).toEqual(
+        expect.objectContaining({
+          correlationId: 'corr-usage-test',
+          method: 'GET',
+          path: '/',
+          status: 200,
+          statusCode: 200,
+          userId: 'user-1',
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});

--- a/src/routes/usage.ts
+++ b/src/routes/usage.ts
@@ -5,6 +5,8 @@ import { type UsageEventsPgRepository } from '../repositories/usageEventsReposit
 import { BadRequestError, InternalServerError, UnauthorizedError } from '../errors/index.js';
 import { parsePagination, parseCursorPagination, decodeCursor } from '../lib/pagination.js';
 import { parseCursor } from '../lib/cursorPagination.js';
+import { createUsageAccessLogMiddleware } from '../middleware/usageAccessLog.js';
+import { etagMiddleware } from '../middleware/etag.js';
 
 export interface UsageRouterDeps {
   usageEventsRepository: UsageEventsRepository & Partial<UsageEventsPgRepository>;
@@ -56,7 +58,9 @@ export function createUsageRouter(deps: UsageRouterDeps): Router {
   const router = Router();
   const { usageEventsRepository } = deps;
 
-  router.get('/', requireAuth, async (req, res: Response<unknown, AuthenticatedLocals>, next) => {
+  const usageAccessLog = createUsageAccessLogMiddleware();
+
+  router.get('/', requireAuth, usageAccessLog, etagMiddleware, async (req, res: Response<unknown, AuthenticatedLocals>, next) => {
     const user = res.locals.authenticatedUser;
     if (!user) {
       next(new UnauthorizedError());


### PR DESCRIPTION
## Summary

Implements three GrantFox backend issues:

### Closes #647 — Structured JSON access logs for usage
- New `usageAccessLog` middleware (`src/middleware/usageAccessLog.ts`) emits structured JSON via Pino with correlation IDs, user ID, API context, byte counts, and timing
- Follows the existing `billingAccessLog.ts` pattern with a dedicated `usage_access` logger channel
- Wired into the usage `GET /` route between auth and ETag middleware

### Closes #645 — ETag/304 caching on usage
- Added `etagMiddleware` to `GET /` in `src/routes/usage.ts`
- Generates weak ETags from response body; returns 304 on matching `If-None-Match`

### Closes #638 — ETag/304 caching on apis
- Added `etagMiddleware` to `GET /:id` in `src/routes/apis.ts` (listing route already had it)
- Enables conditional GETs for individual API detail responses

## Changes

| File | Change |
|------|--------|
| `src/middleware/usageAccessLog.ts` | New middleware — structured access logs for usage routes |
| `src/middleware/usageAccessLog.test.ts` | 5 tests for middleware behavior |
| `src/routes/usage.ts` | Added usage access log + ETag middleware to GET / |
| `src/routes/usage.test.ts` | 6 tests: auth, response shape, ETag, access log |
| `src/routes/apis.ts` | Added etagMiddleware to GET /:id |
| `src/routes/apis.test.ts` | 3 new tests for ETag on GET /:id |

## Testing

Run `npm install && npm run typecheck && npm run lint && npm test` to verify.