### PR TITLE
fix: wire configurable token-bucket rate limiter into /api/gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,16 @@ REST_RATE_LIMIT_WINDOW_MS=60000
 REST_RATE_LIMIT_MAX_REQUESTS=100
 WEBHOOK_SECRET_ROTATION_GRACE_MS=86400000
 
+# Per-API-key token-bucket rate limit for /api/gateway and /v1/call.
+# Each API key gets RATE_LIMIT_MAX_REQUESTS tokens per RATE_LIMIT_WINDOW_MS;
+# exceeding it returns 429 with a Retry-After header.
+# Set RATE_LIMIT_STORE=postgres to share bucket state across multiple
+# gateway instances instead of keeping it in-process memory.
+RATE_LIMIT_MAX_REQUESTS=5
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_STORE=memory
+RATE_LIMIT_PG_TABLE=gateway_rate_limit_buckets
+
 # -----------------------------------------------------------------------------
 # Billing concurrency control
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -362,6 +362,10 @@ For request-id validation, AsyncLocalStorage propagation, structured logging, an
 | `PROXY_TIMEOUT_MS` | No | `30000` | Proxy request timeout (ms) |
 | `REST_RATE_LIMIT_WINDOW_MS` | No | `60000` | Window length for REST API rate limiting (ms) |
 | `REST_RATE_LIMIT_MAX_REQUESTS` | No | `100` | Max REST API requests allowed per user/IP per window |
+| `RATE_LIMIT_MAX_REQUESTS` | No | `5` | Per-API-key token-bucket limit for `/api/gateway` and `/v1/call`; exceeding it returns `429` with `Retry-After` |
+| `RATE_LIMIT_WINDOW_MS` | No | `60000` | Token-bucket refill window for `RATE_LIMIT_MAX_REQUESTS` (ms) |
+| `RATE_LIMIT_STORE` | No | `memory` | `memory` or `postgres`. Use `postgres` to share bucket state across multiple gateway instances |
+| `RATE_LIMIT_PG_TABLE` | No | `gateway_rate_limit_buckets` | Table name used when `RATE_LIMIT_STORE=postgres` (auto-created) |
 | `CORS_ALLOWED_ORIGINS` | No | `http://localhost:5173` | Comma-separated allowed origins |
 | `SOROBAN_RPC_ENABLED` | No | `false` | Enable Soroban RPC health check |
 | `SOROBAN_RPC_URL` | If `SOROBAN_RPC_ENABLED=true` | — | Soroban RPC endpoint URL |

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -144,6 +144,60 @@ describe('env schema — REST rate limit config', () => {
   });
 });
 
+describe('env schema — gateway rate limit config', () => {
+  it('defaults gateway rate limit values when omitted', () => {
+    const result = envSchema.safeParse({ ...baseEnv });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.RATE_LIMIT_MAX_REQUESTS).toBe(5);
+      expect(result.data.RATE_LIMIT_WINDOW_MS).toBe(60_000);
+      expect(result.data.RATE_LIMIT_STORE).toBe('memory');
+      expect(result.data.RATE_LIMIT_PG_TABLE).toBe('gateway_rate_limit_buckets');
+    }
+  });
+
+  it('accepts explicit postgres store configuration', () => {
+    const result = envSchema.safeParse({
+      ...baseEnv,
+      RATE_LIMIT_MAX_REQUESTS: '50',
+      RATE_LIMIT_WINDOW_MS: '10000',
+      RATE_LIMIT_STORE: 'postgres',
+      RATE_LIMIT_PG_TABLE: 'custom_rate_limit_buckets',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.RATE_LIMIT_MAX_REQUESTS).toBe(50);
+      expect(result.data.RATE_LIMIT_WINDOW_MS).toBe(10_000);
+      expect(result.data.RATE_LIMIT_STORE).toBe('postgres');
+      expect(result.data.RATE_LIMIT_PG_TABLE).toBe('custom_rate_limit_buckets');
+    }
+  });
+
+  it('rejects a store value other than "memory" or "postgres"', () => {
+    const result = envSchema.safeParse({
+      ...baseEnv,
+      RATE_LIMIT_STORE: 'redis',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-positive RATE_LIMIT_MAX_REQUESTS', () => {
+    const result = envSchema.safeParse({
+      ...baseEnv,
+      RATE_LIMIT_MAX_REQUESTS: '0',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a table name with characters outside [A-Za-z0-9_]', () => {
+    const result = envSchema.safeParse({
+      ...baseEnv,
+      RATE_LIMIT_PG_TABLE: 'buckets; DROP TABLE users;',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe('env schema — revenue ledger indexer config', () => {
   it('defaults revenue ledger indexer values when omitted', () => {
     const result = envSchema.safeParse({ ...baseEnv });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -89,10 +89,17 @@ export const envSchema = z
     WEBHOOK_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().optional(),
     WEBHOOK_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().optional(),
     WEBHOOK_SECRET_ROTATION_GRACE_MS: z.coerce.number().int().positive().default(24 * 60 * 60 * 1000),
-    RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().optional(),
-    RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().optional(),
-    RATE_LIMIT_STORE: z.string().optional(),
-    RATE_LIMIT_PG_TABLE: z.string().optional(),
+    // Per-API-key token-bucket rate limit applied to /api/gateway and /v1/call.
+    RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(5),
+    RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
+    RATE_LIMIT_STORE: z.enum(["memory", "postgres"]).default("memory"),
+    RATE_LIMIT_PG_TABLE: z
+      .string()
+      .regex(
+        /^[a-z_][a-z0-9_]*$/i,
+        "RATE_LIMIT_PG_TABLE must contain only letters, numbers, and underscores",
+      )
+      .default("gateway_rate_limit_buckets"),
 
     // Login rate limiting (IP-based throttling for auth attempts)
     LOGIN_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(5),

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -77,6 +77,70 @@ describe('config validation', () => {
     });
   });
 
+  it('should expose gateway rate limiter defaults matching the current hardcoded behavior', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'test-secret';
+    process.env.ADMIN_API_KEY = 'test-admin-key';
+    process.env.METRICS_API_KEY = 'test-metrics-key';
+
+    let cfg:
+      | {
+          config: {
+            rateLimiter: {
+              maxRequests: number;
+              windowMs: number;
+              store: 'memory' | 'postgres';
+              postgresTable: string;
+            };
+          };
+        }
+      | undefined;
+    await jest.isolateModulesAsync(async () => {
+      cfg = await import('./index.js');
+    });
+
+    expect(cfg!.config.rateLimiter).toEqual({
+      maxRequests: 5,
+      windowMs: 60_000,
+      store: 'memory',
+      postgresTable: 'gateway_rate_limit_buckets',
+    });
+  });
+
+  it('should expose configured postgres-backed gateway rate limiter values', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'test-secret';
+    process.env.ADMIN_API_KEY = 'test-admin-key';
+    process.env.METRICS_API_KEY = 'test-metrics-key';
+    process.env.RATE_LIMIT_MAX_REQUESTS = '50';
+    process.env.RATE_LIMIT_WINDOW_MS = '10000';
+    process.env.RATE_LIMIT_STORE = 'postgres';
+    process.env.RATE_LIMIT_PG_TABLE = 'custom_rate_limit_buckets';
+
+    let cfg:
+      | {
+          config: {
+            rateLimiter: {
+              maxRequests: number;
+              windowMs: number;
+              store: 'memory' | 'postgres';
+              postgresTable: string;
+            };
+          };
+        }
+      | undefined;
+    await jest.isolateModulesAsync(async () => {
+      cfg = await import('./index.js');
+    });
+
+    expect(cfg!.config.rateLimiter).toEqual({
+      maxRequests: 50,
+      windowMs: 10_000,
+      store: 'postgres',
+      postgresTable: 'custom_rate_limit_buckets',
+    });
+  });
+
   it('should call process.exit(1) when required env vars are missing', async () => {
     // Remove fields that have no defaults — env.ts will fail to parse and call process.exit(1)
     delete process.env.JWT_SECRET;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,10 @@ import adminRouter from "./routes/admin.js";
 import { createUsageAnomaliesRouter } from "./routes/admin/usage/anomalies.js";
 import { defaultDeveloperRepository } from "./repositories/developerRepository.js";
 import { createBillingService } from "./services/billingService.js";
-import { createRateLimiter } from "./services/rateLimiter.js";
+import {
+  createConfiguredRateLimiter,
+  resolveRateLimiterConfig,
+} from "./services/rateLimiter.js";
 import { PgUsageEventsRepository } from "./repositories/usageEventsRepository.pg.js";
 import { createRevenueLedgerIndexerJob } from "./services/revenueLedgerIndexer.js";
 import { RevenueSettlementService } from "./services/revenueSettlementService.js";
@@ -130,7 +133,14 @@ if (isDirectExecution) {
   };
 
   const billing = createBillingService(MOCK_DEVELOPER_BALANCES);
-  const rateLimiter = createRateLimiter(5, 60_000); // 5 reqs per minute
+  // Per-API-key token-bucket rate limit shared by /api/gateway and /v1/call.
+  // Backed by Postgres (RATE_LIMIT_STORE=postgres) so the bucket state is
+  // consistent across multiple gateway instances; defaults to an in-memory
+  // store otherwise. See RATE_LIMIT_* in src/config/env.ts.
+  const rateLimiter = createConfiguredRateLimiter(
+    resolveRateLimiterConfig(config.rateLimiter),
+    pool,
+  );
   const usageStore = createPostgresUsageStore(pool);
   const settlementStore = createPostgresSettlementStore(pool);
   const usageEventsRepository = new PgUsageEventsRepository(pool);

--- a/src/services/rateLimiter.test.ts
+++ b/src/services/rateLimiter.test.ts
@@ -8,6 +8,7 @@ import {
   isPersistentRateLimiterStore,
   type PersistentRateLimiterPool,
   PostgresRateLimiterStore,
+  resolveRateLimiterConfig,
 } from './rateLimiter.js';
 
 type StoredBucket = {
@@ -596,6 +597,72 @@ describe('createConfiguredRateLimiter', () => {
     assert.equal(
       isPersistentRateLimiterStore(new PostgresRateLimiterStore(new MockPersistentPool())),
       true,
+    );
+  });
+});
+
+describe('resolveRateLimiterConfig', () => {
+  test('maps a memory store config without a tableName field', () => {
+    const result = resolveRateLimiterConfig({
+      maxRequests: 5,
+      windowMs: 60_000,
+      store: 'memory',
+      postgresTable: 'gateway_rate_limit_buckets',
+    });
+
+    assert.deepEqual(result, {
+      store: 'memory',
+      maxRequests: 5,
+      windowMs: 60_000,
+    });
+    assert.equal('tableName' in result, false);
+  });
+
+  test('maps a postgres store config, carrying postgresTable over as tableName', () => {
+    const result = resolveRateLimiterConfig({
+      maxRequests: 50,
+      windowMs: 10_000,
+      store: 'postgres',
+      postgresTable: 'custom_rate_limit_buckets',
+    });
+
+    assert.deepEqual(result, {
+      store: 'postgres',
+      maxRequests: 50,
+      windowMs: 10_000,
+      tableName: 'custom_rate_limit_buckets',
+    });
+  });
+
+  test('feeds directly into createConfiguredRateLimiter for the memory case', async () => {
+    const limiter = createConfiguredRateLimiter(
+      resolveRateLimiterConfig({
+        maxRequests: 1,
+        windowMs: 60_000,
+        store: 'memory',
+        postgresTable: 'gateway_rate_limit_buckets',
+      }),
+    );
+
+    assert.ok(limiter instanceof InMemoryRateLimiter);
+    assert.deepEqual(await limiter.check('resolve-config-key'), { allowed: true });
+    const second = await limiter.check('resolve-config-key');
+    assert.equal(second.allowed, false);
+    assert.ok((second.retryAfterMs ?? 0) > 0 && (second.retryAfterMs ?? 0) <= 60_000);
+  });
+
+  test('feeds directly into createConfiguredRateLimiter for the postgres case', () => {
+    assert.throws(
+      () =>
+        createConfiguredRateLimiter(
+          resolveRateLimiterConfig({
+            maxRequests: 5,
+            windowMs: 60_000,
+            store: 'postgres',
+            postgresTable: 'gateway_rate_limit_buckets',
+          }),
+        ),
+      /PostgreSQL pool is required/,
     );
   });
 });

--- a/src/services/rateLimiter.ts
+++ b/src/services/rateLimiter.ts
@@ -388,6 +388,39 @@ export function createRateLimiter(
   return new InMemoryRateLimiter(maxRequests, windowMs, tierPolicies);
 }
 
+export interface AppRateLimiterConfig {
+  maxRequests: number;
+  windowMs: number;
+  store: 'memory' | 'postgres';
+  postgresTable: string;
+}
+
+/**
+ * Translates the app-level `config.rateLimiter` shape (as produced by
+ * `src/config/index.ts` from RATE_LIMIT_* env vars) into the discriminated
+ * `RateLimiterConfig` expected by `createConfiguredRateLimiter`. Kept as a
+ * standalone pure function so the store/table wiring used by the gateway and
+ * proxy routes is unit-testable without booting the full server.
+ */
+export function resolveRateLimiterConfig(
+  config: AppRateLimiterConfig,
+): RateLimiterConfig {
+  if (config.store === 'postgres') {
+    return {
+      store: 'postgres',
+      maxRequests: config.maxRequests,
+      windowMs: config.windowMs,
+      tableName: config.postgresTable,
+    };
+  }
+
+  return {
+    store: 'memory',
+    maxRequests: config.maxRequests,
+    windowMs: config.windowMs,
+  };
+}
+
 export function createConfiguredRateLimiter(
   config: RateLimiterConfig,
   persistentPool?: PersistentRateLimiterPool,


### PR DESCRIPTION
## Summary

`/api/gateway` already enforces a per-API-key token-bucket rate limit (429 + `Retry-After`) via `gatewayRoutes.ts` — but `src/index.ts` was constructing it with a hardcoded `createRateLimiter(5, 60_000)` instead of the already-implemented `createConfiguredRateLimiter`. That meant the `RATE_LIMIT_MAX_REQUESTS` / `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_STORE` env vars — and Postgres-backed bucket persistence for multi-instance deployments — existed in `src/services/rateLimiter.ts` and `src/config/env.ts` but had zero effect at runtime. Git history shows this wiring existed in an earlier commit (`0252d81`) and was silently dropped by a later merge.

This PR restores the wiring end-to-end and makes the gateway's rate limit genuinely configurable and production-ready:

- `src/index.ts`: build the gateway/proxy rate limiter via `createConfiguredRateLimiter(resolveRateLimiterConfig(config.rateLimiter), pool)` instead of a hardcoded in-memory limiter with a fixed 5 req/min.
- `src/services/rateLimiter.ts`: add `resolveRateLimiterConfig()`, a small pure function that translates the app-level `config.rateLimiter` shape into the discriminated `RateLimiterConfig` the service expects (memory vs. postgres store), so the boundary logic is unit-testable independent of the server bootstrap.
- `src/config/env.ts`: tighten `RATE_LIMIT_STORE` to `z.enum(["memory", "postgres"])` and give `RATE_LIMIT_MAX_REQUESTS` / `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_PG_TABLE` explicit defaults (`5`, `60000`, `gateway_rate_limit_buckets`) so behavior is unchanged out of the box.
- `.env.example` / `README.md`: document the `RATE_LIMIT_*` env vars.

Behavior for anyone not setting these env vars is unchanged (still 5 requests/60s, in-memory, 429 + `Retry-After` on the gateway and `/v1/call`). Operators can now tune the limit or point it at Postgres via env vars without code changes.

Closes #739

## Test plan

- [x] `npx jest src/services/rateLimiter.test.ts src/config/env.test.ts src/config/index.test.ts` — 51/51 passing, including new coverage for `resolveRateLimiterConfig` and the `RATE_LIMIT_*` env/config defaults + validation.
- [x] `npx jest src/routes/gatewayRoutes.test.ts` — no new failures (7 pre-existing failures on `main`, unrelated to this change: a repo-wide error-envelope shape assertion mismatch — `res.body.code` vs. the actual `res.body.error.code` — that predates this branch).
- [x] `npx tsc --noEmit` on the changed files — no new type errors (2 pre-existing syntax errors in `src/controllers/authController.ts` predate this branch).
- [x] `npx eslint` on all changed files — clean.