### PR TITLE
feat: add POST /api/admin/audit/replay endpoint

### DIFF
--- a/docs/admin-audit-endpoint.md
+++ b/docs/admin-audit-endpoint.md
@@ -91,3 +91,94 @@ curl -s -H "x-admin-api-key: $ADMIN_API_KEY" \
 - Listing audit logs emits its own `LIST_AUDIT_LOGS` audit event with correlation ID propagation.
 - Data is sourced from the `audit_logs` table (migration `0016_audit_enrichment.sql`).
 - Cursor pagination avoids offset scans and remains stable when new rows are inserted during paging.
+
+---
+
+# Admin Audit Action Replay
+
+`POST /api/admin/audit/replay` re-executes a previously audit-logged admin action using its original parameters, as recorded in the audit entry's `details` JSON blob. The endpoint is idempotent per underlying target (e.g. already-resolved quota requests surface an `already_resolved` outcome rather than double-applying state changes).
+
+## Authentication
+
+Same as the listing endpoint (admin API key or admin JWT, plus IP allowlist).
+
+## Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `entryId` | string | ✅ | The `id` (UUID/text PK) of a row in the `audit_logs` table. |
+
+## Replayable events
+
+Only the following mutating admin events have registered replay handlers. Any other event (read-only listings, replay-of-replay, webhook replays, etc.) returns `AUDIT_ACTION_NOT_REPLAYABLE`.
+
+| Event | `details` fields used | Notes |
+|-------|------------------------|-------|
+| `RESET_USAGE_AGGREGATE` | `developerId` | Re-runs `usageStore.resetDeveloperUsage`. Outcome is `not_found` when no aggregate exists. |
+| `APPROVE_QUOTA_REQUEST` | `requestId`, `adminNotes` | Re-runs `approveQuotaRequest`. Outcome is `already_resolved` if the request is no longer pending, `not_found` if the request was deleted. |
+| `REJECT_QUOTA_REQUEST` | `requestId`, `adminNotes` | Same resolution semantics as approve. |
+| `GRANT_PREPAID_CREDITS` | `userId`, `amountUsdc` | Re-runs `creditsRepository.grant` (the 4-USDC buffer from the route is NOT double-applied — the stored `amountUsdc` in details already included it when the first run logged the event). |
+| `SOFT_DELETE_API` | `apiId` | Re-runs `apiRepository.delete`. Outcome is `not_found` when the API is already deleted or missing. |
+| `RESTORE_API` | `apiId` | Re-runs `apiRepository.restore`. Outcome is `not_found` when the API is not currently soft-deleted. |
+
+## Response shape
+
+```json
+{
+  "data": {
+    "entryId": "550e8400-e29b-41d4-a716-446655440000",
+    "originalEvent": "APPROVE_QUOTA_REQUEST",
+    "outcome": "success",
+    "replayedAt": "2026-06-28T15:00:00.000Z",
+    "message": null
+  }
+}
+```
+
+### Outcome values
+
+| Outcome | Meaning | HTTP status |
+|---------|---------|-------------|
+| `success` | The action was re-applied without error. | 200 |
+| `already_resolved` | The target is idempotently already in the desired state (e.g. quota request already approved). No state was mutated. | 200 |
+| `not_found` | The target resource (API, usage aggregate, quota request) no longer exists. | 200 |
+
+## Error responses
+
+| HTTP | Code | When |
+|------|------|------|
+| 400 | `INVALID_BODY` | Body is missing or not a JSON object. |
+| 400 | `INVALID_ENTRY_ID` | `entryId` is missing, not a string, or empty/whitespace. |
+| 400 | `AUDIT_ACTION_NOT_REPLAYABLE` | The entry's `event` is not in the replayable list above. |
+| 400 | `AUDIT_DETAILS_INCOMPLETE` | The entry's `details` blob is missing required replay parameters (e.g. `developerId`, `apiId`). |
+| 404 | `AUDIT_ENTRY_NOT_FOUND` | No `audit_logs` row exists for the provided `entryId`. |
+| 401 | `UNAUTHORIZED` | Admin auth failed. |
+| 500 | `INTERNAL_SERVER_ERROR` | Unexpected error during replay. |
+
+All error bodies follow the standard envelope:
+
+```json
+{
+  "code": "AUDIT_ACTION_NOT_REPLAYABLE",
+  "message": "Audit action \"LIST_USERS\" is not replayable",
+  "requestId": "…"
+}
+```
+
+## Examples
+
+```bash
+# Replay a specific audit entry
+curl -s -X POST \
+  -H "x-admin-api-key: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"entryId":"550e8400-e29b-41d4-a716-446655440000"}' \
+  "https://api.example.com/api/admin/audit/replay"
+```
+
+## Notes
+
+- Every replay attempt (success, not_replayable, error, already_resolved, not_found) emits its own `AUDIT_REPLAYED` audit event that links back to the original entry via `originalEntryId`. Use this to trace the full history of replayed actions.
+- The replaying admin's identity (`res.locals.adminActor`) is used as the actor for both the replay audit row and for idempotent service-layer fields such as `resolvedBy` on quota requests. Replays are not backdated to the original actor.
+- Correlation IDs (`x-request-id` / `x-correlation-id`) supplied on the replay request are propagated to the replay audit event and are recommended for joining the replay to its access-log entry.
+

--- a/src/repositories/auditLogRepository.ts
+++ b/src/repositories/auditLogRepository.ts
@@ -34,6 +34,7 @@ export interface FindAuditLogsCursorResult {
 
 export interface AuditLogRepository {
   findCursor(params: FindAuditLogsCursorParams): Promise<FindAuditLogsCursorResult>;
+  findById(id: string): Promise<AuditLogEntry | undefined>;
 }
 
 export interface AuditLogRepositoryQueryable {
@@ -157,6 +158,31 @@ export class PgAuditLogRepository implements AuditLogRepository {
     const entries = result.rows.slice(0, params.limit).map(mapAuditLogRow);
 
     return { entries, hasMore };
+  }
+
+  async findById(id: string): Promise<AuditLogEntry | undefined> {
+    const result = await this.read<AuditLogRow>(
+      `
+        SELECT
+          id,
+          event,
+          actor,
+          tenant_id,
+          client_ip,
+          user_agent,
+          correlation_id,
+          body_hash,
+          details,
+          created_at
+        FROM audit_logs
+        WHERE id = $1
+        LIMIT 1
+      `,
+      [id],
+    );
+
+    const row = result.rows[0];
+    return row ? mapAuditLogRow(row) : undefined;
   }
 
   private read<T>(text: string, params?: unknown[]): Promise<{ rows: T[] }> {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -19,6 +19,7 @@ import { createAdminHealthProbesRouter } from './admin/health/probes.js';
 import { createAdminCreditGrantsRouter } from './admin/billing/credits/grant.js';
 import { createAdminUsageExportRouter } from './admin/usage/export.js';
 import { createAdminKeyConcurrencyRouter } from './admin/keys/concurrency.js';
+import { createAdminAuditRouter } from './admin/audit.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 const usageStore: UsageAdminStore = createUsageStore();
@@ -236,6 +237,13 @@ router.use('/billing/credits', createAdminCreditGrantsRouter());
 //         GET /api/admin/keys/concurrency/:keyId
 // ---------------------------------------------------------------------------
 router.use('/keys', createAdminKeyConcurrencyRouter());
+
+// ---------------------------------------------------------------------------
+// Audit log listing and action replay
+// Mounts: GET  /api/admin/audit
+//         POST /api/admin/audit/replay
+// ---------------------------------------------------------------------------
+router.use('/audit', createAdminAuditRouter());
 
 // ---------------------------------------------------------------------------
 // Maintenance banner

--- a/src/routes/admin/audit.ts
+++ b/src/routes/admin/audit.ts
@@ -1,11 +1,15 @@
 /**
- * Admin audit-log listing with cursor pagination.
+ * Admin audit-log listing with cursor pagination and action replay.
  *
- * Route:
- *   GET /api/admin/audit
+ * Routes:
+ *   GET  /api/admin/audit
+ *   POST /api/admin/audit/replay
  *
  * Pagination uses stable keyset ordering over (created_at DESC, id DESC).
  * The opaque `cursor` query param encodes the last row's timestamp and id.
+ *
+ * Replay re-executes a previously logged admin action using the original
+ * parameters stored in the audit row's `details` JSON blob.
  */
 
 import { Router } from 'express';
@@ -26,6 +30,10 @@ import {
   PgAuditLogRepository,
   type AuditLogRepository,
 } from '../../repositories/auditLogRepository.js';
+import {
+  createAdminAuditReplayRouter,
+  type AdminAuditReplayRouterDeps,
+} from './audit/replay.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 
@@ -53,13 +61,16 @@ const parseOptionalString = (value: unknown): string | undefined => {
   return trimmed === '' ? undefined : trimmed;
 };
 
-export interface AdminAuditRouterDeps {
+export interface AdminAuditRouterDeps
+  extends AdminAuditReplayRouterDeps {
   auditLogRepository?: AuditLogRepository;
 }
 
 export function createAdminAuditRouter(deps: AdminAuditRouterDeps = {}): Router {
   const router = Router();
   const auditLogRepository = deps.auditLogRepository ?? new PgAuditLogRepository();
+
+  router.use('/replay', createAdminAuditReplayRouter(deps));
 
   router.get('/', async (req, res, next) => {
     try {

--- a/src/routes/admin/audit/replay.test.ts
+++ b/src/routes/admin/audit/replay.test.ts
@@ -1,0 +1,951 @@
+/**
+ * Tests for POST /api/admin/audit/replay
+ *
+ * Coverage:
+ *   - Successful replay for each replayable action type
+ *   - Authorization (admin API key + JWT)
+ *   - Audit entry not found (404)
+ *   - Non-replayable action type (AUDIT_ACTION_NOT_REPLAYABLE)
+ *   - Invalid entryId input
+ *   - Already resolved quota replay → already_resolved outcome
+ *   - Missing target → not_found outcome
+ *   - Incomplete audit entry details
+ *   - Standardized error envelope
+ *   - Admin audit logging on replay attempts
+ */
+
+jest.mock('better-sqlite3', () => {
+  return class MockDatabase {
+    prepare() {
+      return { get: () => null };
+    }
+    exec() {}
+    close() {}
+  };
+});
+
+jest.mock('../../config/env', () => ({
+  env: {
+    PORT: 3000,
+    NODE_ENV: 'test',
+    DATABASE_URL: 'postgresql://localhost/callora_test',
+    DB_HOST: 'localhost',
+    DB_PORT: 5432,
+    DB_USER: 'postgres',
+    DB_PASSWORD: 'postgres',
+    DB_NAME: 'callora_test',
+    DB_POOL_MAX: 1,
+    DB_IDLE_TIMEOUT_MS: 1000,
+    DB_CONN_TIMEOUT_MS: 1000,
+    JWT_SECRET: 'test-jwt-secret',
+    ADMIN_API_KEY: 'test-admin-api-key',
+    METRICS_API_KEY: 'test-metrics-api-key',
+    UPSTREAM_URL: 'http://localhost:4000',
+    PROXY_TIMEOUT_MS: 30000,
+    CORS_ALLOWED_ORIGINS: 'http://localhost:5173',
+    SOROBAN_RPC_ENABLED: false,
+    HORIZON_ENABLED: false,
+    STELLAR_TESTNET_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+    STELLAR_MAINNET_HORIZON_URL: 'https://horizon.stellar.org',
+    SOROBAN_TESTNET_RPC_URL: 'https://soroban-testnet.stellar.org',
+    SOROBAN_MAINNET_RPC_URL: 'https://soroban-mainnet.stellar.org',
+    STELLAR_BASE_FEE: 100,
+    HEALTH_CHECK_DB_TIMEOUT: 2000,
+    APP_VERSION: '1.0.0',
+    LOG_LEVEL: 'info',
+    GATEWAY_PROFILING_ENABLED: false,
+  },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { errorHandler } from '../../../middleware/errorHandler.js';
+import {
+  createAdminAuditReplayRouter,
+  type AdminAuditReplayRouterDeps,
+} from './replay.js';
+import type {
+  AuditLogEntry,
+  AuditLogRepository,
+} from '../../../repositories/auditLogRepository.js';
+import type { CreditsRepository } from '../../../repositories/creditsRepository.js';
+import type { ApiRepository, Api } from '../../../repositories/apiRepository.js';
+import type {
+  UsageAdminStore,
+  UsageAggregateSnapshot,
+} from '../../../services/usageStore.js';
+import {
+  getQuotaRequestStore,
+  setQuotaRequestStore,
+  type QuotaRequest,
+  type QuotaRequestStore,
+} from '../../../services/quotaService.js';
+
+jest.mock('../../../logger', () => {
+  const actual = jest.requireActual('../../../logger');
+  return {
+    ...actual,
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      audit: jest.fn(),
+    },
+  };
+});
+
+import { logger } from '../../../logger.js';
+
+const ADMIN_KEY = 'test-replay-admin-key';
+const JWT_SECRET = 'test-replay-jwt-secret';
+
+// ---------------------------------------------------------------------------
+// Mock repositories
+// ---------------------------------------------------------------------------
+
+class InMemoryAuditRepo implements AuditLogRepository {
+  constructor(private readonly entries: Map<string, AuditLogEntry> = new Map()) {}
+
+  setEntry(entry: AuditLogEntry): this {
+    this.entries.set(entry.id, entry);
+    return this;
+  }
+
+  findCursor(): Promise<{ entries: AuditLogEntry[]; hasMore: boolean }> {
+    return Promise.resolve({ entries: [], hasMore: false });
+  }
+
+  findById(id: string): Promise<AuditLogEntry | undefined> {
+    return Promise.resolve(this.entries.get(id));
+  }
+}
+
+class MockCreditsRepo implements CreditsRepository {
+  grantCalls: Array<{ userId: string; amountUsdc: string }> = [];
+
+  findByUserId(): Promise<undefined> {
+    return Promise.resolve(undefined);
+  }
+  getOrCreateByUserId(userId: string) {
+    return Promise.resolve({
+      id: 1,
+      user_id: userId,
+      balance_usdc: '0.00',
+      created_at: new Date(0),
+      updated_at: new Date(0),
+    });
+  }
+  updateBalance(userId: string, newBalance: string) {
+    return Promise.resolve({
+      id: 1,
+      user_id: userId,
+      balance_usdc: newBalance,
+      created_at: new Date(0),
+      updated_at: new Date(0),
+    });
+  }
+  grant(userId: string, amountUsdc: string) {
+    this.grantCalls.push({ userId, amountUsdc });
+    return Promise.resolve({
+      id: 1,
+      user_id: userId,
+      balance_usdc: amountUsdc,
+      created_at: new Date(0),
+      updated_at: new Date(),
+    });
+  }
+}
+
+class MockApiRepo implements ApiRepository {
+  deleteResults = new Map<number, boolean>();
+  restoreResults = new Map<number, Api | null>();
+
+  create() { throw new Error('not implemented'); }
+  createWithEndpoints() { throw new Error('not implemented'); }
+  update() { throw new Error('not implemented'); }
+  findById() { throw new Error('not implemented'); }
+  listByDeveloper() { throw new Error('not implemented'); }
+  listAll() { throw new Error('not implemented'); }
+  listActive() { throw new Error('not implemented'); }
+
+  delete(id: number): Promise<boolean> {
+    return Promise.resolve(this.deleteResults.get(id) ?? true);
+  }
+  restore(id: number): Promise<Api | null> {
+    return Promise.resolve(
+      this.restoreResults.has(id)
+        ? this.restoreResults.get(id)!
+        : ({ id, name: 'x', description: null, base_url: '', category: '', status: 'active', developer_id: 1, logo_url: null, created_at: new Date(0), updated_at: new Date(0), deleted_at: null } as unknown as Api),
+    );
+  }
+}
+
+class MockUsageStore implements UsageAdminStore {
+  resetResults = new Map<string, UsageAggregateSnapshot | undefined>();
+  record(): boolean { return true; }
+  hasEvent(): boolean { return false; }
+  getEvents() { return []; }
+  getUnsettledEvents() { return []; }
+  markAsSettled() { return; }
+  getDeveloperUsageSnapshot() { return undefined; }
+
+  resetDeveloperUsage(developerId: string): UsageAggregateSnapshot | undefined {
+    return this.resetResults.get(developerId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quota store helpers
+// ---------------------------------------------------------------------------
+
+function makeQuotaStore(pendingRequests: QuotaRequest[] = []): QuotaRequestStore {
+  return {
+    create: () => Promise.reject(),
+    async findById(id): Promise<QuotaRequest | undefined> {
+      return pendingRequests.find((r) => r.id === id);
+    },
+    async list(): Promise<QuotaRequest[]> {
+      return pendingRequests;
+    },
+    async update(id, changes): Promise<QuotaRequest | undefined> {
+      const r = pendingRequests.find((x) => x.id === id);
+      if (!r) return undefined;
+      return Object.assign(r, changes);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Base entry helper
+// ---------------------------------------------------------------------------
+
+const baseEntry = (overrides: Partial<AuditLogEntry> = {}): AuditLogEntry => ({
+  id: 'audit-base',
+  event: 'RESET_USAGE_AGGREGATE',
+  actor: 'admin-api-key',
+  tenantId: null,
+  clientIp: '127.0.0.1',
+  userAgent: 'jest',
+  correlationId: 'req-1',
+  bodyHash: null,
+  details: null,
+  createdAt: '2026-06-28T10:00:00.000Z',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+
+function buildApp(deps: AdminAuditReplayRouterDeps = {}) {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate adminAuth middleware paths
+  app.use((req, res, next) => {
+    const apiKey = req.headers['x-admin-api-key'];
+    if (apiKey === ADMIN_KEY) {
+      res.locals.adminActor = 'admin-api-key';
+      return next();
+    }
+
+    const auth = req.headers['authorization'];
+    if (auth?.startsWith('Bearer ')) {
+      try {
+        const payload = jwt.verify(auth.slice(7), JWT_SECRET) as { role?: string };
+        if (payload.role === 'admin') {
+          res.locals.adminActor = 'admin-jwt';
+          return next();
+        }
+      } catch {
+        // fall through
+      }
+    }
+
+    res.status(401).json({
+      code: 'UNAUTHORIZED',
+      message: 'Unauthorized: admin access required',
+      requestId: 'test',
+    });
+  });
+
+  app.use('/api/admin/audit/replay', createAdminAuditReplayRouter(deps));
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Authorization tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/audit/replay — authorization', () => {
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    process.env.JWT_SECRET = JWT_SECRET;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_API_KEY;
+    delete process.env.JWT_SECRET;
+    jest.restoreAllMocks();
+  });
+
+  it('returns 200 with a valid admin API key', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({ id: 'auth-1', details: { developerId: 'dev-1' } }));
+
+    const usageStore = new MockUsageStore();
+    usageStore.resetResults.set('dev-1', {
+      developerId: 'dev-1',
+      totalEvents: 1,
+      settledEvents: 0,
+      unsettledEvents: 1,
+      totalAmountUsdc: 0,
+      settledAmountUsdc: 0,
+      unsettledAmountUsdc: 0,
+      apiCount: 0,
+      endpointCount: 0,
+      firstEventAt: null,
+      lastEventAt: null,
+      statusCodes: {},
+    });
+
+    const app = buildApp({ auditLogRepository: auditRepo, usageStore });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'auth-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 with a valid admin JWT', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({ id: 'auth-2', details: { developerId: 'dev-2' } }));
+
+    const usageStore = new MockUsageStore();
+    usageStore.resetResults.set('dev-2', undefined);
+
+    const app = buildApp({ auditLogRepository: auditRepo, usageStore });
+    const token = jwt.sign({ role: 'admin', sub: 'admin-user' }, JWT_SECRET, { expiresIn: '1h' });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'auth-2' })
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 with no credentials', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'any' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 with a wrong API key', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'any' })
+      .set('x-admin-api-key', 'definitely-wrong');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with a non-admin JWT role', async () => {
+    const app = buildApp();
+    const token = jwt.sign({ role: 'developer', sub: 'user-1' }, JWT_SECRET, { expiresIn: '1h' });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'any' })
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/audit/replay — input validation', () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    process.env.JWT_SECRET = JWT_SECRET;
+    jest.clearAllMocks();
+    app = buildApp();
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_API_KEY;
+    delete process.env.JWT_SECRET;
+    jest.restoreAllMocks();
+  });
+
+  it('returns 400 when request body is missing', async () => {
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    // express.json() sets body to undefined or {} depending on content-type;
+    // either way the handler throws INVALID_BODY or INVALID_ENTRY_ID.
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBeDefined();
+  });
+
+  it('returns 400 when entryId is missing', async () => {
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({})
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_ENTRY_ID');
+    expect(res.body.message).toContain('entryId');
+  });
+
+  it('returns 400 when entryId is not a string', async () => {
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 12345 })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_ENTRY_ID');
+  });
+
+  it('returns 400 when entryId is empty', async () => {
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: '' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when entryId is only whitespace', async () => {
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: '   ' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Audit entry not found
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/audit/replay — entry not found', () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    process.env.JWT_SECRET = JWT_SECRET;
+    jest.clearAllMocks();
+    app = buildApp({ auditLogRepository: new InMemoryAuditRepo() });
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_API_KEY;
+    delete process.env.JWT_SECRET;
+    jest.restoreAllMocks();
+  });
+
+  it('returns 404 when no audit entry exists for entryId', async () => {
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'nonexistent-entry' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('AUDIT_ENTRY_NOT_FOUND');
+    expect(res.body.message).toContain('nonexistent-entry');
+  });
+
+  it('records a failed replay attempt in the admin audit log', async () => {
+    await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'missing-entry' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(logger.audit).toHaveBeenCalledWith(
+      'AUDIT_REPLAYED',
+      'admin-api-key',
+      expect.objectContaining({
+        originalEntryId: 'missing-entry',
+        outcome: 'error',
+        errorCode: 'AUDIT_ENTRY_NOT_FOUND',
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-replayable action type
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/audit/replay — non-replayable action', () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    process.env.JWT_SECRET = JWT_SECRET;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_API_KEY;
+    delete process.env.JWT_SECRET;
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['LIST_USERS', null],
+    ['LIST_AUDIT_LOGS', { count: 5 }],
+    ['READ_USAGE_AGGREGATE', { developerId: 'dev-1' }],
+    ['LIST_QUOTA_REQUESTS', { count: 2 }],
+    ['AUDIT_REPLAYED', { originalEntryId: 'x' }],
+    ['WEBHOOK_REPLAYED', { deliveryId: 'dlq-1' }],
+  ])('returns 400 AUDIT_ACTION_NOT_REPLAYABLE for event=%s', async (event, details) => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({ id: `nr-${event}`, event, details }));
+    app = buildApp({ auditLogRepository: auditRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: `nr-${event}` })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('AUDIT_ACTION_NOT_REPLAYABLE');
+    expect(res.body.message).toContain(event);
+  });
+
+  it('records the not_replayable outcome in the admin audit log', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({ id: 'nr-log', event: 'LIST_USERS', details: { count: 1 } }));
+    app = buildApp({ auditLogRepository: auditRepo });
+
+    await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'nr-log' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(logger.audit).toHaveBeenCalledWith(
+      'AUDIT_REPLAYED',
+      'admin-api-key',
+      expect.objectContaining({
+        originalEntryId: 'nr-log',
+        originalEvent: 'LIST_USERS',
+        outcome: 'not_replayable',
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful replays
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/audit/replay — successful replay', () => {
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    process.env.JWT_SECRET = JWT_SECRET;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_API_KEY;
+    delete process.env.JWT_SECRET;
+    setQuotaRequestStore(undefined as unknown as QuotaRequestStore);
+    jest.restoreAllMocks();
+  });
+
+  it('replays RESET_USAGE_AGGREGATE with success outcome', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'reset-1',
+      event: 'RESET_USAGE_AGGREGATE',
+      details: { developerId: 'dev-reset-ok' },
+    }));
+    const usageStore = new MockUsageStore();
+    const prior: UsageAggregateSnapshot = {
+      developerId: 'dev-reset-ok',
+      totalEvents: 10,
+      settledEvents: 0,
+      unsettledEvents: 10,
+      totalAmountUsdc: 50,
+      settledAmountUsdc: 0,
+      unsettledAmountUsdc: 50,
+      apiCount: 2,
+      endpointCount: 5,
+      firstEventAt: '2026-01-01T00:00:00.000Z',
+      lastEventAt: '2026-06-01T00:00:00.000Z',
+      statusCodes: { '200': 10 },
+    };
+    usageStore.resetResults.set('dev-reset-ok', prior);
+
+    const app = buildApp({ auditLogRepository: auditRepo, usageStore });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'reset-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.entryId).toBe('reset-1');
+    expect(res.body.data.originalEvent).toBe('RESET_USAGE_AGGREGATE');
+    expect(res.body.data.outcome).toBe('success');
+    expect(res.body.data.replayedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('replays RESET_USAGE_AGGREGATE with not_found outcome when snapshot missing', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'reset-nf',
+      event: 'RESET_USAGE_AGGREGATE',
+      details: { developerId: 'dev-missing' },
+    }));
+    const usageStore = new MockUsageStore();
+    usageStore.resetResults.set('dev-missing', undefined);
+
+    const app = buildApp({ auditLogRepository: auditRepo, usageStore });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'reset-nf' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.outcome).toBe('not_found');
+    expect(res.body.data.message).toContain('dev-missing');
+  });
+
+  it('replays APPROVE_QUOTA_REQUEST with success outcome', async () => {
+    const req: QuotaRequest = {
+      id: 'qr-approve-1',
+      developerId: 'dev-1',
+      requestedTier: 'pro',
+      reason: 'need more quota',
+      status: 'pending',
+      createdAt: new Date(),
+    };
+    setQuotaRequestStore(makeQuotaStore([req]));
+
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'qa-1',
+      event: 'APPROVE_QUOTA_REQUEST',
+      details: { requestId: 'qr-approve-1', adminNotes: 'approved during replay' },
+    }));
+
+    const app = buildApp({ auditLogRepository: auditRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'qa-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.outcome).toBe('success');
+    expect(res.body.data.originalEvent).toBe('APPROVE_QUOTA_REQUEST');
+
+    const store = getQuotaRequestStore();
+    const updated = await store.findById('qr-approve-1');
+    expect(updated?.status).toBe('approved');
+    expect(updated?.resolvedBy).toBe('admin-api-key');
+  });
+
+  it('replays APPROVE_QUOTA_REQUEST with already_resolved outcome', async () => {
+    const req: QuotaRequest = {
+      id: 'qr-already',
+      developerId: 'dev-1',
+      requestedTier: 'pro',
+      reason: 'x',
+      status: 'approved',
+      createdAt: new Date(),
+      resolvedAt: new Date(),
+      resolvedBy: 'prior-admin',
+    };
+    setQuotaRequestStore(makeQuotaStore([req]));
+
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'qa-ar',
+      event: 'APPROVE_QUOTA_REQUEST',
+      details: { requestId: 'qr-already' },
+    }));
+
+    const app = buildApp({ auditLogRepository: auditRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'qa-ar' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.outcome).toBe('already_resolved');
+    expect(res.body.data.message).toContain('qr-already');
+  });
+
+  it('replays REJECT_QUOTA_REQUEST with success outcome', async () => {
+    const req: QuotaRequest = {
+      id: 'qr-reject-1',
+      developerId: 'dev-1',
+      requestedTier: 'pro',
+      reason: 'need',
+      status: 'pending',
+      createdAt: new Date(),
+    };
+    setQuotaRequestStore(makeQuotaStore([req]));
+
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'qr-1',
+      event: 'REJECT_QUOTA_REQUEST',
+      details: { requestId: 'qr-reject-1', adminNotes: 'rejected during replay' },
+    }));
+
+    const app = buildApp({ auditLogRepository: auditRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'qr-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.outcome).toBe('success');
+
+    const store = getQuotaRequestStore();
+    const updated = await store.findById('qr-reject-1');
+    expect(updated?.status).toBe('rejected');
+  });
+
+  it('replays GRANT_PREPAID_CREDITS with success outcome', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'grant-1',
+      event: 'GRANT_PREPAID_CREDITS',
+      details: { userId: 'u-grant-1', amountUsdc: '100.00', campaign: 'GrantFox FWC26' },
+    }));
+    const creditsRepo = new MockCreditsRepo();
+
+    const app = buildApp({ auditLogRepository: auditRepo, creditsRepository: creditsRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'grant-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.outcome).toBe('success');
+    expect(creditsRepo.grantCalls).toEqual([
+      { userId: 'u-grant-1', amountUsdc: '100.00' },
+    ]);
+  });
+
+  it('replays SOFT_DELETE_API with success outcome', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'del-1',
+      event: 'SOFT_DELETE_API',
+      details: { apiId: 42 },
+    }));
+    const apiRepo = new MockApiRepo();
+    apiRepo.deleteResults.set(42, true);
+
+    const app = buildApp({ auditLogRepository: auditRepo, apiRepository: apiRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'del-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.outcome).toBe('success');
+  });
+
+  it('replays SOFT_DELETE_API with not_found outcome when already deleted', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'del-nf',
+      event: 'SOFT_DELETE_API',
+      details: { apiId: 99 },
+    }));
+    const apiRepo = new MockApiRepo();
+    apiRepo.deleteResults.set(99, false);
+
+    const app = buildApp({ auditLogRepository: auditRepo, apiRepository: apiRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'del-nf' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.outcome).toBe('not_found');
+  });
+
+  it('replays RESTORE_API with success outcome', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'rst-1',
+      event: 'RESTORE_API',
+      details: { apiId: 7 },
+    }));
+    const apiRepo = new MockApiRepo();
+
+    const app = buildApp({ auditLogRepository: auditRepo, apiRepository: apiRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'rst-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.outcome).toBe('success');
+  });
+
+  it('records AUDIT_REPLAYED audit event on success', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'logged-1',
+      event: 'SOFT_DELETE_API',
+      details: { apiId: 10 },
+    }));
+    const apiRepo = new MockApiRepo();
+
+    const app = buildApp({ auditLogRepository: auditRepo, apiRepository: apiRepo });
+
+    await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'logged-1' })
+      .set('x-admin-api-key', ADMIN_KEY)
+      .set('x-request-id', 'cor-abc');
+
+    expect(logger.audit).toHaveBeenCalledWith(
+      'AUDIT_REPLAYED',
+      'admin-api-key',
+      expect.objectContaining({
+        originalEntryId: 'logged-1',
+        originalEvent: 'SOFT_DELETE_API',
+        outcome: 'success',
+        correlationId: 'cor-abc',
+      }),
+    );
+  });
+
+  it('returns AUDIT_DETAILS_INCOMPLETE when details lack required fields', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'inc-1',
+      event: 'GRANT_PREPAID_CREDITS',
+      details: { userId: 'only-user-id' }, // missing amountUsdc
+    }));
+    const app = buildApp({ auditLogRepository: auditRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'inc-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('AUDIT_DETAILS_INCOMPLETE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response shape (standardized envelope)
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/audit/replay — response envelope', () => {
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    process.env.JWT_SECRET = JWT_SECRET;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_API_KEY;
+    delete process.env.JWT_SECRET;
+    jest.restoreAllMocks();
+  });
+
+  it('wraps the result in a { data } envelope on success', async () => {
+    const auditRepo = new InMemoryAuditRepo();
+    auditRepo.setEntry(baseEntry({
+      id: 'env-1',
+      event: 'RESTORE_API',
+      details: { apiId: 1 },
+    }));
+    const apiRepo = new MockApiRepo();
+
+    const app = buildApp({ auditLogRepository: auditRepo, apiRepository: apiRepo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'env-1' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body.data).toHaveProperty('entryId', 'env-1');
+    expect(res.body.data).toHaveProperty('outcome', 'success');
+  });
+
+  it('returns a standardized error envelope on 400 invalid input', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({})
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('code');
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('returns a standardized error envelope on 404', async () => {
+    const app = buildApp({ auditLogRepository: new InMemoryAuditRepo() });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'env-nf' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('code', 'AUDIT_ENTRY_NOT_FOUND');
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('returns a standardized error envelope on internal error', async () => {
+    const repo = new InMemoryAuditRepo();
+    jest.spyOn(repo, 'findById').mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const app = buildApp({ auditLogRepository: repo });
+
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .send({ entryId: 'env-500' })
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty('code');
+    expect(res.body).toHaveProperty('message');
+  });
+});

--- a/src/routes/admin/audit/replay.ts
+++ b/src/routes/admin/audit/replay.ts
@@ -1,0 +1,449 @@
+/**
+ * src/routes/admin/audit/replay.ts
+ *
+ * Admin audit-log replay endpoint.
+ *
+ * Route:
+ *   POST /api/admin/audit/replay
+ *
+ * Re-executes a previously audit-logged admin action using its original
+ * parameters as recorded in the `details` JSON blob of the audit entry.
+ *
+ * Authentication: adminAuth middleware applied at the parent admin router.
+ * Audit:        Every replay attempt (success or failure) is recorded via
+ *               logger.audit() with AUDIT_REPLAYED event and correlation ID.
+ *
+ * Replayable events:
+ *   - RESET_USAGE_AGGREGATE    (reset a developer's usage counters)
+ *   - APPROVE_QUOTA_REQUEST    (approve a quota increase request)
+ *   - REJECT_QUOTA_REQUEST     (reject a quota increase request)
+ *   - GRANT_PREPAID_CREDITS    (issue GrantFox prepaid credits)
+ *   - SOFT_DELETE_API          (soft-delete an API listing)
+ *   - RESTORE_API              (restore a soft-deleted API listing)
+ *
+ * Non-replayable events (read-only queries, replay of replays, etc.) return
+ * a 400 with error code AUDIT_ACTION_NOT_REPLAYABLE.
+ */
+
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { getClientIp } from '../../../lib/clientIp.js';
+import {
+  AppError,
+  BadRequestError,
+  NotFoundError,
+  InternalServerError,
+} from '../../../errors/index.js';
+import { logger } from '../../../logger.js';
+import {
+  PgAuditLogRepository,
+  type AuditLogEntry,
+  type AuditLogRepository,
+} from '../../../repositories/auditLogRepository.js';
+import {
+  approveQuotaRequest,
+  rejectQuotaRequest,
+} from '../../../services/quotaService.js';
+import {
+  defaultCreditsRepository,
+  type CreditsRepository,
+} from '../../../repositories/creditsRepository.js';
+import {
+  defaultApiRepository,
+  type ApiRepository,
+} from '../../../repositories/apiRepository.js';
+import {
+  createUsageStore,
+  type UsageAdminStore,
+} from '../../../services/usageStore.js';
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+// ---------------------------------------------------------------------------
+// Replay registry
+// ---------------------------------------------------------------------------
+
+export type ReplayOutcome =
+  | { status: 'success'; event: string; result?: unknown }
+  | { status: 'already_resolved'; event: string; message: string }
+  | { status: 'not_found'; event: string; message: string };
+
+export interface ReplayHandlerContext {
+  adminActor: string;
+}
+
+export type ReplayHandler = (
+  entry: AuditLogEntry,
+  ctx: ReplayHandlerContext,
+) => Promise<ReplayOutcome>;
+
+const REPLAYABLE_EVENTS: ReadonlySet<string> = new Set([
+  'RESET_USAGE_AGGREGATE',
+  'APPROVE_QUOTA_REQUEST',
+  'REJECT_QUOTA_REQUEST',
+  'GRANT_PREPAID_CREDITS',
+  'SOFT_DELETE_API',
+  'RESTORE_API',
+]);
+
+function isReplayable(event: string): boolean {
+  return REPLAYABLE_EVENTS.has(event);
+}
+
+function extractString(
+  details: Record<string, unknown> | null,
+  key: string,
+): string | undefined {
+  if (!details) return undefined;
+  const v = details[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+function extractNumber(
+  details: Record<string, unknown> | null,
+  key: string,
+): number | undefined {
+  if (!details) return undefined;
+  const v = details[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Router dependencies (overridable for tests)
+// ---------------------------------------------------------------------------
+
+export interface AdminAuditReplayRouterDeps {
+  auditLogRepository?: AuditLogRepository;
+  creditsRepository?: CreditsRepository;
+  apiRepository?: ApiRepository;
+  usageStore?: UsageAdminStore;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createAdminAuditReplayRouter(
+  deps: AdminAuditReplayRouterDeps = {},
+): Router {
+  const router = Router();
+  const auditLogRepository =
+    deps.auditLogRepository ?? new PgAuditLogRepository();
+  const creditsRepository =
+    deps.creditsRepository ?? defaultCreditsRepository;
+  const apiRepository = deps.apiRepository ?? defaultApiRepository;
+  const usageStore = deps.usageStore ?? createUsageStore();
+
+  /**
+   * @openapi
+   * /api/admin/audit/replay:
+   *   post:
+   *     summary: Replay a previously audit-logged admin action
+   *     description: |
+   *       Re-executes the admin action recorded in the given audit log entry
+   *       using the parameters stored in the entry's `details` field.
+   *
+   *       Only mutating admin actions are replayable (see the docs for the
+   *       full list). Read-only queries, replay-of-replay events, and any
+   *       entry without a registered replay handler will return a 400 with
+   *       `AUDIT_ACTION_NOT_REPLAYABLE`.
+   *
+   *       Every replay attempt emits its own `AUDIT_REPLAYED` audit event
+   *       linking back to the original entry ID.
+   *     security:
+   *       - AdminApiKey: []
+   *       - AdminJWT: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [ entryId ]
+   *             properties:
+   *               entryId:
+   *                 type: string
+   *                 description: The audit log entry ID (primary key of the audit_logs row).
+   *     responses:
+   *       '200':
+   *         description: Action replayed successfully.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     entryId:      { type: string }
+   *                     originalEvent:{ type: string }
+   *                     outcome:
+   *                       type: string
+   *                       enum: [success, already_resolved, not_found]
+   *                     replayedAt:   { type: string, format: date-time }
+   *                     message:      { type: string }
+   *       '400': { $ref: '#/components/responses/BadRequest' }
+   *       '401': { $ref: '#/components/responses/Unauthorized' }
+   *       '404': { $ref: '#/components/responses/NotFound' }
+   *       '500': { $ref: '#/components/responses/InternalServerError' }
+   */
+  router.post('/', async (req: Request, res: Response, next: NextFunction) => {
+    const replayedAt = new Date();
+
+    try {
+      // ── Input validation at the boundary ──────────────────────────────
+      if (!req.body || typeof req.body !== 'object') {
+        throw new BadRequestError(
+          'Request body is required',
+          'INVALID_BODY',
+        );
+      }
+
+      const { entryId } = req.body;
+
+      if (!entryId || typeof entryId !== 'string' || entryId.trim() === '') {
+        throw new BadRequestError(
+          'entryId is required and must be a non-empty string',
+          'INVALID_ENTRY_ID',
+        );
+      }
+
+      const trimmedEntryId = entryId.trim();
+
+      // ── Look up the original audit entry ──────────────────────────────
+      const originalEntry = await auditLogRepository.findById(trimmedEntryId);
+      if (!originalEntry) {
+        throw new NotFoundError(
+          `No audit log entry found for entryId: ${trimmedEntryId}`,
+          'AUDIT_ENTRY_NOT_FOUND',
+        );
+      }
+
+      // ── Non-replayable action gate ────────────────────────────────────
+      if (!isReplayable(originalEntry.event)) {
+        const error = new BadRequestError(
+          `Audit action "${originalEntry.event}" is not replayable`,
+          'AUDIT_ACTION_NOT_REPLAYABLE',
+        );
+        recordReplayAttempt(req, res, {
+          originalEntryId: trimmedEntryId,
+          originalEvent: originalEntry.event,
+          outcome: 'not_replayable',
+          replayedAt: replayedAt.toISOString(),
+          errorMessage: error.message,
+        });
+        throw error;
+      }
+
+      // ── Build the handler context and dispatch ────────────────────────
+      const adminActor = res.locals.adminActor ?? 'admin';
+      const ctx: ReplayHandlerContext = { adminActor };
+      const details = originalEntry.details;
+
+      let outcome: ReplayOutcome;
+
+      switch (originalEntry.event) {
+        case 'RESET_USAGE_AGGREGATE': {
+          const developerId = extractString(details, 'developerId');
+          if (!developerId) {
+            throw badDetails('developerId');
+          }
+          const prior = await usageStore.resetDeveloperUsage(developerId);
+          outcome = prior
+            ? { status: 'success', event: originalEntry.event, result: { developerId, priorValues: prior } }
+            : { status: 'not_found', event: originalEntry.event, message: `Usage aggregate not found for developer ${developerId}` };
+          break;
+        }
+
+        case 'APPROVE_QUOTA_REQUEST': {
+          const requestId = extractString(details, 'requestId');
+          const adminNotes = extractString(details, 'adminNotes');
+          if (!requestId) {
+            throw badDetails('requestId');
+          }
+          try {
+            const updated = await approveQuotaRequest(requestId, adminActor, adminNotes);
+            outcome = { status: 'success', event: originalEntry.event, result: { requestId, status: updated.status } };
+          } catch (e) {
+            outcome = mapQuotaError(e, originalEntry.event, requestId);
+          }
+          break;
+        }
+
+        case 'REJECT_QUOTA_REQUEST': {
+          const requestId = extractString(details, 'requestId');
+          const adminNotes = extractString(details, 'adminNotes');
+          if (!requestId) {
+            throw badDetails('requestId');
+          }
+          try {
+            const updated = await rejectQuotaRequest(requestId, adminActor, adminNotes);
+            outcome = { status: 'success', event: originalEntry.event, result: { requestId, status: updated.status } };
+          } catch (e) {
+            outcome = mapQuotaError(e, originalEntry.event, requestId);
+          }
+          break;
+        }
+
+        case 'GRANT_PREPAID_CREDITS': {
+          const userId = extractString(details, 'userId');
+          const amountUsdc = extractString(details, 'amountUsdc');
+          if (!userId || !amountUsdc) {
+            throw badDetails('userId, amountUsdc');
+          }
+          const credits = await creditsRepository.grant(userId, amountUsdc);
+          outcome = {
+            status: 'success',
+            event: originalEntry.event,
+            result: { userId, amountUsdc, balanceUsdc: credits.balance_usdc },
+          };
+          break;
+        }
+
+        case 'SOFT_DELETE_API': {
+          const apiId = extractNumber(details, 'apiId');
+          if (apiId === undefined) {
+            throw badDetails('apiId');
+          }
+          const deleted = await apiRepository.delete(apiId);
+          outcome = deleted
+            ? { status: 'success', event: originalEntry.event, result: { apiId, deleted: true } }
+            : { status: 'not_found', event: originalEntry.event, message: `API ${apiId} not found or already deleted` };
+          break;
+        }
+
+        case 'RESTORE_API': {
+          const apiId = extractNumber(details, 'apiId');
+          if (apiId === undefined) {
+            throw badDetails('apiId');
+          }
+          const restored = await apiRepository.restore(apiId);
+          outcome = restored
+            ? { status: 'success', event: originalEntry.event, result: { apiId, restored: true } }
+            : { status: 'not_found', event: originalEntry.event, message: `API ${apiId} not found or not currently deleted` };
+          break;
+        }
+
+        default:
+          // Should not reach here because of the isReplayable gate above.
+          throw new BadRequestError(
+            `Audit action "${originalEntry.event}" is not replayable`,
+            'AUDIT_ACTION_NOT_REPLAYABLE',
+          );
+      }
+
+      // ── Record successful replay attempt ──────────────────────────────
+      recordReplayAttempt(req, res, {
+        originalEntryId: trimmedEntryId,
+        originalEvent: originalEntry.event,
+        outcome: outcome.status,
+        replayedAt: replayedAt.toISOString(),
+        message:
+          outcome.status === 'success'
+            ? undefined
+            : 'message' in outcome
+              ? outcome.message
+              : undefined,
+      });
+
+      // ── Response ──────────────────────────────────────────────────────
+      return res.status(200).json({
+        data: {
+          entryId: trimmedEntryId,
+          originalEvent: originalEntry.event,
+          outcome: outcome.status,
+          replayedAt: replayedAt.toISOString(),
+          message:
+            'message' in outcome && outcome.message ? outcome.message : undefined,
+        },
+      });
+    } catch (error) {
+      if (error instanceof AppError) {
+        // Record failed attempts (404 / 400 / validation) before forwarding.
+        const originalEntryId =
+          typeof req.body?.entryId === 'string' ? req.body.entryId.trim() : undefined;
+        if (originalEntryId) {
+          recordReplayAttempt(req, res, {
+            originalEntryId,
+            originalEvent: undefined,
+            outcome: 'error',
+            replayedAt: replayedAt.toISOString(),
+            errorCode: error.code,
+            errorMessage: error.message,
+          }).catch(() => undefined);
+        }
+        next(error);
+        return;
+      }
+      logger.error('[admin] Audit replay failed unexpectedly', error);
+      next(new InternalServerError('Failed to replay audit action'));
+    }
+  });
+
+  // ── Helpers used inside the route ────────────────────────────────────
+
+  function badDetails(fields: string): BadRequestError {
+    return new BadRequestError(
+      `Audit entry details are missing required field(s): ${fields}`,
+      'AUDIT_DETAILS_INCOMPLETE',
+    );
+  }
+
+  function mapQuotaError(
+    e: unknown,
+    event: string,
+    requestId: string,
+  ): ReplayOutcome {
+    if (e instanceof AppError) {
+      if (e.code === 'QUOTA_REQUEST_NOT_FOUND') {
+        return {
+          status: 'not_found',
+          event,
+          message: `Quota request ${requestId} not found`,
+        };
+      }
+      if (e.code === 'QUOTA_REQUEST_ALREADY_RESOLVED') {
+        return {
+          status: 'already_resolved',
+          event,
+          message: `Quota request ${requestId} is already resolved`,
+        };
+      }
+    }
+    throw e;
+  }
+
+  function recordReplayAttempt(
+    req: Request,
+    res: Response,
+    payload: {
+      originalEntryId: string;
+      originalEvent: string | undefined;
+      outcome: string;
+      replayedAt: string;
+      message?: string | undefined;
+      errorCode?: string | undefined;
+      errorMessage?: string | undefined;
+    },
+  ): void {
+    const correlationId =
+      (typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : undefined) ??
+      (typeof req.headers['x-correlation-id'] === 'string' ? req.headers['x-correlation-id'] : undefined);
+
+    logger.audit('AUDIT_REPLAYED', res.locals.adminActor, {
+      originalEntryId: payload.originalEntryId,
+      originalEvent: payload.originalEvent,
+      outcome: payload.outcome,
+      replayedAt: payload.replayedAt,
+      message: payload.message,
+      errorCode: payload.errorCode,
+      errorMessage: payload.errorMessage,
+      clientIp: getClientIp(req, TRUST_PROXY),
+      userAgent: req.get('User-Agent'),
+      correlationId,
+    });
+  }
+
+  return router;
+}
+
+export default createAdminAuditReplayRouter();


### PR DESCRIPTION
Replays previously audit-logged admin actions using stored details JSON parameters. Supports RESET_USAGE_AGGREGATE, APPROVE_QUOTA_REQUEST, REJECT_QUOTA_REQUEST, GRANT_PREPAID_CREDITS, SOFT_DELETE_API, RESTORE_API.
- AuditLogRepository.findById() for by-id entry lookup
- Idempotent outcomes: success / already_resolved / not_found (all 200)
- Boundary validation: INVALID_BODY, INVALID_ENTRY_ID, AUDIT_ENTRY_NOT_FOUND, AUDIT_ACTION_NOT_REPLAYABLE, AUDIT_DETAILS_INCOMPLETE
- Every attempt emits AUDIT_REPLAYED audit event with originalEntryId, outcome, correlationId propagation
- Tests cover auth, input, 404, non-replayable, per-event success/not_found/ already_resolved, incomplete details, envelope shapes
- Docs: replay events table, outcome semantics, error matrix, curl example
Closes #617 