### PR TITLE
feat(backend): add graceful timeout on /api/spike with cooperative abort

### DIFF
--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -1,0 +1,61 @@
+import { type Request, type Response, type NextFunction } from 'express';
+import { GatewayTimeoutError } from '../errors/index.js';
+
+export interface TimeoutOptions {
+  timeoutMs: number;
+}
+
+/**
+ * Middleware that applies a per-request timeout.
+ * Attaches a standard AbortSignal to `req.signal` for cooperative abort logic.
+ */
+export function timeoutMiddleware(options: TimeoutOptions) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Determine timeout duration (default to options.timeoutMs)
+    let timeoutMs = options.timeoutMs;
+
+    // Check query parameter override
+    if (typeof req.query.timeout === 'string') {
+      const parsed = parseInt(req.query.timeout, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        timeoutMs = parsed;
+      }
+    }
+
+    // Check header override
+    const headerTimeout = req.header('x-timeout-ms');
+    if (headerTimeout) {
+      const parsed = parseInt(headerTimeout, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        timeoutMs = parsed;
+      }
+    }
+
+    // 2. Set up AbortController for cooperative abort
+    const controller = new AbortController();
+    req.signal = controller.signal;
+
+    // 3. Set timeout timer
+    const timer = setTimeout(() => {
+      if (!res.headersSent) {
+        controller.abort();
+        next(new GatewayTimeoutError('Request timeout exceeded'));
+      }
+    }, timeoutMs);
+
+    // 4. Register cleanup event listeners
+    res.on('finish', () => {
+      clearTimeout(timer);
+    });
+
+    res.on('close', () => {
+      clearTimeout(timer);
+      // If the client disconnects or connection drops, trigger cooperative abort
+      if (!res.headersSent) {
+        controller.abort();
+      }
+    });
+
+    next();
+  };
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,7 @@ import billingRouter from './billing.js';
 import { createBillingPortalRouter } from './billing/portal.js';
 import healthRouter from './health.js';
 import { createApisRouter, type ApisRouterDeps } from './apis.js';
+import { createSpikeRouter } from './spike.js';
 import { createUsageRouter, type UsageRouterDeps } from './usage.js';
 import { createLimitsRouter } from './limits.js';
 import { InMemoryRestRateLimiter } from '../middleware/restRateLimit.js';
@@ -36,6 +37,7 @@ export function createApiRouter(deps: ApiRouterDeps = {}): Router {
   const router = Router();
 
   router.use('/health', healthRouter);
+  router.use('/spike', createSpikeRouter());
   
   router.use('/apis', createApisRouter({
     apiRepository: deps.apiRepository,

--- a/src/routes/spike.ts
+++ b/src/routes/spike.ts
@@ -1,0 +1,46 @@
+import { Router } from 'express';
+import { timeoutMiddleware } from '../middleware/timeout.js';
+
+export function createSpikeRouter(): Router {
+  const router = Router();
+
+  // Apply timeout middleware with a default 1000ms limit
+  router.get('/', timeoutMiddleware({ timeoutMs: 1000 }), async (req, res, next) => {
+    try {
+      // Determine the duration of the simulated task (defaults to 2000ms)
+      let delay = 2000;
+      if (typeof req.query.delay === 'string') {
+        const parsed = parseInt(req.query.delay, 10);
+        if (!isNaN(parsed) && parsed > 0) {
+          delay = parsed;
+        }
+      }
+
+      const sleepInterval = 50; // Check status every 50ms
+      let elapsed = 0;
+
+      while (elapsed < delay) {
+        // Cooperative Abort Check: Check if the request has been aborted/timed out
+        if (req.signal?.aborted) {
+          // Exit early cooperatively. Do not try to write to res or call next()
+          // because the timeout middleware has already sent the 504 response.
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, sleepInterval));
+        elapsed += sleepInterval;
+      }
+
+      // If completed successfully without timeout, send 200 response
+      res.json({
+        success: true,
+        message: 'Spike completed successfully',
+        delay,
+        elapsed,
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -24,6 +24,8 @@ declare global {
       apiKeyValue?: string;
       /** Enriched forensic context attached by auditEnrichMiddleware. */
       auditContext: AuditContext;
+      /** AbortSignal for request timeout or client cancellation. */
+      signal?: AbortSignal;
     }
   }
 }

--- a/tests/integration/spike.test.ts
+++ b/tests/integration/spike.test.ts
@@ -1,0 +1,63 @@
+process.env.JWT_SECRET = 'test-secret';
+process.env.ADMIN_API_KEY = 'test-admin-key';
+process.env.METRICS_API_KEY = 'test-metrics-key';
+
+import { jest } from '@jest/globals';
+
+jest.mock('better-sqlite3', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      prepare: jest.fn().mockReturnValue({ get: jest.fn() }),
+      exec: jest.fn(),
+      close: jest.fn(),
+    };
+  });
+});
+
+import request from 'supertest';
+import { createApp } from '../../src/app.js';
+
+describe('Spike Route Timeout Integration Tests', () => {
+  let app: any;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  it('should complete successfully (200 OK) when delay is smaller than timeout', async () => {
+    const res = await request(app)
+      .get('/api/spike?delay=100&timeout=500');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.delay).toBe(100);
+  });
+
+  it('should timeout (504 Gateway Timeout) when delay is larger than default timeout (1000ms)', async () => {
+    const res = await request(app)
+      .get('/api/spike?delay=1200'); // default timeout is 1000ms
+
+    expect(res.status).toBe(504);
+    expect(res.body.code).toBe('GATEWAY_TIMEOUT');
+    expect(res.body.message).toBe('Request timeout exceeded');
+  });
+
+  it('should timeout (504 Gateway Timeout) when delay is larger than custom query timeout', async () => {
+    const res = await request(app)
+      .get('/api/spike?delay=500&timeout=200');
+
+    expect(res.status).toBe(504);
+    expect(res.body.code).toBe('GATEWAY_TIMEOUT');
+    expect(res.body.message).toBe('Request timeout exceeded');
+  });
+
+  it('should support custom timeout via x-timeout-ms header', async () => {
+    const res = await request(app)
+      .get('/api/spike?delay=500')
+      .set('x-timeout-ms', '200');
+
+    expect(res.status).toBe(504);
+    expect(res.body.code).toBe('GATEWAY_TIMEOUT');
+    expect(res.body.message).toBe('Request timeout exceeded');
+  });
+});


### PR DESCRIPTION
## Description
Closes #774

This PR adds a per-request timeout middleware and a `/api/spike` route handler that simulates a long-running request with cooperative abort logic, returning 504 Gateway Timeout when the limit is exceeded.

### Key Changes
1. **Extend Express Request**: Added `signal?: AbortSignal` to `Express.Request` inside `src/types/express.d.ts` to support cooperative abort flags.
2. **Timeout Middleware**: Created `src/middleware/timeout.ts` to manage AbortControllers, timeout timers, and auto-cleanup. Supports query parameter (`?timeout=...`) and header (`x-timeout-ms`) overrides.
3. **Spike Route**: Created `src/routes/spike.ts` to simulate delays, checking `req.signal.aborted` periodically.
4. **Mount Route**: Mounted the route under `/spike` inside `src/routes/index.ts`.
5. **Integration Test Suite**: Created `tests/integration/spike.test.ts` to test:
   - Successful completions when delay < timeout.
   - Timed-out requests when delay > timeout (defaults to 1000ms).
   - Custom timeout values passed via query parameters or headers.

## Verification
- Verified all files compile cleanly under TypeScript.

### Testing Instructions
To run the integration tests locally:
1. Update dependencies:
   ```bash
   npm install
