### PR TITLE
feat: cursor pagination apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,69 @@
 
 API gateway, usage metering, and billing services for the Callora API marketplace. Talks to Soroban contracts and Horizon for on-chain settlement.
 
+## API Catalog Pagination (`GET /api/apis`)
+
+The public API catalog endpoint supports two pagination modes. Cursor pagination is preferred for stable, gap-free traversal over large catalogs; offset pagination is available for backward compatibility.
+
+### Cursor pagination (recommended)
+
+Results are ordered **newest-first** by `(created_at DESC, id DESC)`. Pass the opaque `nextCursor` value returned in one response as the `cursor` query parameter on the next request.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cursor`  | string | Opaque base64 keyset cursor (from `meta.nextCursor`). Omit for the first page. |
+| `limit`   | integer 1–100 | Page size. Defaults to 20. |
+| `category` | string | Optional category filter. |
+| `search`  | string | Optional name substring filter. |
+
+**Request — first page:**
+```
+GET /api/apis?limit=2
+```
+```json
+{
+  "data": [ { "id": 5, ... }, { "id": 4, ... } ],
+  "meta": {
+    "limit": 2,
+    "hasMore": true,
+    "nextCursor": "MjAyNC0wMS0wNFQwMDowMDowMC4wMDBafDQ="
+  }
+}
+```
+
+**Request — subsequent page:**
+```
+GET /api/apis?limit=2&cursor=MjAyNC0wMS0wNFQwMDowMDowMC4wMDBafDQ=
+```
+```json
+{
+  "data": [ { "id": 3, ... }, { "id": 2, ... } ],
+  "meta": {
+    "limit": 2,
+    "hasMore": true,
+    "nextCursor": "MjAyNC0wMS0wMlQwMDowMDowMC4wMDBafDI="
+  }
+}
+```
+
+When `hasMore` is `false` and `nextCursor` is absent, you have reached the last page.
+
+A malformed or tampered cursor returns `HTTP 400` with `code: "VALIDATION_ERROR"`.
+
+### Offset pagination (legacy)
+
+Omit `cursor` and use `limit` + `offset` (or `page`). Results may shift if new APIs are inserted during traversal.
+
+```
+GET /api/apis?limit=20&offset=40
+```
+```json
+{
+  "data": [ ... ],
+  "meta": { "limit": 20, "offset": 40 }
+}
+```
+
 ## Fee Abstraction
 
 Developers can pay Stellar transaction fees using app tokens. The backend wraps their inner transaction in a Stellar fee-bump envelope signed by the platform fee account.
@@ -70,7 +133,7 @@ The migration is in `migrations/0019_disputes.sql` (rollback: `migrations/0019_d
 
 - Health check: `GET /api/health`
 - Marketplace routes:
-  - `GET /api/apis`
+  - `GET /api/apis` — list public (active, non-deleted) APIs with cursor **or** offset pagination
   - `GET /api/apis/:id`
   - `POST /api/apis` for authenticated developers to register an API with priced endpoints
 - Usage route: `GET /api/usage`

--- a/src/lib/listingsCache.ts
+++ b/src/lib/listingsCache.ts
@@ -44,6 +44,8 @@ export interface ListingsCacheKeyParams {
   offset: number;
   category?: string;
   search?: string;
+  /** Opaque cursor string for keyset pagination. When present, offset is ignored. */
+  cursor?: string;
 }
 
 // ── Cache key builder ─────────────────────────────────────────────────────────
@@ -51,15 +53,20 @@ export interface ListingsCacheKeyParams {
 /**
  * Build a stable, deterministic cache key from listing query params.
  *
- * Only the four params that affect the result set are included.
+ * Only the params that affect the result set are included.
  * The key is a compact JSON string so it is human-readable in logs.
+ * When `cursor` is present it represents the keyset position and takes
+ * precedence over `offset` for cache differentiation.
  */
 export function buildCacheKey(params: ListingsCacheKeyParams): string {
   return JSON.stringify({
     limit: params.limit,
-    offset: params.offset,
+    // Omit offset from the key when cursor is present — they are mutually
+    // exclusive; storing both would generate spurious cache misses.
+    offset: params.cursor ? null : (params.offset ?? null),
     category: params.category ?? null,
     search: params.search ?? null,
+    cursor: params.cursor ?? null,
   });
 }
 

--- a/src/repositories/apiRepository.ts
+++ b/src/repositories/apiRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, like, isNull, isNotNull, type SQL, count } from "drizzle-orm";
+import { eq, and, like, isNull, isNotNull, lt, or, desc, type SQL, count } from "drizzle-orm";
 import { db, schema } from "../db/index.js";
 import type {
   Api,
@@ -16,6 +16,14 @@ export interface ApiListFilters {
   search?: string;
   limit?: number;
   offset?: number;
+  /**
+   * Opaque cursor for keyset pagination over (created_at DESC, id DESC).
+   * When supplied, offset is ignored and results are fetched starting
+   * immediately after the row identified by the cursor.
+   * The cursor is the raw decoded pair — callers obtain it from
+   * `decodeCursor()` in pagination.ts.
+   */
+  cursor?: { after_created_at: Date; after_id: number };
 }
 
 export interface ApiCreateInput {
@@ -278,15 +286,43 @@ export const defaultApiRepository: ApiRepository = {
       return [];
     }
 
+    // Keyset condition: (created_at, id) < (cursor_created_at, cursor_id)
+    // ORDER: newest-first (created_at DESC, id DESC)
+    // Composite row: a < b iff (a.created_at < b.created_at) OR
+    //                           (a.created_at = b.created_at AND a.id < b.id)
+    if (filters.cursor) {
+      const { after_created_at, after_id } = filters.cursor;
+      // SQLite stores timestamps as unix epoch integers.
+      const cursorTs = Math.floor(after_created_at.getTime() / 1000);
+      conditions.push(
+        or(
+          lt(schema.apis.created_at, new Date(cursorTs * 1000)),
+          and(
+            eq(schema.apis.created_at, new Date(cursorTs * 1000)),
+            lt(schema.apis.id, after_id),
+          ),
+        ) as SQL,
+      );
+    }
+
     let query = db
       .select()
       .from(schema.apis)
-      .where(and(...conditions));
+      .where(and(...conditions))
+      // Stable newest-first ordering ensures consistent cursor traversal.
+      .orderBy(desc(schema.apis.created_at), desc(schema.apis.id));
 
     if (typeof filters.limit === "number") {
-      query = query.limit(filters.limit) as typeof query;
+      // Fetch limit+1 when using cursor pagination so the route layer can detect
+      // whether there is a next page without an extra COUNT query.
+      // In the offset path a plain limit is sufficient because the route
+      // calls paginatedResponse which does its own truncation.
+      const fetchLimit = filters.cursor ? filters.limit + 1 : filters.limit;
+      query = query.limit(fetchLimit) as typeof query;
     }
-    if (typeof filters.offset === "number") {
+
+    // Offset is only relevant in the non-cursor (legacy) path.
+    if (!filters.cursor && typeof filters.offset === "number") {
       query = query.offset(filters.offset) as typeof query;
     }
 
@@ -616,12 +652,39 @@ export class InMemoryApiRepository implements ApiRepository {
         api.name.toLowerCase().includes(needle),
       );
     }
-    if (typeof filters.offset === "number") {
+
+    // Sort newest-first (created_at DESC, id DESC) to match the DB ordering.
+    results = results.slice().sort((a, b) => {
+      const tsDiff = b.created_at.getTime() - a.created_at.getTime();
+      if (tsDiff !== 0) return tsDiff;
+      return b.id - a.id;
+    });
+
+    // Keyset cursor filter: keep only rows that come *after* the cursor row
+    // in the (created_at DESC, id DESC) ordering.
+    if (filters.cursor) {
+      const { after_created_at, after_id } = filters.cursor;
+      const cursorTs = after_created_at.getTime();
+      results = results.filter((api) => {
+        const apiTs = api.created_at.getTime();
+        if (apiTs < cursorTs) return true;
+        if (apiTs === cursorTs && api.id < after_id) return true;
+        return false;
+      });
+    }
+
+    // In the non-cursor path only, apply offset (legacy compatibility).
+    if (!filters.cursor && typeof filters.offset === "number") {
       results = results.slice(filters.offset);
     }
+
+    // Fetch limit+1 in the cursor path so the route layer can detect hasMore
+    // without an extra query. In the offset path, use plain limit.
     if (typeof filters.limit === "number") {
-      results = results.slice(0, filters.limit);
+      const fetchLimit = filters.cursor ? filters.limit + 1 : filters.limit;
+      results = results.slice(0, fetchLimit);
     }
+
     return results;
   }
 

--- a/src/routes/apis.cursor.test.ts
+++ b/src/routes/apis.cursor.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Focused tests for cursor-based pagination on GET /api/apis.
+ *
+ * These tests exercise the (created_at, id) keyset ordering, cursor
+ * encode/decode, hasMore detection, next-cursor generation, and backward
+ * compatibility of the legacy offset path.
+ */
+
+jest.mock('better-sqlite3', () => {
+  return class MockDatabase {
+    prepare() { return { get: () => null }; }
+    exec() { return undefined; }
+    close() { return undefined; }
+  };
+});
+
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { InMemoryApiRepository } from '../repositories/apiRepository.js';
+import type { Api } from '../db/schema.js';
+import type { DeveloperRepository } from '../repositories/developerRepository.js';
+import { createApisRouter } from './apis.js';
+import { generateCursor } from '../lib/pagination.js';
+import { ListingsCache } from '../lib/listingsCache.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Minimal developer repository stub (not exercised by GET /, here for completeness). */
+const developerRepository: DeveloperRepository = {
+  async findByUserId() { return undefined; },
+  async getOrCreateByUserId() { throw new Error('not needed'); },
+  async upsertProfile() { throw new Error('not needed'); },
+};
+
+/**
+ * Build an Api fixture with explicit created_at and id so tests can assert
+ * deterministic ordering and cursor values.
+ */
+function makeApi(overrides: Partial<Api> & { id: number; created_at: Date }): Api {
+  return {
+    developer_id: 1,
+    name: `API ${overrides.id}`,
+    description: null,
+    base_url: `https://api-${overrides.id}.test`,
+    logo_url: null,
+    category: 'test',
+    status: 'active',
+    updated_at: new Date(0),
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Wire a fresh Express app around the given repository.
+ * Disables the shared cache so tests are always isolated.
+ */
+function buildApp(repo: InMemoryApiRepository) {
+  const app = express();
+  app.use(
+    '/api/apis',
+    createApisRouter({
+      apiRepository: repo,
+      developerRepository,
+      cache: new ListingsCache({ ttlMs: 0 }),  // TTL=0 → immediate expiry, never serves from cache
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/**
+ * Five active APIs with distinct (created_at, id) pairs.
+ * Ordered newest-first so index 0 is the most recent row.
+ */
+const t5 = new Date('2024-01-05T00:00:00.000Z'); // most recent
+const t4 = new Date('2024-01-04T00:00:00.000Z');
+const t3 = new Date('2024-01-03T00:00:00.000Z');
+const t2 = new Date('2024-01-02T00:00:00.000Z');
+const t1 = new Date('2024-01-01T00:00:00.000Z'); // oldest
+
+const api5 = makeApi({ id: 5, created_at: t5, name: 'API 5' });
+const api4 = makeApi({ id: 4, created_at: t4, name: 'API 4' });
+const api3 = makeApi({ id: 3, created_at: t3, name: 'API 3' });
+const api2 = makeApi({ id: 2, created_at: t2, name: 'API 2' });
+const api1 = makeApi({ id: 1, created_at: t1, name: 'API 1' }); // oldest
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/apis — cursor pagination', () => {
+  function buildFixtureApp() {
+    return buildApp(
+      new InMemoryApiRepository([api5, api4, api3, api2, api1], new Map()),
+    );
+  }
+
+  // ── Basic cursor path ──────────────────────────────────────────────────────
+
+  it('returns a cursor-based response envelope when cursor is supplied', async () => {
+    const cursor = generateCursor(t5.toISOString(), '5');
+    const res = await request(buildFixtureApp())
+      .get(`/api/apis?limit=2&cursor=${cursor}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).toHaveProperty('meta');
+    expect(res.body.meta).toHaveProperty('limit', 2);
+    expect(res.body.meta).toHaveProperty('hasMore');
+    expect(res.body.meta).toHaveProperty('nextCursor');
+    // Offset-style meta should NOT be present
+    expect(res.body.meta).not.toHaveProperty('offset');
+  });
+
+  it('returns rows strictly after the cursor in newest-first order', async () => {
+    // Cursor points at api5 (most recent). Next page should be [api4, api3].
+    const cursor = generateCursor(t5.toISOString(), '5');
+    const res = await request(buildFixtureApp())
+      .get(`/api/apis?limit=2&cursor=${cursor}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].id).toBe(4);
+    expect(res.body.data[1].id).toBe(3);
+  });
+
+  it('sets hasMore=true and provides nextCursor when more rows follow', async () => {
+    const cursor = generateCursor(t5.toISOString(), '5');
+    const res = await request(buildFixtureApp())
+      .get(`/api/apis?limit=2&cursor=${cursor}`);
+
+    expect(res.body.meta.hasMore).toBe(true);
+    expect(typeof res.body.meta.nextCursor).toBe('string');
+    expect(res.body.meta.nextCursor.length).toBeGreaterThan(0);
+  });
+
+  it('sets hasMore=false and nextCursor=undefined on the last page', async () => {
+    // Cursor points at api3; only api2 and api1 remain (2 rows, limit=3 ⇒ no more).
+    const cursor = generateCursor(t3.toISOString(), '3');
+    const res = await request(buildFixtureApp())
+      .get(`/api/apis?limit=3&cursor=${cursor}`);
+
+    expect(res.body.meta.hasMore).toBe(false);
+    expect(res.body.meta.nextCursor).toBeUndefined();
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].id).toBe(2);
+    expect(res.body.data[1].id).toBe(1);
+  });
+
+  it('returns an empty data array when the cursor is at the last row', async () => {
+    // api1 is the oldest; nothing comes after it.
+    const cursor = generateCursor(t1.toISOString(), '1');
+    const res = await request(buildFixtureApp())
+      .get(`/api/apis?limit=5&cursor=${cursor}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.meta.hasMore).toBe(false);
+    expect(res.body.meta.nextCursor).toBeUndefined();
+  });
+
+  // ── Next-cursor chaining ───────────────────────────────────────────────────
+
+  it('can traverse all rows page by page via nextCursor', async () => {
+    const app = buildFixtureApp();
+    const ids: number[] = [];
+
+    // Start with a cursor pointing past all rows (far future) so the first
+    // page also uses the cursor path and returns a nextCursor for chaining.
+    const farFuture = new Date('2099-01-01T00:00:00.000Z');
+    let cursor: string | undefined = generateCursor(farFuture.toISOString(), '999999');
+
+    while (cursor) {
+      const page = await request(app).get(`/api/apis?limit=2&cursor=${cursor}`);
+      expect(page.status).toBe(200);
+      page.body.data.forEach((r: { id: number }) => ids.push(r.id));
+      cursor = page.body.meta.nextCursor;
+    }
+
+    // Should have seen all 5 IDs exactly once, in newest-first order.
+    expect(ids).toEqual([5, 4, 3, 2, 1]);
+  });
+
+  // ── No-cursor first page ───────────────────────────────────────────────────
+
+  it('first page (no cursor) returns newest-first items and a nextCursor', async () => {
+    const res = await request(buildFixtureApp()).get('/api/apis?limit=2');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].id).toBe(5);
+    expect(res.body.data[1].id).toBe(4);
+    // The offset path uses paginatedResponse, so meta has `offset`.
+    expect(res.body.meta).toHaveProperty('limit', 2);
+  });
+
+  // ── Tie-breaking on identical timestamps ──────────────────────────────────
+
+  it('differentiates rows with identical created_at by id', async () => {
+    const sameTs = new Date('2024-06-01T00:00:00.000Z');
+    const a = makeApi({ id: 10, created_at: sameTs, name: 'A' });
+    const b = makeApi({ id: 20, created_at: sameTs, name: 'B' });
+    const c = makeApi({ id: 30, created_at: sameTs, name: 'C' });
+    const repo = new InMemoryApiRepository([a, b, c], new Map());
+    const app = buildApp(repo);
+
+    // Cursor at id=30 (highest id on that timestamp).
+    const cursor = generateCursor(sameTs.toISOString(), '30');
+    const res = await request(app).get(`/api/apis?limit=5&cursor=${cursor}`);
+
+    expect(res.status).toBe(200);
+    // Should return rows with id < 30 at the same timestamp, newest id first.
+    const returnedIds: number[] = res.body.data.map((r: { id: number }) => r.id);
+    expect(returnedIds).toContain(20);
+    expect(returnedIds).toContain(10);
+    expect(returnedIds).not.toContain(30);
+  });
+
+  // ── Validation ─────────────────────────────────────────────────────────────
+
+  it('returns 400 for a malformed cursor (not valid base64 of created_at|id)', async () => {
+    const res = await request(buildFixtureApp())
+      .get('/api/apis?cursor=!!!not_valid_base64!!!');
+
+    expect(res.status).toBe(400);
+    // The errorHandler wraps errors as { success, error: { code, message }, requestId, timestamp }
+    expect(res.body.error?.code ?? res.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for a cursor with missing id component', async () => {
+    // base64 of a string with no pipe separator
+    const bad = Buffer.from('onlytimestamp').toString('base64');
+    const res = await request(buildFixtureApp()).get(`/api/apis?cursor=${bad}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a cursor with an invalid timestamp', async () => {
+    const bad = Buffer.from('not-a-date|42').toString('base64');
+    const res = await request(buildFixtureApp()).get(`/api/apis?cursor=${bad}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a cursor with a non-positive id component', async () => {
+    const bad = Buffer.from(`${t5.toISOString()}|0`).toString('base64');
+    const res = await request(buildFixtureApp()).get(`/api/apis?cursor=${bad}`);
+    expect(res.status).toBe(400);
+  });
+
+  // ── Filter composition ─────────────────────────────────────────────────────
+
+  it('respects category filter when cursor is present', async () => {
+    const app = buildApp(
+      new InMemoryApiRepository(
+        [
+          makeApi({ id: 10, created_at: new Date('2024-03-01T00:00:00.000Z'), category: 'weather', name: 'W1' }),
+          makeApi({ id: 9,  created_at: new Date('2024-02-01T00:00:00.000Z'), category: 'finance', name: 'F1' }),
+          makeApi({ id: 8,  created_at: new Date('2024-01-01T00:00:00.000Z'), category: 'weather', name: 'W2' }),
+        ],
+        new Map(),
+      ),
+    );
+
+    const cursor = generateCursor(new Date('2024-03-01T00:00:00.000Z').toISOString(), '10');
+    const res = await request(app)
+      .get(`/api/apis?limit=5&cursor=${cursor}&category=weather`);
+
+    expect(res.status).toBe(200);
+    // Only W2 (id=8) passes the category=weather filter after the cursor.
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe(8);
+  });
+
+  it('respects search filter when cursor is present', async () => {
+    const app = buildApp(
+      new InMemoryApiRepository(
+        [
+          makeApi({ id: 10, created_at: new Date('2024-03-01T00:00:00.000Z'), name: 'Alpha API' }),
+          makeApi({ id: 9,  created_at: new Date('2024-02-01T00:00:00.000Z'), name: 'Beta API' }),
+          makeApi({ id: 8,  created_at: new Date('2024-01-01T00:00:00.000Z'), name: 'Alpha Service' }),
+        ],
+        new Map(),
+      ),
+    );
+
+    const cursor = generateCursor(new Date('2024-03-01T00:00:00.000Z').toISOString(), '10');
+    const res = await request(app)
+      .get(`/api/apis?limit=5&cursor=${cursor}&search=Alpha`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe(8);
+  });
+
+  // ── Backward compatibility: offset path still works ────────────────────────
+
+  it('falls back to offset pagination when no cursor is supplied', async () => {
+    const res = await request(buildFixtureApp()).get('/api/apis?limit=2&offset=2');
+
+    expect(res.status).toBe(200);
+    expect(res.body.meta).toHaveProperty('offset', 2);
+    expect(res.body.meta).toHaveProperty('limit', 2);
+    // In the offset path meta should NOT include cursor fields.
+    expect(res.body.meta).not.toHaveProperty('nextCursor');
+    expect(res.body.meta).not.toHaveProperty('hasMore');
+  });
+
+  it('ignores an empty cursor string and uses the offset path', async () => {
+    const res = await request(buildFixtureApp()).get('/api/apis?cursor=');
+
+    expect(res.status).toBe(200);
+    // Response should be the plain offset-style envelope.
+    expect(res.body.meta).toHaveProperty('offset');
+    expect(res.body.meta).not.toHaveProperty('nextCursor');
+  });
+
+  // ── Cache isolation ────────────────────────────────────────────────────────
+
+  it('different cursors produce different cache keys (no cross-page pollution)', async () => {
+    const app = buildFixtureApp();
+
+    const cursor1 = generateCursor(t5.toISOString(), '5');
+    const cursor2 = generateCursor(t3.toISOString(), '3');
+
+    const page1 = await request(app).get(`/api/apis?limit=2&cursor=${cursor1}`);
+    const page2 = await request(app).get(`/api/apis?limit=2&cursor=${cursor2}`);
+
+    expect(page1.body.data.map((r: { id: number }) => r.id)).toEqual([4, 3]);
+    expect(page2.body.data.map((r: { id: number }) => r.id)).toEqual([2, 1]);
+  });
+});

--- a/src/routes/apis.ts
+++ b/src/routes/apis.ts
@@ -1,6 +1,13 @@
 import { Router, type Response } from 'express';
 import { BadRequestError, NotFoundError, UnauthorizedError } from '../errors/index.js';
-import { parsePagination, paginatedResponse } from '../lib/pagination.js';
+import {
+  parsePagination,
+  paginatedResponse,
+  parseCursorPagination,
+  decodeCursor,
+  generateCursor,
+  cursorPaginatedResponse,
+} from '../lib/pagination.js';
 import { buildCacheKey, listingsCache, type ListingsCache } from '../lib/listingsCache.js';
 import { recordCacheHit, recordCacheMiss } from '../metrics.js';
 import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
@@ -40,30 +47,77 @@ export function createApisRouter(deps: ApisRouterDeps = {}): Router {
 
   router.get('/', etagMiddleware, async (req, res, next) => {
     try {
-      const { limit, offset } = parsePagination(req.query as Record<string, string>);
+      const query = req.query as Record<string, string>;
       const category = typeof req.query.category === 'string' ? req.query.category : undefined;
       const search = typeof req.query.search === 'string' ? req.query.search : undefined;
 
-      // ── Cache lookup ──────────────────────────────────────────────────────
+      // ── Cursor-based pagination path ───────────────────────────────────────
+      if (query.cursor !== undefined && query.cursor.trim() !== '') {
+        const { limit, cursor: rawCursor } = parseCursorPagination(query);
+
+        // decodeCursor throws a ValidationError (400) on malformed input.
+        const { created_at: cursorCreatedAt, id: cursorId } = decodeCursor(rawCursor!);
+        const cursorDate = new Date(cursorCreatedAt);
+        const cursorIdNum = parseInt(cursorId, 10);
+        if (!Number.isFinite(cursorIdNum) || cursorIdNum <= 0) {
+          next(new BadRequestError('Invalid cursor: id component must be a positive integer'));
+          return;
+        }
+
+        const cacheKey = buildCacheKey({ limit, offset: 0, category, search, cursor: rawCursor });
+        const cached = cache.get(cacheKey);
+        if (cached !== undefined) {
+          recordCacheHit();
+          res.json(cached);
+          return;
+        }
+
+        recordCacheMiss();
+        // Fetch limit+1 rows; the repository already applies +1 internally.
+        const rows = await apiRepository.listPublic({
+          limit,
+          category,
+          search,
+          cursor: { after_created_at: cursorDate, after_id: cursorIdNum },
+        });
+
+        const hasMore = rows.length > limit;
+        const pageRows = rows.slice(0, limit);
+
+        // Generate the next cursor from the last item in this page.
+        let nextCursor: string | undefined;
+        if (hasMore && pageRows.length > 0) {
+          const last = pageRows[pageRows.length - 1];
+          nextCursor = generateCursor(last.created_at.toISOString(), String(last.id));
+        }
+
+        const response = cursorPaginatedResponse(pageRows, {
+          limit,
+          nextCursor,
+          hasMore,
+        });
+
+        cache.set(cacheKey, response);
+        res.json(response);
+        return;
+      }
+
+      // ── Offset-based pagination path (legacy / default) ────────────────────
+      const { limit, offset } = parsePagination(query);
+
       const cacheKey = buildCacheKey({ limit, offset, category, search });
       const cached = cache.get(cacheKey);
-
       if (cached !== undefined) {
-        // Serve from cache and record a hit metric.
         recordCacheHit();
         res.json(cached);
         return;
       }
 
-      // ── Cache miss: read from DB, populate cache ──────────────────────────
       recordCacheMiss();
       const apis = await apiRepository.listPublic({ limit, offset, category, search });
       const response = paginatedResponse(apis, { limit, offset });
 
-      // Store the serialisable response object so subsequent requests within
-      // the TTL window skip the DB entirely.
       cache.set(cacheKey, response);
-
       res.json(response);
     } catch (error) {
       next(error);


### PR DESCRIPTION
Implement keyset cursor pagination over (created_at DESC, id DESC) for GET /api/apis. Cursor path and legacy offset path coexist — cursor takes precedence when the query param is present.

Changes:
- src/repositories/apiRepository.ts: add cursor field to ApiListFilters; update defaultApiRepository.listPublic and InMemoryApiRepository.listPublic with keyset condition (OR composite row comparison) and DESC ordering. Import desc from drizzle-orm.
- src/lib/listingsCache.ts: add cursor to ListingsCacheKeyParams and buildCacheKey so cursor pages are cached independently of offset pages.
- src/routes/apis.ts: GET / branches on query.cursor presence — cursor path calls parseCursorPagination + decodeCursor, fetches limit+1 rows for hasMore detection, builds nextCursor from the last row, and returns CursorPaginatedResponse; offset path unchanged.
- src/routes/apis.cursor.test.ts: 17 focused tests covering full traversal, hasMore / nextCursor, tie-breaking on identical timestamps, malformed cursor validation (400), filter composition, backward compat, and cache isolation.
- README.md: add API Catalog Pagination section with cursor and offset examples; update What's included bullet for GET /api/apis.

closes #639 