### PR TITLE
Add billing cursor pagination and quota counts summary endpoints

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,7 @@ import { errorHandler } from './middleware/errorHandler.js';
 import { performHealthCheck, type HealthCheckConfig } from './services/healthCheck.js';
 import { createDependenciesRouter } from './routes/health/dependencies.js';
 import quotaRequestsRouter from './routes/quota/requests.js';
+import quotaCountsRouter from './routes/quotas/counts.js';
 import { parsePagination, paginatedResponse } from './lib/pagination.js';
 import { InMemoryVaultRepository, type VaultRepository } from './repositories/vaultRepository.js';
 import { DepositController } from './controllers/depositController.js';
@@ -317,6 +318,7 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
 
   // Quota self-service — developers submit requests, admins manage via /api/admin/quota/requests
   app.use('/api/quota/requests', quotaRequestsRouter);
+  app.use('/api/quotas/counts', quotaCountsRouter);
 
   // Prometheus metrics endpoint — auth-gated in production
   app.get('/api/metrics', metricsEndpoint);

--- a/src/routes/billing.test.ts
+++ b/src/routes/billing.test.ts
@@ -1,0 +1,83 @@
+import express from 'express';
+import request from 'supertest';
+import billingRouter from './billing.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { requestIdMiddleware } from '../middleware/requestId.js';
+import { encodeCursor } from '../lib/cursorPagination.js';
+
+function buildApp(pool: { query: jest.Mock }) {
+  const app = express();
+  app.use(express.json());
+  app.use(requestIdMiddleware);
+  app.locals.dbPool = pool;
+  app.use('/api/billing', billingRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('GET /api/billing', () => {
+  it('returns paginated billing requests for the authenticated developer', async () => {
+    const pool = {
+      query: jest.fn().mockResolvedValue({
+        rows: [
+          {
+            id: 'req-2',
+            request_id: 'request-2',
+            developer_id: 'dev-1',
+            api_id: 'api-2',
+            endpoint_id: 'endpoint-2',
+            api_key_id: 'key-2',
+            amount_usdc: '4.00',
+            created_at: new Date('2024-01-02T00:00:00.000Z'),
+          },
+          {
+            id: 'req-1',
+            request_id: 'request-1',
+            developer_id: 'dev-1',
+            api_id: 'api-1',
+            endpoint_id: 'endpoint-1',
+            api_key_id: 'key-1',
+            amount_usdc: '2.00',
+            created_at: new Date('2024-01-01T00:00:00.000Z'),
+          },
+        ],
+      }),
+    };
+
+    const app = buildApp(pool as unknown as { query: jest.Mock });
+    const res = await request(app)
+      .get('/api/billing?limit=1')
+      .set('x-user-id', 'dev-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].requestId).toBe('request-2');
+    expect(res.body.meta.hasMore).toBe(true);
+    expect(res.body.meta.nextCursor).toBeTruthy();
+  });
+
+  it('rejects an invalid cursor', async () => {
+    const app = buildApp({ query: jest.fn() } as unknown as { query: jest.Mock });
+    const res = await request(app)
+      .get('/api/billing?cursor=invalid-cursor')
+      .set('x-user-id', 'dev-1');
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns the next page when a valid cursor is supplied', async () => {
+    const cursor = encodeCursor(new Date('2024-01-02T00:00:00.000Z'), 'req-2');
+    const pool = {
+      query: jest.fn().mockResolvedValue({ rows: [] }),
+    };
+
+    const app = buildApp(pool as unknown as { query: jest.Mock });
+    const res = await request(app)
+      .get(`/api/billing?limit=1&cursor=${encodeURIComponent(cursor)}`)
+      .set('x-user-id', 'dev-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.meta.hasMore).toBe(false);
+  });
+});

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import type { NextFunction, Request, Response } from "express";
 import type { Pool } from "pg";
+import { encodeCursor, parseCursor } from "../lib/cursorPagination.js";
 
 import {
   BadGatewayError,
@@ -30,6 +31,7 @@ import { billingAccessLogMiddleware } from "../middleware/billingAccessLog.js";
 import creditsRouter from "./billing/credits.js";
 import disputesRouter from "./billing/disputes.js";
 import { createFeeAbstractionRouter } from "./billing/feeAbstraction.js";
+import bulkDeductRouter from './billing/deduct/bulk.js';
 
 const router = Router();
 
@@ -111,6 +113,89 @@ function sendSimulationFailure(
     simulationDetails: redactSimulationDetails(result.simulationDetails),
   });
 }
+
+router.get(
+  "/",
+  requireAuth,
+  async (
+    req: Request,
+    res: Response<unknown, AuthenticatedLocals>,
+    next: NextFunction,
+  ) => {
+    try {
+      const user = res.locals.authenticatedUser;
+      if (!user) {
+        next(new UnauthorizedError());
+        return;
+      }
+
+      const pool = getPool(req);
+      const limit = Number(req.query.limit ?? 20);
+      if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+        next(new BadRequestError("limit must be an integer between 1 and 100"));
+        return;
+      }
+
+      const cursor = parseCursor(req.query.cursor);
+      if (req.query.cursor !== undefined && !cursor) {
+        next(new BadRequestError("Invalid cursor"));
+        return;
+      }
+
+      const query = {
+        text: `
+          SELECT id, request_id, developer_id, api_id, endpoint_id, api_key_id, amount_usdc, created_at
+          FROM billing_requests
+          WHERE developer_id = $1
+          ${cursor ? "AND (created_at < $2 OR (created_at = $2 AND id < $3))" : ""}
+          ORDER BY created_at DESC, id DESC
+          LIMIT $4
+        `,
+        values: cursor
+          ? [user.id, cursor.timestamp, cursor.id, limit + 1]
+          : [user.id, limit + 1],
+      };
+
+      const result = await pool.query(query);
+      const rows = result.rows as Array<{
+        id: string;
+        request_id: string;
+        developer_id: string;
+        api_id: string;
+        endpoint_id: string;
+        api_key_id: string;
+        amount_usdc: string;
+        created_at: Date;
+      }>;
+
+      const hasMore = rows.length > limit;
+      const data = hasMore ? rows.slice(0, limit) : rows;
+      const nextCursor = hasMore && data.length > 0
+        ? encodeCursor(data[data.length - 1].created_at, data[data.length - 1].id)
+        : null;
+
+      res.status(200).json({
+        data: data.map((row) => ({
+          id: row.id,
+          requestId: row.request_id,
+          developerId: row.developer_id,
+          apiId: row.api_id,
+          endpointId: row.endpoint_id,
+          apiKeyId: row.api_key_id,
+          amountUsdc: row.amount_usdc,
+          createdAt: row.created_at.toISOString(),
+        })),
+        meta: {
+          limit,
+          nextCursor,
+          hasMore,
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
 
 router.post(
   "/deduct",

--- a/src/routes/quota/requests.test.ts
+++ b/src/routes/quota/requests.test.ts
@@ -19,6 +19,7 @@
 import request from 'supertest';
 import express from 'express';
 import quotaRequestsRouter from './requests.js';
+import quotaCountsRouter from './counts.js';
 import { errorHandler } from '../../middleware/errorHandler.js';
 import { requestIdMiddleware } from '../../middleware/requestId.js';
 import {
@@ -39,6 +40,7 @@ function createTestApp() {
   app.use(express.json());
   app.use(requestIdMiddleware);
   app.use('/api/quota/requests', quotaRequestsRouter);
+  app.use('/api/quotas/counts', quotaCountsRouter);
   app.use(errorHandler);
   return app;
 }
@@ -647,6 +649,41 @@ describe('GET /api/quota/requests/:id', () => {
 // ---------------------------------------------------------------------------
 // Tracing span tests
 // ---------------------------------------------------------------------------
+
+describe('GET /api/quotas/counts', () => {
+  beforeEach(() => {
+    setQuotaRequestStore(new InMemoryQuotaRequestStore());
+  });
+
+  it('returns a summary of the caller requests by status', async () => {
+    const app = createTestApp();
+
+    await request(app)
+      .post('/api/quota/requests')
+      .set('x-user-id', 'dev-1')
+      .send(validBody);
+
+    const approved = await request(app)
+      .post('/api/quota/requests')
+      .set('x-user-id', 'dev-1')
+      .send({ requested_tier: 'enterprise', reason: 'Second request for enterprise tier upgrade' });
+
+    const store = getQuotaRequestStore();
+    await store.update(approved.body.data.id, { status: 'approved' });
+
+    await request(app)
+      .post('/api/quota/requests')
+      .set('x-user-id', 'dev-2')
+      .send({ requested_tier: 'pro', reason: 'Other developer request' });
+
+    const res = await request(app)
+      .get('/api/quotas/counts')
+      .set('x-user-id', 'dev-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ total: 2, pending: 1, approved: 1, rejected: 0 });
+  });
+});
 
 describe('Tracing spans for /api/quota/requests', () => {
   let getSpans: () => RecordedSpan[];

--- a/src/routes/quotas/counts.ts
+++ b/src/routes/quotas/counts.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import { requireAuth, type AuthenticatedLocals } from '../../middleware/requireAuth.js';
+import { listQuotaRequests } from '../../services/quotaService.js';
+import { logger } from '../../logger.js';
+
+const router = Router();
+
+interface QuotaCountsResponse {
+  data: {
+    total: number;
+    pending: number;
+    approved: number;
+    rejected: number;
+  };
+}
+
+router.get(
+  '/',
+  requireAuth,
+  async (req: Request, res: Response<QuotaCountsResponse, AuthenticatedLocals>, next: NextFunction) => {
+    try {
+      const user = res.locals.authenticatedUser;
+      if (!user) {
+        res.status(401).json({ data: { total: 0, pending: 0, approved: 0, rejected: 0 } });
+        return;
+      }
+
+      const allRequests = await listQuotaRequests();
+      const ownRequests = allRequests.filter((request) => request.developerId === user.id);
+
+      const counts = {
+        total: ownRequests.length,
+        pending: ownRequests.filter((request) => request.status === 'pending').length,
+        approved: ownRequests.filter((request) => request.status === 'approved').length,
+        rejected: ownRequests.filter((request) => request.status === 'rejected').length,
+      };
+
+      logger.info('Quota counts summary fetched', {
+        developerId: user.id,
+        counts,
+      });
+
+      res.status(200).json({ data: counts });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export default router;


### PR DESCRIPTION
This PR delivers the implementation for issues #653 and #675.

- Adds GET /api/billing with cursor-based pagination for billing requests.
- Adds GET /api/quotas/counts to return developer quota request summary counts.
- Includes tests covering pagination behavior and quota count response structure.

Changes are on branch feature/combined-issues from fork victor-olamide/Callora-Backend.

If accepted, this closes the assigned upstream issues and provides the requested summary endpoints for billing and quota UIs.

closes #653
closes #675