### PR TITLE
feat: rate limit usage

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import { getClientIp } from '../lib/clientIp.js';
 import { logger } from '../logger.js';
 import { resolveRequestUserId } from './requireAuth.js';
+import { TooManyRequestsError } from '../errors/index.js';
 
 export interface RateLimitOptions {
   windowMs: number;
@@ -83,12 +84,7 @@ export function createRateLimitMiddleware(
       });
 
       res.set('Retry-After', String(retryAfterSeconds));
-      res.status(429).json({
-        code: 'TOO_MANY_REQUESTS',
-        message: 'Too Many Requests',
-        requestId,
-        retryAfterMs,
-      });
+      next(new TooManyRequestsError('Too Many Requests'));
       return;
     }
 

--- a/src/routes/usage.test.ts
+++ b/src/routes/usage.test.ts
@@ -1,0 +1,73 @@
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+import { createUsageRouter } from './usage.js';
+import { createRateLimitMiddleware } from '../middleware/rateLimit.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { type UsageEventsRepository } from '../repositories/usageEventsRepository.js';
+
+const mockUsageEventsRepository: jest.Mocked<UsageEventsRepository> = {
+  record: jest.fn(),
+  findByUser: jest.fn().mockResolvedValue([]),
+  findByApi: jest.fn().mockResolvedValue([]),
+  aggregateByUser: jest.fn().mockResolvedValue({ totalCalls: 0, totalRevenue: 0, breakdownByApi: [] }),
+  aggregateByApi: jest.fn().mockResolvedValue({ totalCalls: 0, totalRevenue: 0, breakdownByApi: [] }),
+};
+
+describe('Usage Router Rate Limiting', () => {
+  function buildApp() {
+    const app = express();
+    
+    app.use((req: Request, res: Response, next: NextFunction) => {
+      req.id = 'test-request-id';
+      res.locals.authenticatedUser = { id: 'test-user-id' };
+      next();
+    });
+
+    const rateLimitMiddleware = createRateLimitMiddleware({
+      windowMs: 1000, // 1 second
+      maxRequests: 2, // 2 requests per window
+    });
+
+    const router = createUsageRouter({
+      usageEventsRepository: mockUsageEventsRepository,
+      rateLimitMiddleware,
+    });
+
+    app.use('/usage', router);
+    app.use(errorHandler);
+
+    return app;
+  }
+
+  it('should enforce rate limits on usage endpoint', async () => {
+    const app = buildApp();
+
+    // First request should succeed
+    let response = await request(app).get('/usage');
+    expect(response.status).toBe(200);
+
+    // Second request should succeed
+    response = await request(app).get('/usage');
+    expect(response.status).toBe(200);
+
+    // Third request should hit the rate limit
+    response = await request(app).get('/usage');
+    expect(response.status).toBe(429);
+    expect(response.body).toEqual({
+      success: false,
+      error: {
+        code: 'TOO_MANY_REQUESTS',
+        message: 'Too Many Requests'
+      },
+      requestId: 'test-request-id',
+    });
+    expect(response.headers['retry-after']).toBeDefined();
+    
+    // Wait for window to reset (mocking time might be better but real wait is simple here)
+    await new Promise(resolve => setTimeout(resolve, 1050));
+    
+    // Fourth request should succeed after window resets
+    response = await request(app).get('/usage');
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/routes/usage.ts
+++ b/src/routes/usage.ts
@@ -5,9 +5,11 @@ import { type UsageEventsPgRepository } from '../repositories/usageEventsReposit
 import { BadRequestError, InternalServerError, UnauthorizedError } from '../errors/index.js';
 import { parsePagination, parseCursorPagination, decodeCursor } from '../lib/pagination.js';
 import { parseCursor } from '../lib/cursorPagination.js';
+import { createRateLimitMiddleware } from '../middleware/rateLimit.js';
 
 export interface UsageRouterDeps {
   usageEventsRepository: UsageEventsRepository & Partial<UsageEventsPgRepository>;
+  rateLimitMiddleware?: ReturnType<typeof createRateLimitMiddleware>;
 }
 
 const isValidGroupBy = (value: string): value is GroupBy =>
@@ -55,6 +57,12 @@ const parseDate = (value: unknown): Date | null => {
 export function createUsageRouter(deps: UsageRouterDeps): Router {
   const router = Router();
   const { usageEventsRepository } = deps;
+  const rateLimitMiddleware = deps.rateLimitMiddleware ?? createRateLimitMiddleware({
+    windowMs: 60_000,
+    maxRequests: 60,
+  });
+
+  router.use(rateLimitMiddleware);
 
   router.get('/', requireAuth, async (req, res: Response<unknown, AuthenticatedLocals>, next) => {
     const user = res.locals.authenticatedUser;


### PR DESCRIPTION
Closes #649 
 This PR addresses the GrantFox campaign backend issue #12 by introducing a per-user rate limit specifically for the usage endpoints.

Changes Made:
Rate Limit Middleware Application (src/routes/usage.ts):
Integrated the createRateLimitMiddleware to the usage router to limit incoming requests and prevent abuse.
Configured limits to 60 requests per 1-minute window, effectively restricting potential scraping or overload.
Standardized Error Envelope (src/middleware/rateLimit.ts):
Updated the rate limiter's rejection handler. Instead of returning a hardcoded HTTP 429 JSON response, it now throws a TooManyRequestsError.
This error passes through the global errorHandler, maintaining the boundary's standardized { success: false, error: ... } JSON structure while keeping the necessary Retry-After HTTP headers intact.
Focused Tests (src/routes/usage.test.ts):
Added a dedicated test suite using supertest with mocked router dependencies to verify that rate limits function properly and that the new error envelope behaves as expected on the 429 status code.
Acceptance Criteria Addressed:
 Implementation matches the description (per-user rate limit).
 Input validation at the boundary and standardized error envelope handled via AppError.
 Tests added and cover edge cases (e.g., verifying Retry-After headers and 429 returns).
 Code adheres to the repository style.
Please review for merge!