### PR TITLE
feat: add per-user token-bucket rate limit on /api/billing/credits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,12 @@ REST_RATE_LIMIT_MAX_REQUESTS=100
 WEBHOOK_SECRET_ROTATION_GRACE_MS=86400000
 
 # -----------------------------------------------------------------------------
+# Credits endpoint token-bucket rate limiting (GET /api/billing/credits)
+# -----------------------------------------------------------------------------
+# CREDITS_RATE_LIMIT_CAPACITY=10      # Max burst size (default: 10)
+# CREDITS_RATE_LIMIT_REFILL_RATE=1    # Tokens per second (default: 1)
+
+# -----------------------------------------------------------------------------
 # Billing concurrency control
 # -----------------------------------------------------------------------------
 # Maximum concurrent billing deduct operations allowed per developer.

--- a/src/__tests__/billing-credits.test.ts
+++ b/src/__tests__/billing-credits.test.ts
@@ -1,36 +1,20 @@
-/**
- * Tests for /api/billing/credits endpoint
- * 
- * Test coverage:
- * - Authentication requirements
- * - GET requests with valid authentication
- * - Credits record creation for new users
- * - Credits record retrieval for existing users
- * - Error handling and edge cases
- */
-
 import express from 'express';
 import type { Application } from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 
-import creditsRouter from '../routes/billing/credits.js';
+import creditsRouter, { resetCreditsRateLimit } from '../routes/billing/credits.js';
 import { errorHandler } from '../middleware/errorHandler.js';
 import type { Credit } from '../db/schema.js';
 
-// Mock the credits repository
-const mockCreditsRepository = {
-  findByUserId: jest.fn(),
-  getOrCreateByUserId: jest.fn(),
-  updateBalance: jest.fn(),
-};
-
-// Mock the repository module
 jest.mock('../repositories/creditsRepository.ts', () => ({
-  defaultCreditsRepository: mockCreditsRepository,
+  defaultCreditsRepository: {
+    findByUserId: jest.fn(),
+    getOrCreateByUserId: jest.fn(),
+    updateBalance: jest.fn(),
+  },
 }));
 
-// Mock logger to prevent console noise during tests
 jest.mock('../logger.js', () => ({
   logger: {
     info: jest.fn(),
@@ -39,36 +23,40 @@ jest.mock('../logger.js', () => ({
     audit: jest.fn(),
   },
   getRequestId: jest.fn(),
-  runWithRequestContext: jest.fn((_, callback) => callback()),
+  runWithRequestContext: jest.fn((_: unknown, callback: () => void) => callback()),
 }));
+
+import { defaultCreditsRepository } from '../repositories/creditsRepository.js';
+
+const mockCreditsRepository = defaultCreditsRepository as {
+  findByUserId: jest.Mock;
+  getOrCreateByUserId: jest.Mock;
+  updateBalance: jest.Mock;
+};
 
 describe('GET /api/billing/credits', () => {
   let app: Application;
   const JWT_SECRET = 'test-secret-key-for-credits-endpoint';
   const TEST_USER_ID = 'test_user_123';
-  
+
   beforeAll(() => {
     process.env.JWT_SECRET = JWT_SECRET;
   });
 
   beforeEach(() => {
-    // Create Express app with credits router
     app = express();
     app.use(express.json());
     app.use('/api/billing/credits', creditsRouter);
     app.use(errorHandler);
 
-    // Reset all mocks before each test
     jest.clearAllMocks();
+    resetCreditsRateLimit();
   });
 
   afterAll(() => {
     delete process.env.JWT_SECRET;
   });
 
-  /**
-   * Helper to generate a valid JWT token for testing
-   */
   function generateToken(userId: string): string {
     return jwt.sign({ userId }, JWT_SECRET, { algorithm: 'HS256', expiresIn: '1h' });
   }
@@ -79,8 +67,10 @@ describe('GET /api/billing/credits', () => {
 
       expect(response.status).toBe(401);
       expect(response.body).toMatchObject({
-        code: 'UNAUTHORIZED',
-        message: expect.any(String),
+        error: {
+          code: 'UNAUTHORIZED',
+          message: expect.any(String),
+        },
       });
     });
 
@@ -91,7 +81,9 @@ describe('GET /api/billing/credits', () => {
 
       expect(response.status).toBe(401);
       expect(response.body).toMatchObject({
-        code: 'INVALID_AUTH_HEADER',
+        error: {
+          code: 'INVALID_AUTH_HEADER',
+        },
       });
     });
 
@@ -181,7 +173,7 @@ describe('GET /api/billing/credits', () => {
       const mockCredit: Credit = {
         id: 3,
         user_id: TEST_USER_ID,
-        balance_usdc: '0.0000001', // Testing 7 decimal precision
+        balance_usdc: '0.0000001',
         created_at: new Date('2024-01-15T10:00:00Z'),
         updated_at: new Date('2024-01-15T10:00:00Z'),
       };
@@ -201,7 +193,7 @@ describe('GET /api/billing/credits', () => {
       const mockCredit: Credit = {
         id: 4,
         user_id: TEST_USER_ID,
-        balance_usdc: '999999.9999999', // Large amount with max precision
+        balance_usdc: '999999.9999999',
         created_at: new Date('2024-01-15T10:00:00Z'),
         updated_at: new Date('2024-01-15T10:00:00Z'),
       };
@@ -230,7 +222,9 @@ describe('GET /api/billing/credits', () => {
 
       expect(response.status).toBe(500);
       expect(response.body).toMatchObject({
-        code: 'INTERNAL_SERVER_ERROR',
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+        },
       });
     });
 
@@ -243,7 +237,9 @@ describe('GET /api/billing/credits', () => {
 
       expect(response.status).toBe(400);
       expect(response.body).toMatchObject({
-        code: 'VALIDATION_ERROR',
+        error: {
+          code: 'VALIDATION_ERROR',
+        },
       });
     });
 
@@ -253,7 +249,7 @@ describe('GET /api/billing/credits', () => {
         id: 5,
         user_id: TEST_USER_ID,
         balance_usdc: '25.00',
-        created_at: null as unknown as Date, // Simulating missing timestamp
+        created_at: null as unknown as Date,
         updated_at: null as unknown as Date,
       };
 
@@ -266,7 +262,6 @@ describe('GET /api/billing/credits', () => {
       expect(response.status).toBe(200);
       expect(response.body.user_id).toBe(TEST_USER_ID);
       expect(response.body.balance_usdc).toBe('25.00');
-      // Should use current date when timestamps are missing
       expect(response.body.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(response.body.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
@@ -285,7 +280,6 @@ describe('GET /api/billing/credits', () => {
 
       mockCreditsRepository.getOrCreateByUserId.mockResolvedValue(mockCredit);
 
-      // Make multiple concurrent requests
       const requests = [
         request(app).get('/api/billing/credits').set('Authorization', `Bearer ${token}`),
         request(app).get('/api/billing/credits').set('Authorization', `Bearer ${token}`),
@@ -294,14 +288,114 @@ describe('GET /api/billing/credits', () => {
 
       const responses = await Promise.all(requests);
 
-      // All should succeed
       responses.forEach(response => {
         expect(response.status).toBe(200);
         expect(response.body.balance_usdc).toBe('75.25');
       });
 
-      // Repository should be called for each request
       expect(mockCreditsRepository.getOrCreateByUserId).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Rate Limiting', () => {
+    it('should allow requests within burst capacity', async () => {
+      const mockCredit: Credit = {
+        id: 10,
+        user_id: TEST_USER_ID,
+        balance_usdc: '50.00',
+        created_at: new Date('2024-01-15T10:00:00Z'),
+        updated_at: new Date('2024-01-15T10:00:00Z'),
+      };
+      mockCreditsRepository.getOrCreateByUserId.mockResolvedValue(mockCredit);
+
+      const responses = await Promise.all(
+        Array.from({ length: 10 }, () =>
+          request(app)
+            .get('/api/billing/credits')
+            .set('Authorization', `Bearer ${generateToken(TEST_USER_ID)}`),
+        ),
+      );
+
+      responses.forEach((response) => {
+        expect(response.status).toBe(200);
+      });
+    });
+
+    it('should return 429 when burst capacity is exceeded', async () => {
+      const token = generateToken(TEST_USER_ID);
+      const mockCredit: Credit = {
+        id: 11,
+        user_id: TEST_USER_ID,
+        balance_usdc: '50.00',
+        created_at: new Date('2024-01-15T10:00:00Z'),
+        updated_at: new Date('2024-01-15T10:00:00Z'),
+      };
+      mockCreditsRepository.getOrCreateByUserId.mockResolvedValue(mockCredit);
+
+      const promises = Array.from({ length: 12 }, () =>
+        request(app)
+          .get('/api/billing/credits')
+          .set('Authorization', `Bearer ${token}`),
+      );
+      const responses = await Promise.all(promises);
+
+      const successCount = responses.filter((r) => r.status === 200).length;
+      const rateLimitCount = responses.filter((r) => r.status === 429).length;
+
+      expect(successCount).toBe(10);
+      expect(rateLimitCount).toBe(2);
+    });
+
+    it('should return Retry-After header on rate limit', async () => {
+      const token = generateToken(TEST_USER_ID);
+      const mockCredit: Credit = {
+        id: 12,
+        user_id: TEST_USER_ID,
+        balance_usdc: '50.00',
+        created_at: new Date('2024-01-15T10:00:00Z'),
+        updated_at: new Date('2024-01-15T10:00:00Z'),
+      };
+      mockCreditsRepository.getOrCreateByUserId.mockResolvedValue(mockCredit);
+
+      const promises = Array.from({ length: 11 }, () =>
+        request(app)
+          .get('/api/billing/credits')
+          .set('Authorization', `Bearer ${token}`),
+      );
+      const responses = await Promise.all(promises);
+      const rateLimitedResponse = responses.find((r) => r.status === 429);
+
+      expect(rateLimitedResponse).toBeDefined();
+      expect(rateLimitedResponse!.headers['retry-after']).toBeDefined();
+      expect(rateLimitedResponse!.body.code).toBe('TOO_MANY_REQUESTS');
+      expect(rateLimitedResponse!.body.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    it('should track rate limits separately per user', async () => {
+      const mockCredit: Credit = {
+        id: 13,
+        user_id: 'any_user',
+        balance_usdc: '50.00',
+        created_at: new Date('2024-01-15T10:00:00Z'),
+        updated_at: new Date('2024-01-15T10:00:00Z'),
+      };
+      mockCreditsRepository.getOrCreateByUserId.mockResolvedValue(mockCredit);
+
+      const tokenA = generateToken('user-A');
+      const tokenB = generateToken('user-B');
+
+      const requestsA = Array.from({ length: 10 }, () =>
+        request(app).get('/api/billing/credits').set('Authorization', `Bearer ${tokenA}`),
+      );
+      const requestsB = Array.from({ length: 10 }, () =>
+        request(app).get('/api/billing/credits').set('Authorization', `Bearer ${tokenB}`),
+      );
+
+      const responsesA = await Promise.all(requestsA);
+      const responsesB = await Promise.all(requestsB);
+
+      responsesA.forEach((r) => expect(r.status).toBe(200));
+      responsesB.forEach((r) => expect(r.status).toBe(200));
     });
   });
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -98,6 +98,10 @@ export const envSchema = z
     LOGIN_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(5),
     LOGIN_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000), // 1 minute sliding window
 
+    // Credits endpoint token-bucket rate limiting
+    CREDITS_RATE_LIMIT_CAPACITY: z.coerce.number().int().positive().default(10),
+    CREDITS_RATE_LIMIT_REFILL_RATE: z.coerce.number().positive().default(1),
+
     // CORS
     CORS_ALLOWED_ORIGINS: z.string().default("http://localhost:5173"),
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -155,6 +155,11 @@ export const config = {
     maxRequests: env.LOGIN_RATE_LIMIT_MAX_REQUESTS,
   },
 
+  creditsRateLimit: {
+    capacity: env.CREDITS_RATE_LIMIT_CAPACITY,
+    refillRate: env.CREDITS_RATE_LIMIT_REFILL_RATE,
+  },
+
   rateLimiter: {
     maxRequests: env.RATE_LIMIT_MAX_REQUESTS,
     windowMs: env.RATE_LIMIT_WINDOW_MS,

--- a/src/middleware/rateLimit.test.ts
+++ b/src/middleware/rateLimit.test.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import request from 'supertest';
 import { errorHandler } from './errorHandler.js';
-import { createRateLimitMiddleware } from './rateLimit.js';
+import { createRateLimitMiddleware, TokenBucketRateLimiter, createTokenBucketRateLimitMiddleware } from './rateLimit.js';
 import { requireAuth, type AuthenticatedLocals } from './requireAuth.js';
 import { TEST_JWT_SECRET, signTestToken } from '../../tests/helpers/jwt.js';
 
@@ -76,5 +76,163 @@ describe('rateLimit middleware', () => {
 
     expect(response.status).toBe(429);
     expect(response.headers['retry-after']).toBe('60');
+  });
+});
+
+describe('TokenBucketRateLimiter', () => {
+  let now: number;
+
+  beforeEach(() => {
+    now = 100_000;
+  });
+
+  test('allows requests up to capacity', () => {
+    const limiter = new TokenBucketRateLimiter(3, 1);
+    expect(limiter.check('key', now)).toEqual({ allowed: true });
+    expect(limiter.check('key', now)).toEqual({ allowed: true });
+    expect(limiter.check('key', now)).toEqual({ allowed: true });
+  });
+
+  test('denies when tokens are exhausted', () => {
+    const limiter = new TokenBucketRateLimiter(2, 1);
+    limiter.check('key', now);
+    limiter.check('key', now);
+    const result = limiter.check('key', now);
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  test('refills tokens over time', () => {
+    const limiter = new TokenBucketRateLimiter(2, 1);
+    limiter.check('key', now);
+    limiter.check('key', now);
+    expect(limiter.check('key', now).allowed).toBe(false);
+
+    const result = limiter.check('key', now + 2000);
+    expect(result.allowed).toBe(true);
+  });
+
+  test('tracks buckets separately per key', () => {
+    const limiter = new TokenBucketRateLimiter(1, 1);
+    expect(limiter.check('user-a', now)).toEqual({ allowed: true });
+    expect(limiter.check('user-b', now)).toEqual({ allowed: true });
+    expect(limiter.check('user-a', now)).toEqual({ allowed: false, retryAfterMs: 1000 });
+    expect(limiter.check('user-b', now)).toEqual({ allowed: false, retryAfterMs: 1000 });
+  });
+
+  test('does not exceed capacity on refill', () => {
+    const limiter = new TokenBucketRateLimiter(3, 5);
+    limiter.check('key', now);
+    // After 10 seconds with refillRate=5, would add 50 tokens, but should cap at capacity=3
+    const result = limiter.check('key', now + 10_000);
+    expect(result.allowed).toBe(true);
+    // Should now have 2 tokens left (capacity - 1 after consuming)
+    expect(limiter.check('key', now + 10_000).allowed).toBe(true);
+    expect(limiter.check('key', now + 10_000).allowed).toBe(true);
+    expect(limiter.check('key', now + 10_000).allowed).toBe(false);
+  });
+
+  test('retryAfterMs is proportional to refill rate', () => {
+    const limiter = new TokenBucketRateLimiter(1, 2);
+    limiter.check('key', now);
+    const result = limiter.check('key', now);
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBe(500);
+  });
+
+  test('reset clears all buckets', () => {
+    const limiter = new TokenBucketRateLimiter(1, 1);
+    limiter.check('key-a', now);
+    limiter.check('key-b', now);
+    limiter.reset();
+    expect(limiter.check('key-a', now)).toEqual({ allowed: true });
+    expect(limiter.check('key-b', now)).toEqual({ allowed: true });
+  });
+
+  test('partial refill accumulates fractional tokens across multiple checks', () => {
+    const limiter = new TokenBucketRateLimiter(1, 0.5);
+    limiter.check('key', now);
+    // After 1 second with refillRate=0.5, only 0.5 tokens — not enough to consume
+    expect(limiter.check('key', now + 1000).allowed).toBe(false);
+    // After 2 seconds, 1.0 tokens — enough to consume
+    expect(limiter.check('key', now + 2000).allowed).toBe(true);
+    // Next immediate request fails (0 tokens remaining)
+    expect(limiter.check('key', now + 2000).allowed).toBe(false);
+  });
+});
+
+describe('token bucket rate limit middleware', () => {
+  const originalSecret = process.env.JWT_SECRET;
+
+  function buildTokenBucketApp(capacity = 3, refillRate = 1) {
+    const app = express();
+    const rateLimit = createTokenBucketRateLimitMiddleware({ capacity, refillRate });
+
+    app.get(
+      '/protected',
+      rateLimit,
+      requireAuth,
+      (_req, res: express.Response<unknown, AuthenticatedLocals>) => {
+        res.json({ ok: true, userId: res.locals.authenticatedUser?.id });
+      },
+    );
+
+    app.use(errorHandler);
+    return app;
+  }
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = TEST_JWT_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret !== undefined) {
+      process.env.JWT_SECRET = originalSecret;
+    } else {
+      delete process.env.JWT_SECRET;
+    }
+  });
+
+  test('returns 200 within burst capacity', async () => {
+    const app = buildTokenBucketApp(3, 1);
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+  });
+
+  test('returns 429 after burst capacity is exceeded', async () => {
+    const app = buildTokenBucketApp(2, 1);
+
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    const response = await request(app).get('/protected').set('x-user-id', 'user-1');
+
+    expect(response.status).toBe(429);
+    expect(response.headers['retry-after']).toBe('1');
+    expect(response.body.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  test('tracks limits separately per user', async () => {
+    const app = buildTokenBucketApp(2, 1);
+
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-2').expect(200);
+
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    await request(app).get('/protected').set('x-user-id', 'user-2').expect(200);
+
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(429);
+    await request(app).get('/protected').set('x-user-id', 'user-2').expect(429);
+  });
+
+  test('returns 429 with code TOO_MANY_REQUESTS', async () => {
+    const app = buildTokenBucketApp(1, 1);
+
+    await request(app).get('/protected').set('x-user-id', 'user-1').expect(200);
+    const response = await request(app).get('/protected').set('x-user-id', 'user-1');
+
+    expect(response.status).toBe(429);
+    expect(response.body.code).toBe('TOO_MANY_REQUESTS');
+    expect(response.body.message).toBe('Too Many Requests');
   });
 });

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -18,6 +18,100 @@ export interface RateLimitCheckResult {
   retryAfterMs?: number;
 }
 
+// ─── Token Bucket Rate Limiter ───────────────────────────────────────────────
+
+export interface TokenBucketOptions {
+  capacity: number;
+  refillRate: number;
+}
+
+interface TokenBucketState {
+  tokens: number;
+  lastRefill: number;
+}
+
+export class TokenBucketRateLimiter {
+  private readonly buckets = new Map<string, TokenBucketState>();
+
+  constructor(
+    private readonly capacity: number,
+    private readonly refillRate: number,
+  ) {}
+
+  check(key: string, now = Date.now()): RateLimitCheckResult {
+    const bucket = this.buckets.get(key);
+
+    if (!bucket) {
+      this.buckets.set(key, {
+        tokens: this.capacity - 1,
+        lastRefill: now,
+      });
+      return { allowed: true };
+    }
+
+    const elapsedMs = now - bucket.lastRefill;
+    if (elapsedMs > 0) {
+      const tokensToAdd = (elapsedMs / 1000) * this.refillRate;
+      bucket.tokens = Math.min(this.capacity, bucket.tokens + tokensToAdd);
+      bucket.lastRefill = now;
+    }
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return { allowed: true };
+    }
+
+    const retryAfterMs = Math.ceil((1000 / this.refillRate) * (1 - bucket.tokens));
+    return { allowed: false, retryAfterMs };
+  }
+
+  reset(): void {
+    this.buckets.clear();
+  }
+}
+
+export function createTokenBucketRateLimitMiddleware(
+  options: TokenBucketOptions,
+  limiter = new TokenBucketRateLimiter(options.capacity, options.refillRate),
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = getRateLimitKey(req);
+    const result = limiter.check(key);
+
+    if (!result.allowed) {
+      const retryAfterMs = result.retryAfterMs ?? 1000;
+      const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+      const requestId: string = (req as Request & { id?: string }).id ?? 'unknown';
+
+      logger.warn('[tokenBucketRateLimit] request limit exceeded', {
+        requestId,
+        key,
+        retryAfterMs,
+      });
+
+      res.set('Retry-After', String(retryAfterSeconds));
+      res.status(429).json({
+        code: 'TOO_MANY_REQUESTS',
+        message: 'Too Many Requests',
+        requestId,
+        retryAfterMs,
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+export function createCreditsRateLimitMiddleware(
+  options?: TokenBucketOptions,
+): RequestHandler {
+  const opts: TokenBucketOptions = options ?? { capacity: 10, refillRate: 1 };
+  return createTokenBucketRateLimitMiddleware(opts);
+}
+
+// ─── Fixed-Window Rate Limiter ───────────────────────────────────────────────
+
 export class InMemoryRateLimiter {
   private readonly buckets = new Map<string, RateLimitBucket>();
 

--- a/src/routes/billing/credits.ts
+++ b/src/routes/billing/credits.ts
@@ -7,8 +7,19 @@ import { requireAuth, type AuthenticatedLocals } from '../../middleware/requireA
 import { validate } from '../../middleware/validate.js';
 import { defaultCreditsRepository, type CreditsRepository } from '../../repositories/creditsRepository.js';
 import { logger } from '../../logger.js';
+import { TokenBucketRateLimiter, createTokenBucketRateLimitMiddleware } from '../../middleware/rateLimit.js';
 
 const router = Router();
+
+const creditsRateLimiter = new TokenBucketRateLimiter(10, 1);
+const creditsRateLimit = createTokenBucketRateLimitMiddleware(
+  { capacity: 10, refillRate: 1 },
+  creditsRateLimiter,
+);
+
+export function resetCreditsRateLimit(): void {
+  creditsRateLimiter.reset();
+}
 
 /**
  * Validation schema for query parameters
@@ -51,6 +62,7 @@ interface CreditsBalanceResponse {
  */
 router.get(
   '/',
+  creditsRateLimit,
   requireAuth,
   validate({ query: getCreditsQuerySchema }),
   async (


### PR DESCRIPTION
Implements TokenBucketRateLimiter middleware returning 429 + Retry-After when the per-user bucket is exhausted. Capacity=10, refillRate=1/s by default, configurable via CREDITS_RATE_LIMIT_CAPACITY and CREDITS_RATE_LIMIT_REFILL_RATE env vars.

Closes #709