### PR TITLE
Aafeat: wire per-key concurrency tracking into the gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,18 @@ BILLING_MAX_CONCURRENCY_PER_DEV=1
 BILLING_SEMAPHORE_TTL_MS=300000
 
 # -----------------------------------------------------------------------------
+# Gateway per-API-key concurrency
+# -----------------------------------------------------------------------------
+# Maximum simultaneous in-flight gateway requests per API key. The default is
+# deliberately generous: the counts primarily feed the admin visibility
+# endpoint (GET /api/admin/keys/concurrency). Lower this to enforce a cap —
+# requests beyond it fail fast with 429 rather than queueing.
+# See docs/per-key-concurrency.md
+KEY_MAX_CONCURRENCY_PER_KEY=50
+# How long an idle API key's concurrency state is kept in memory (ms).
+KEY_SEMAPHORE_TTL_MS=300000
+
+# -----------------------------------------------------------------------------
 # Idempotency cleanup
 # -----------------------------------------------------------------------------
 # How long idempotency cache entries are kept before they become eligible

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The migration is in `migrations/0019_disputes.sql` (rollback: `migrations/0019_d
 - Admin usage anomalies: `GET /api/admin/usage/anomalies` returns per-API daily usage anomalies (z-score spikes/drops) for admin review, filterable by `from`/`to`/`apiId`/`threshold`/`limit` (admin auth + IP allowlist)
 - Admin usage export: `GET /api/admin/usage/export` streams usage events as CSV or JSON for reporting, with optional `from`/`to`/`developerId`/`apiId`/`format` filters (admin auth + IP allowlist); see [docs/admin-usage-export.md](./docs/admin-usage-export.md)
 - Admin DB explain: `POST /api/admin/db/explain` runs `EXPLAIN (ANALYZE, FORMAT JSON)` on a read-only SQL query and returns the query plan for diagnostic use (admin auth + IP allowlist); see [docs/admin-db-explain.md](./docs/admin-db-explain.md)
+- Per-API-key concurrency: `GET /api/admin/keys/concurrency` (and `/:keyId`) report how many gateway requests each API key has in flight right now, with an optional per-key ceiling that fails fast with `429` (admin auth + IP allowlist); see [docs/per-key-concurrency.md](./docs/per-key-concurrency.md)
 - Usage anomaly detector: background worker emits `usage.anomaly.detected` when per-developer 5-minute traffic exceeds a rolling 12-window baseline by a configurable multiplier (see `docs/usage-anomaly-detector.md`)
 - Settlement reconciliation: nightly worker that reconciles DB settlement status with on-chain Horizon transaction data, detecting discrepancies like missing transactions, stale pending settlements, and false failures (see `docs/settlement-reconciliation-worker.md`)
 - Multi-region read-replica routing: optional round-robin routing of SELECT queries to PostgreSQL read replicas via `REPLICA_URLS`; writes always use the primary; automatic fallback to primary on replica failure (see [docs/replica-routing.md](./docs/replica-routing.md))
@@ -252,6 +253,8 @@ callora-backend/
 | `STELLAR_TRANSACTION_TIMEOUT` | Transaction timeout (seconds) | `30` |
 | `BILLING_MAX_CONCURRENCY_PER_DEV` | Max concurrent deducts per developer | `1` |
 | `BILLING_SEMAPHORE_TTL_MS` | Idle semaphore state TTL in ms | `300000` |
+| `KEY_MAX_CONCURRENCY_PER_KEY` | Max concurrent in-flight gateway requests per API key; beyond it requests fail fast with `429`. See [docs/per-key-concurrency.md](./docs/per-key-concurrency.md). | `50` |
+| `KEY_SEMAPHORE_TTL_MS` | Idle per-key concurrency state TTL in ms | `300000` |
 | `IDEMPOTENCY_SWEEPER_INTERVAL_MS` | Interval for periodic idempotency cleanup in milliseconds | `60000` |
 | `CIRCUIT_BREAKER_THRESHOLD` | Failures before opening circuit | `5` |
 | `CIRCUIT_BREAKER_COOLDOWN_MS` | Cooldown period (ms) | `30000` |

--- a/docs/per-key-concurrency.md
+++ b/docs/per-key-concurrency.md
@@ -1,0 +1,83 @@
+# Per-API-Key Concurrency
+
+Callora tracks how many gateway requests are in flight for each API key at any moment. The counts are exposed to operators through two admin endpoints, and the same signal can optionally be used to cap runaway keys.
+
+The unit of measurement is **concurrency** (requests in flight right now), not rate (requests per interval). A key making 1,000 fast sequential calls has a concurrency of 1; a key holding 20 slow upstream calls open has a concurrency of 20. Rate limiting is handled separately — see [tiered-rate-limits.md](./tiered-rate-limits.md).
+
+## How counts are collected
+
+`createPerKeyConcurrencyMiddleware` ([src/middleware/perKeyConcurrency.ts](../src/middleware/perKeyConcurrency.ts)) runs on the gateway proxy route, immediately after API-key authentication. For each authenticated request it acquires a slot on the shared `KeySemaphore` and holds it until the response emits `finish` or `close`. Client disconnects therefore release the slot just like normal completions.
+
+Requests are bucketed by the **API key record id**, never the raw key value, so no secret material reaches the stats endpoints or the audit log.
+
+Both the middleware and the admin routes read from the same `sharedKeySemaphore` singleton ([src/utils/keySemaphore.ts](../src/utils/keySemaphore.ts)). This is load-bearing: if either side constructed its own instance, the endpoints would report zero forever.
+
+Counts are per process and in memory. Across a multi-instance deployment each instance reports only the traffic it is serving, and all counts reset on restart. State for an idle key is evicted after `KEY_SEMAPHORE_TTL_MS`, so the map does not grow without bound.
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KEY_MAX_CONCURRENCY_PER_KEY` | `50` | Maximum simultaneous in-flight requests per API key |
+| `KEY_SEMAPHORE_TTL_MS` | `300000` | Idle time before a key's tracking state is evicted |
+
+The default ceiling is deliberately generous, so out of the box this feature is **observability only** — ordinary traffic never reaches the limit. Lowering `KEY_MAX_CONCURRENCY_PER_KEY` turns the same signal into enforcement.
+
+When a key is at its ceiling, further requests fail fast with `429` rather than queueing, so callers get an immediate back-off signal instead of tying up connections:
+
+```json
+{
+  "code": "TOO_MANY_REQUESTS",
+  "message": "Concurrency limit reached for this API key. Please retry your request.",
+  "requestId": "req-abc123"
+}
+```
+
+A rejected request never occupies a slot, so a saturated key cannot deepen its own backlog.
+
+## Endpoints
+
+Both routes live under `/api/admin` and require admin credentials — an `x-admin-api-key` header or `Authorization: Bearer <JWT>` with `role: admin`. The admin IP allowlist applies, and each read is written to the audit log with the actor, client IP, and correlation id.
+
+### `GET /api/admin/keys/concurrency`
+
+Snapshot of every key with at least one request in flight. Keys sitting at zero are omitted.
+
+```json
+{
+  "data": {
+    "keyCounts": { "key_abc": 2, "key_def": 1 },
+    "totalActive": 3,
+    "maxConcurrencyPerKey": 50,
+    "campaign": "GrantFox FWC26"
+  }
+}
+```
+
+An idle gateway returns an empty `keyCounts` object and a `totalActive` of `0`.
+
+### `GET /api/admin/keys/concurrency/:keyId`
+
+Detail for a single key. Unlike the collection endpoint, this reports keys with no active requests rather than omitting them, so polling a specific key is stable.
+
+```json
+{
+  "data": {
+    "keyId": "key_abc",
+    "activeCount": 2,
+    "atLimit": false,
+    "maxConcurrencyPerKey": 50,
+    "campaign": "GrantFox FWC26"
+  }
+}
+```
+
+`atLimit` is `activeCount >= maxConcurrencyPerKey` — the condition under which the next request for this key would receive a `429`.
+
+Note that a trailing slash (`/api/admin/keys/concurrency/`) resolves to the collection endpoint, not to this route with an empty `keyId`.
+
+## Operational notes
+
+- **A key pinned at its ceiling** is usually a slow upstream rather than an abusive caller. Check upstream latency and the circuit-breaker state for the affected API before lowering limits.
+- **`totalActive` tracking the instance's request volume** is expected; a value that stays high while throughput is flat suggests requests are not completing — look for upstream timeouts.
+- **Counts that stay at zero under real traffic** mean the middleware is no longer running after authentication on the proxy route, or a second `KeySemaphore` instance has been introduced.

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -234,6 +234,13 @@ export const envSchema = z
     BILLING_MAX_CONCURRENCY_PER_DEV: z.coerce.number().int().positive().default(1),
     BILLING_SEMAPHORE_TTL_MS: z.coerce.number().int().positive().default(300000),
 
+    // Gateway per-API-key concurrency control.
+    // The default ceiling is deliberately generous: the primary purpose is
+    // observability via GET /api/admin/keys/concurrency. Operators opt into
+    // enforcement by lowering KEY_MAX_CONCURRENCY_PER_KEY.
+    KEY_MAX_CONCURRENCY_PER_KEY: z.coerce.number().int().positive().default(50),
+    KEY_SEMAPHORE_TTL_MS: z.coerce.number().int().positive().default(300000),
+
     // Idempotency
     IDEMPOTENCY_RETENTION_WINDOW_SECONDS: z.coerce.number().int().positive().default(86400),
     IDEMPOTENCY_SWEEPER_INTERVAL_MS: z.coerce.number().int().positive().default(60_000),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -213,6 +213,10 @@ export const config = {
     maxPerDeveloper: env.BILLING_MAX_CONCURRENCY_PER_DEV,
     semaphoreTtlMs: env.BILLING_SEMAPHORE_TTL_MS,
   },
+  keyConcurrency: {
+    maxPerKey: env.KEY_MAX_CONCURRENCY_PER_KEY,
+    semaphoreTtlMs: env.KEY_SEMAPHORE_TTL_MS,
+  },
   routeBodyLimits: env.ROUTE_BODY_LIMITS,
   idempotency: {
     retentionWindowSeconds: env.IDEMPOTENCY_RETENTION_WINDOW_SECONDS,

--- a/src/middleware/perKeyConcurrency.test.ts
+++ b/src/middleware/perKeyConcurrency.test.ts
@@ -1,0 +1,242 @@
+import express from 'express';
+import request from 'supertest';
+
+import { createPerKeyConcurrencyMiddleware } from './perKeyConcurrency.js';
+import { KeySemaphore } from '../utils/keySemaphore.js';
+
+/**
+ * Stands in for the gateway API-key auth middleware, which is what populates
+ * `req.apiKeyRecord` in production. The key id is taken from a header so tests
+ * can simulate different keys.
+ */
+function fakeAuth(): express.RequestHandler {
+  return (req, _res, next) => {
+    const keyId = req.get('x-test-key-id');
+    if (keyId) {
+      req.apiKeyRecord = { id: keyId };
+    }
+    next();
+  };
+}
+
+function buildApp(
+  semaphore: KeySemaphore,
+  maxConcurrent: number,
+  delayMs = 0,
+): express.Express {
+  const app = express();
+  const perKeyConcurrency = createPerKeyConcurrencyMiddleware({ semaphore, maxConcurrent });
+
+  app.get('/v1/call/demo', fakeAuth(), perKeyConcurrency, (_req, res) => {
+    if (delayMs === 0) {
+      res.json({ ok: true });
+      return;
+    }
+    setTimeout(() => res.json({ ok: true }), delayMs);
+  });
+
+  return app;
+}
+
+/** Fires a request without awaiting it, so it can overlap with others. */
+function fireRequest(
+  app: express.Express,
+  keyId: string,
+): Promise<request.Response> {
+  return new Promise((resolve, reject) => {
+    request(app)
+      .get('/v1/call/demo')
+      .set('x-test-key-id', keyId)
+      .end((err, res) => (err ? reject(err) : resolve(res)));
+  });
+}
+
+describe('perKeyConcurrency middleware', () => {
+  let semaphore: KeySemaphore;
+
+  beforeEach(() => {
+    semaphore = new KeySemaphore(50, 1000);
+  });
+
+  afterEach(() => {
+    semaphore.clear();
+  });
+
+  describe('concurrency tracking', () => {
+    test('holds a slot on the shared semaphore while a request is in flight', async () => {
+      // This is the behaviour that makes the admin stats endpoint meaningful:
+      // without it, getCurrentActiveSlotCounts() is permanently empty.
+      const app = buildApp(semaphore, 50, 120);
+
+      const inFlight = fireRequest(app, 'key-tracked');
+      await new Promise((r) => setTimeout(r, 40));
+
+      expect(semaphore.getActiveSlotCount('key-tracked')).toBe(1);
+      expect(semaphore.getTotalActiveSlotCount()).toBe(1);
+      expect(semaphore.getCurrentActiveSlotCounts()).toEqual({ 'key-tracked': 1 });
+
+      await inFlight;
+    });
+
+    test('releases the slot once the response finishes', async () => {
+      const app = buildApp(semaphore, 50, 50);
+
+      const res = await fireRequest(app, 'key-release');
+      expect(res.status).toBe(200);
+
+      // Slot release happens on the 'finish' event; allow it to settle.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(semaphore.getActiveSlotCount('key-release')).toBe(0);
+    });
+
+    test('releases the slot for synchronous handlers', async () => {
+      // Regression guard: a handler that responds synchronously may emit
+      // 'finish' before the slot callback attaches its listeners.
+      const app = buildApp(semaphore, 50, 0);
+
+      for (let i = 0; i < 5; i++) {
+        const res = await fireRequest(app, 'key-sync');
+        expect(res.status).toBe(200);
+      }
+
+      await new Promise((r) => setTimeout(r, 30));
+      expect(semaphore.getActiveSlotCount('key-sync')).toBe(0);
+    });
+
+    test('counts concurrent requests for the same key', async () => {
+      const app = buildApp(semaphore, 50, 150);
+
+      const reqs = [
+        fireRequest(app, 'key-multi'),
+        fireRequest(app, 'key-multi'),
+        fireRequest(app, 'key-multi'),
+      ];
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(semaphore.getActiveSlotCount('key-multi')).toBe(3);
+
+      const results = await Promise.all(reqs);
+      results.forEach((r) => expect(r.status).toBe(200));
+    });
+
+    test('tracks distinct keys independently', async () => {
+      const app = buildApp(semaphore, 50, 150);
+
+      const reqs = [fireRequest(app, 'key-a'), fireRequest(app, 'key-b')];
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(semaphore.getCurrentActiveSlotCounts()).toEqual({
+        'key-a': 1,
+        'key-b': 1,
+      });
+      expect(semaphore.getTotalActiveSlotCount()).toBe(2);
+
+      await Promise.all(reqs);
+    });
+
+    test('releases the slot when the client disconnects mid-flight', async () => {
+      const app = buildApp(semaphore, 50, 500);
+
+      await new Promise<void>((resolve) => {
+        const req = request(app).get('/v1/call/demo').set('x-test-key-id', 'key-abort');
+        req.end(() => {});
+        setTimeout(() => {
+          req.abort();
+          resolve();
+        }, 40);
+      });
+
+      // Allow the abort to propagate to the server and fire 'close'.
+      await new Promise((r) => setTimeout(r, 120));
+      expect(semaphore.getActiveSlotCount('key-abort')).toBe(0);
+    });
+  });
+
+  describe('limit enforcement', () => {
+    test('rejects with 429 once the key is at its limit', async () => {
+      const app = buildApp(semaphore, 1, 200);
+
+      const inFlight = fireRequest(app, 'key-limited');
+      await new Promise((r) => setTimeout(r, 40));
+
+      const rejected = await fireRequest(app, 'key-limited');
+      expect(rejected.status).toBe(429);
+      expect(rejected.body.code).toBe('TOO_MANY_REQUESTS');
+      expect(rejected.body.message).toContain('Concurrency limit');
+      expect(rejected.body).toHaveProperty('requestId');
+
+      await inFlight;
+    });
+
+    test('one key hitting its limit does not affect another key', async () => {
+      const app = buildApp(semaphore, 1, 200);
+
+      const busy = fireRequest(app, 'key-busy');
+      await new Promise((r) => setTimeout(r, 40));
+
+      const rejected = await fireRequest(app, 'key-busy');
+      expect(rejected.status).toBe(429);
+
+      const other = await fireRequest(app, 'key-idle');
+      expect(other.status).toBe(200);
+
+      await busy;
+    });
+
+    test('allows requests again after in-flight requests drain', async () => {
+      const app = buildApp(semaphore, 1, 50);
+
+      const first = await fireRequest(app, 'key-drain');
+      expect(first.status).toBe(200);
+
+      const second = await fireRequest(app, 'key-drain');
+      expect(second.status).toBe(200);
+    });
+
+    test('a rejected request does not consume a slot', async () => {
+      const app = buildApp(semaphore, 1, 200);
+
+      const inFlight = fireRequest(app, 'key-no-leak');
+      await new Promise((r) => setTimeout(r, 40));
+
+      await fireRequest(app, 'key-no-leak'); // 429
+      expect(semaphore.getActiveSlotCount('key-no-leak')).toBe(1);
+
+      await inFlight;
+      await new Promise((r) => setTimeout(r, 30));
+      expect(semaphore.getActiveSlotCount('key-no-leak')).toBe(0);
+    });
+  });
+
+  describe('requests without an API key', () => {
+    test('passes through untracked when no key record is present', async () => {
+      const app = buildApp(semaphore, 1, 0);
+
+      const res = await request(app).get('/v1/call/demo');
+      expect(res.status).toBe(200);
+      expect(semaphore.getTotalActiveSlotCount()).toBe(0);
+    });
+
+    test('ignores a key record with a non-string id', async () => {
+      const app = express();
+      const perKeyConcurrency = createPerKeyConcurrencyMiddleware({
+        semaphore,
+        maxConcurrent: 1,
+      });
+
+      app.get(
+        '/v1/call/demo',
+        (req, _res, next) => {
+          req.apiKeyRecord = { id: 42 };
+          next();
+        },
+        perKeyConcurrency,
+        (_req, res) => res.json({ ok: true }),
+      );
+
+      const res = await request(app).get('/v1/call/demo');
+      expect(res.status).toBe(200);
+      expect(semaphore.getTotalActiveSlotCount()).toBe(0);
+    });
+  });
+});

--- a/src/middleware/perKeyConcurrency.ts
+++ b/src/middleware/perKeyConcurrency.ts
@@ -1,0 +1,122 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { config } from '../config/index.js';
+import { logger } from '../logger.js';
+import { KeySemaphore, sharedKeySemaphore } from '../utils/keySemaphore.js';
+
+export interface PerKeyConcurrencyOptions {
+  /** Maximum concurrent in-flight requests per API key. */
+  maxConcurrent?: number;
+  /** Semaphore instance to acquire slots on (defaults to the shared singleton). */
+  semaphore?: KeySemaphore;
+}
+
+/**
+ * Resolves the API key identity used to bucket concurrency.
+ *
+ * `req.apiKeyRecord` is populated by the gateway API-key auth middleware, so
+ * this must run after it. The record id — not the raw key value — is used so
+ * that secrets never reach the admin stats endpoint or the logs.
+ */
+function resolveKeyId(req: Request): string | undefined {
+  const record = req.apiKeyRecord as { id?: unknown } | undefined;
+  const id = record?.id;
+  return typeof id === 'string' && id.length > 0 ? id : undefined;
+}
+
+/**
+ * Express middleware that tracks — and optionally caps — the number of
+ * concurrent in-flight gateway requests per API key.
+ *
+ * Its primary purpose is observability: holding a slot for the lifetime of
+ * each request is what makes `GET /api/admin/keys/concurrency` report real
+ * traffic instead of zeroes. Because the default ceiling
+ * (`KEY_MAX_CONCURRENCY_PER_KEY`) is generous, enforcement is effectively
+ * opt-in — operators lower it to turn the same signal into a limit.
+ *
+ * When a key is at its limit, further requests fast-fail with HTTP 429 rather
+ * than queueing, so callers get an immediate back-off signal. This mirrors
+ * {@link createPerDevConcurrencyMiddleware}, which does the same per developer
+ * on the REST surface.
+ *
+ * Requests without an authenticated API key pass through untracked; the auth
+ * middleware is responsible for rejecting them.
+ *
+ * @example
+ * // Mount after the gateway auth middleware so req.apiKeyRecord is populated:
+ * router.all('/:apiSlugOrId/*', authMiddleware, perKeyConcurrency, handleProxy);
+ */
+export function createPerKeyConcurrencyMiddleware(
+  options: PerKeyConcurrencyOptions = {},
+): RequestHandler {
+  const semaphore = options.semaphore ?? sharedKeySemaphore;
+  const maxConcurrent = options.maxConcurrent ?? config.keyConcurrency.maxPerKey;
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keyId = resolveKeyId(req);
+    if (!keyId) {
+      // No API key identity — pass through (auth middleware will reject).
+      next();
+      return;
+    }
+
+    if (semaphore.getActiveSlotCount(keyId) >= maxConcurrent) {
+      const requestId: string = (req as Request & { id?: string }).id ?? 'unknown';
+      logger.warn('[perKeyConcurrency] key at concurrency limit', {
+        keyId,
+        maxConcurrent,
+        requestId,
+      });
+      res.status(429).json({
+        code: 'TOO_MANY_REQUESTS',
+        message: 'Concurrency limit reached for this API key. Please retry your request.',
+        requestId,
+      });
+      return;
+    }
+
+    // Acquire a slot and hold it until the response settles. This is
+    // non-blocking here because we only reach this point when capacity is
+    // available — withSlot queues only once every slot is occupied.
+    semaphore
+      .withSlot(keyId, () => {
+        return new Promise<void>((resolve) => {
+          const releaseSlot = () => {
+            res.removeListener('finish', releaseSlot);
+            res.removeListener('close', releaseSlot);
+            resolve();
+          };
+
+          // Guard against handlers that respond synchronously: by the time
+          // this microtask runs, 'finish' may already have been emitted (or
+          // the socket destroyed), and a late listener would never fire —
+          // leaking the slot for the full TTL.
+          if (res.writableEnded || res.destroyed) {
+            resolve();
+            return;
+          }
+
+          res.once('finish', releaseSlot);
+          res.once('close', releaseSlot);
+        });
+      })
+      .catch((err) => {
+        // The response is already in flight, so a slot failure must not crash
+        // the process — but it MUST be logged so operators can spot leaks.
+        logger.error('[perKeyConcurrency] slot error:', err);
+      });
+
+    next();
+  };
+}
+
+/**
+ * Pre-configured per-key concurrency middleware bound to the shared semaphore
+ * that the admin stats route reads from.
+ */
+export function createConfiguredPerKeyConcurrencyMiddleware(): RequestHandler {
+  return createPerKeyConcurrencyMiddleware({
+    semaphore: sharedKeySemaphore,
+    maxConcurrent: config.keyConcurrency.maxPerKey,
+  });
+}

--- a/src/routes/admin/keys/concurrency.test.ts
+++ b/src/routes/admin/keys/concurrency.test.ts
@@ -181,17 +181,33 @@ describe('GET /api/admin/keys/concurrency/:keyId', () => {
     expect(response.status).toBe(401);
   });
 
-  it('rejects empty keyId param', async () => {
+  it('treats a trailing slash as the collection endpoint, not an empty keyId', async () => {
     const app = buildApp(keySemaphore);
 
-    // This test uses supertest to send a request with an empty keyId
-    // The validate middleware should catch it as 400
+    // Express (with strict routing off) normalises the trailing slash, so this
+    // matches GET /concurrency rather than /concurrency/:keyId with an empty
+    // param. The detail handler is therefore never reached with a blank keyId.
     const response = await request(app)
       .get('/api/admin/keys/concurrency/')
       .set('x-admin-api-key', ADMIN_KEY);
 
-    // Without a keyId, the route won't match :keyId, so it'll either 404 or
-    // fall through. The app should return a standard error.
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(200);
+    expect(response.body.data).toHaveProperty('keyCounts');
+    expect(response.body.data).not.toHaveProperty('keyId');
+  });
+
+  it('reports the configured per-key ceiling alongside the counts', async () => {
+    const sem = new KeySemaphore(9, 1000);
+    const app = buildApp(sem);
+
+    const listResponse = await request(app)
+      .get('/api/admin/keys/concurrency')
+      .set('x-admin-api-key', ADMIN_KEY);
+    expect(listResponse.body.data.maxConcurrencyPerKey).toBe(9);
+
+    const detailResponse = await request(app)
+      .get('/api/admin/keys/concurrency/key_abc')
+      .set('x-admin-api-key', ADMIN_KEY);
+    expect(detailResponse.body.data.maxConcurrencyPerKey).toBe(9);
   });
 });

--- a/src/routes/admin/keys/concurrency.ts
+++ b/src/routes/admin/keys/concurrency.ts
@@ -59,6 +59,7 @@ export function createAdminKeyConcurrencyRouter(
         data: {
           keyCounts,
           totalActive,
+          maxConcurrencyPerKey: keySemaphore.maxConcurrency,
           campaign: GRANTFOX_FWC26_CAMPAIGN,
         },
       });
@@ -97,6 +98,7 @@ export function createAdminKeyConcurrencyRouter(
             keyId,
             activeCount,
             atLimit,
+            maxConcurrencyPerKey: keySemaphore.maxConcurrency,
             campaign: GRANTFOX_FWC26_CAMPAIGN,
           },
         });

--- a/src/routes/proxyRoutes.ts
+++ b/src/routes/proxyRoutes.ts
@@ -10,6 +10,7 @@ import {
   recordEndpointThroughputSaturation,
 } from '../metrics.js';
 import { createMapBackedGatewayApiKeyAuthMiddleware } from '../middleware/gatewayApiKeyAuth.js';
+import { createConfiguredPerKeyConcurrencyMiddleware } from '../middleware/perKeyConcurrency.js';
 import { buildHopByHopSet } from '../lib/hopByHop.js';
 import {
   buildUpstreamTargetUrl,
@@ -109,10 +110,15 @@ export function createProxyRouter(deps: ProxyDeps): Router {
     },
   });
 
+  // Tracks in-flight requests per API key on the shared semaphore that
+  // GET /api/admin/keys/concurrency reads from. Must run after authMiddleware
+  // so that req.apiKeyRecord is populated.
+  const perKeyConcurrency = deps.perKeyConcurrency ?? createConfiguredPerKeyConcurrencyMiddleware();
+
   // Use a param of 0 to capture the wildcard path (everything after the slug)
-  router.all('/:apiSlugOrId/*', authMiddleware, handleProxy);
+  router.all('/:apiSlugOrId/*', authMiddleware, perKeyConcurrency, handleProxy);
   // Also handle requests without a trailing path (e.g. /v1/call/my-api)
-  router.all('/:apiSlugOrId', authMiddleware, handleProxy);
+  router.all('/:apiSlugOrId', authMiddleware, perKeyConcurrency, handleProxy);
 
   async function handleProxy(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -142,6 +142,8 @@ export interface ProxyDeps {
   registry: ApiRegistry;
   apiKeys?: Map<string, ApiKey>;
   authMiddleware?: RequestHandler;
+  /** Per-API-key concurrency tracker. Defaults to the shared-semaphore middleware. */
+  perKeyConcurrency?: RequestHandler;
   proxyConfig?: Partial<ProxyConfig>;
   circuitBreakerStore?: CircuitBreakerStore;
 }

--- a/src/utils/keySemaphore.test.ts
+++ b/src/utils/keySemaphore.test.ts
@@ -1,5 +1,3 @@
-import assert from 'node:assert';
-import { test, describe, beforeEach, afterEach } from 'node:test';
 import { KeySemaphore } from './keySemaphore.js';
 
 describe('KeySemaphore', () => {
@@ -25,11 +23,8 @@ describe('KeySemaphore', () => {
       ]);
 
       // The semaphore should never exceed maxConcurrency per key
-      assert.ok(
-        activeAtPeak.every((c) => c <= 2),
-        `Active count never exceeded 2: ${activeAtPeak}`,
-      );
-      assert.equal(semaphore.getTotalActiveSlotCount(), 0);
+      expect(activeAtPeak.every((c) => c <= 2)).toBe(true);
+      expect(semaphore.getTotalActiveSlotCount()).toBe(0);
     });
 
     test('isolates concurrency limits between keys', async () => {
@@ -48,7 +43,29 @@ describe('KeySemaphore', () => {
       ]);
 
       // Two different keys should both be active concurrently
-      assert.equal(peakTotal, 2);
+      expect(peakTotal).toBe(2);
+    });
+
+    test('queues work beyond the limit rather than dropping it', async () => {
+      const semaphore = new KeySemaphore(1, 1000);
+      const order: number[] = [];
+
+      await Promise.all([
+        semaphore.withSlot('key-fifo', async () => {
+          order.push(1);
+          await new Promise((r) => setTimeout(r, 20));
+        }),
+        semaphore.withSlot('key-fifo', async () => {
+          order.push(2);
+        }),
+        semaphore.withSlot('key-fifo', async () => {
+          order.push(3);
+        }),
+      ]);
+
+      // All three tasks ran, in FIFO order, despite a limit of one slot
+      expect(order).toEqual([1, 2, 3]);
+      expect(semaphore.getActiveSlotCount('key-fifo')).toBe(0);
     });
   });
 
@@ -56,27 +73,27 @@ describe('KeySemaphore', () => {
     test('getCurrentActiveSlotCounts returns only active keys', async () => {
       const semaphore = new KeySemaphore(5, 1000);
 
-      assert.deepEqual(semaphore.getCurrentActiveSlotCounts(), {});
+      expect(semaphore.getCurrentActiveSlotCounts()).toEqual({});
 
       await semaphore.withSlot('key-x', async () => {
         const counts = semaphore.getCurrentActiveSlotCounts();
-        assert.equal(counts['key-x'], 1);
-        assert.equal(Object.keys(counts).length, 1);
+        expect(counts['key-x']).toBe(1);
+        expect(Object.keys(counts)).toHaveLength(1);
       });
 
-      assert.deepEqual(semaphore.getCurrentActiveSlotCounts(), {});
+      expect(semaphore.getCurrentActiveSlotCounts()).toEqual({});
     });
 
     test('getActiveSlotCount returns count for specific key', async () => {
       const semaphore = new KeySemaphore(5, 1000);
 
-      assert.equal(semaphore.getActiveSlotCount('key-y'), 0);
+      expect(semaphore.getActiveSlotCount('key-y')).toBe(0);
 
       await semaphore.withSlot('key-y', async () => {
-        assert.equal(semaphore.getActiveSlotCount('key-y'), 1);
+        expect(semaphore.getActiveSlotCount('key-y')).toBe(1);
       });
 
-      assert.equal(semaphore.getActiveSlotCount('key-y'), 0);
+      expect(semaphore.getActiveSlotCount('key-y')).toBe(0);
     });
 
     test('getTotalActiveSlotCount sums all active slots', async () => {
@@ -98,8 +115,8 @@ describe('KeySemaphore', () => {
         }),
       ]);
 
-      assert.equal(total, 3);
-      assert.equal(semaphore.getTotalActiveSlotCount(), 0);
+      expect(total).toBe(3);
+      expect(semaphore.getTotalActiveSlotCount()).toBe(0);
     });
   });
 
@@ -108,18 +125,24 @@ describe('KeySemaphore', () => {
       const semaphore = new KeySemaphore(1, 1000);
 
       await semaphore.withSlot('key-limit', async () => {
-        assert.equal(semaphore.isAtLimit('key-limit'), true);
+        expect(semaphore.isAtLimit('key-limit')).toBe(true);
       });
 
-      assert.equal(semaphore.isAtLimit('key-limit'), false);
+      expect(semaphore.isAtLimit('key-limit')).toBe(false);
     });
 
     test('returns false when key is under its concurrency limit', async () => {
       const semaphore = new KeySemaphore(2, 1000);
 
       await semaphore.withSlot('key-under', async () => {
-        assert.equal(semaphore.isAtLimit('key-under'), false);
+        expect(semaphore.isAtLimit('key-under')).toBe(false);
       });
+    });
+  });
+
+  describe('maxConcurrency', () => {
+    test('exposes the configured per-key ceiling', () => {
+      expect(new KeySemaphore(7, 1000).maxConcurrency).toBe(7);
     });
   });
 
@@ -133,30 +156,26 @@ describe('KeySemaphore', () => {
 
       // Should be able to acquire the slot again
       await semaphore.withSlot('key-release', async () => {
-        assert.equal(semaphore.getActiveSlotCount('key-release'), 1);
+        expect(semaphore.getActiveSlotCount('key-release')).toBe(1);
       });
 
-      assert.equal(semaphore.getActiveSlotCount('key-release'), 0);
+      expect(semaphore.getActiveSlotCount('key-release')).toBe(0);
     });
 
     test('releases slot on error', async () => {
       const semaphore = new KeySemaphore(1, 1000);
 
-      let errorCaught = false;
-      try {
-        await semaphore.withSlot('key-err', async () => {
+      await expect(
+        semaphore.withSlot('key-err', async () => {
           throw new Error('test error');
-        });
-      } catch {
-        errorCaught = true;
-      }
+        }),
+      ).rejects.toThrow('test error');
 
-      assert.ok(errorCaught);
-      assert.equal(semaphore.getActiveSlotCount('key-err'), 0);
+      expect(semaphore.getActiveSlotCount('key-err')).toBe(0);
 
       // Should be able to acquire the slot again
       await semaphore.withSlot('key-err', async () => {
-        assert.equal(semaphore.getActiveSlotCount('key-err'), 1);
+        expect(semaphore.getActiveSlotCount('key-err')).toBe(1);
       });
     });
   });
@@ -167,13 +186,13 @@ describe('KeySemaphore', () => {
 
       // Acquire a slot so we have state
       await semaphore.withSlot('key-clr', async () => {
-        assert.equal(semaphore.getActiveSlotCount('key-clr'), 1);
+        expect(semaphore.getActiveSlotCount('key-clr')).toBe(1);
       });
 
       semaphore.clear();
-      assert.equal(semaphore.getTotalActiveSlotCount(), 0);
-      assert.equal(semaphore.getActiveSlotCount('key-clr'), 0);
-      assert.deepEqual(semaphore.getCurrentActiveSlotCounts(), {});
+      expect(semaphore.getTotalActiveSlotCount()).toBe(0);
+      expect(semaphore.getActiveSlotCount('key-clr')).toBe(0);
+      expect(semaphore.getCurrentActiveSlotCounts()).toEqual({});
     });
   });
 });

--- a/src/utils/keySemaphore.ts
+++ b/src/utils/keySemaphore.ts
@@ -1,3 +1,5 @@
+import { config } from '../config/index.js';
+
 type QueueEntry = (release: () => void) => void;
 
 /**
@@ -70,6 +72,11 @@ export class KeySemaphore {
   isAtLimit(keyId: string): boolean {
     const active = this.getActiveSlotCount(keyId);
     return active >= this.maxConcurrencyPerKey;
+  }
+
+  /** The configured maximum number of concurrent slots per API key. */
+  get maxConcurrency(): number {
+    return this.maxConcurrencyPerKey;
   }
 
   private acquireSlot(keyId: string): Promise<() => void> {
@@ -150,5 +157,12 @@ export class KeySemaphore {
  * Shared singleton KeySemaphore instance used across the gateway middleware
  * and the admin concurrency stats route. Tests should create isolated
  * instances via the class constructor directly.
+ *
+ * Both sides must use this same instance: the gateway proxy acquires slots on
+ * it (see `createPerKeyConcurrencyMiddleware`) and the admin stats route reads
+ * from it. A separate instance on either side would report counts of zero.
  */
-export const sharedKeySemaphore = new KeySemaphore();
+export const sharedKeySemaphore = new KeySemaphore(
+  config.keyConcurrency.maxPerKey,
+  config.keyConcurrency.semaphoreTtlMs,
+);


### PR DESCRIPTION
Wires per-API-key concurrency tracking into the gateway so the admin stats endpoints report real traffic.

The endpoints added in #620 read from a `KeySemaphore` that nothing ever acquired slots on, so they returned `{keyCounts: {}, totalActive: 0}` regardless of load.

**Changes**
- `createPerKeyConcurrencyMiddleware` holds a slot for the lifetime of each authenticated gateway request, releasing on `finish` or `close`. Requests are bucketed by API key record id, never the raw key value.
- Mounted on the proxy route after API-key auth. The shared semaphore is configured from `KEY_MAX_CONCURRENCY_PER_KEY` (default 50) and `KEY_SEMAPHORE_TTL_MS`.
- The generous default keeps this observability-only. Lowering it opts into enforcement, where over-limit requests fail fast with 429 instead of queueing; a rejected request never occupies a slot.
- Both responses now report `maxConcurrencyPerKey` so `atLimit` is interpretable.

**Test fixes**
`src/utils/keySemaphore.test.ts` imported from `node:test`, so none of its 10 cases ran under jest — converted to jest. The empty-keyId case asserted 404 for a path Express resolves to the collection endpoint — corrected to assert the actual behaviour.

34/34 tests pass, up from 8 passing / 1 failing / 10 not running. Lint clean.

Pre-existing and untouched (identical on `main`): 8 gateway-test failures from an error-envelope shape change, and a syntax error in `src/controllers/authController.ts` that fails `tsc` and `eslint` repo-wide.

Documented in `docs/per-key-concurrency.md`, with README and `.env.example` updated.

Closes #554