### PR TITLE
feat(auth): add graceful per-request timeout middleware on /api/auth

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -94,6 +94,9 @@ export const envSchema = z
     RATE_LIMIT_STORE: z.string().optional(),
     RATE_LIMIT_PG_TABLE: z.string().optional(),
 
+    // Auth per-request timeout (graceful timeout with 504 Gateway Timeout)
+    AUTH_TIMEOUT_MS: z.coerce.number().int().positive().default(10_000),
+
     // Login rate limiting (IP-based throttling for auth attempts)
     LOGIN_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(5),
     LOGIN_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000), // 1 minute sliding window

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -150,6 +150,8 @@ export const config = {
     secretRotationGraceMs: env.WEBHOOK_SECRET_ROTATION_GRACE_MS,
   },
 
+  authTimeoutMs: env.AUTH_TIMEOUT_MS,
+
   loginRateLimit: {
     windowMs: env.LOGIN_RATE_LIMIT_WINDOW_MS,
     maxRequests: env.LOGIN_RATE_LIMIT_MAX_REQUESTS,

--- a/src/middleware/timeout.test.ts
+++ b/src/middleware/timeout.test.ts
@@ -1,0 +1,115 @@
+import express from 'express';
+import request from 'supertest';
+import { createTimeoutMiddleware } from './timeout.js';
+import { errorHandler } from './errorHandler.js';
+
+describe('createTimeoutMiddleware', () => {
+  it('passes through requests that complete within the timeout', async () => {
+    const app = express();
+    app.get('/fast', createTimeoutMiddleware({ timeoutMs: 5_000 }), (_req, res) => {
+      res.json({ status: 'ok' });
+    });
+    app.use(errorHandler);
+
+    const res = await request(app).get('/fast');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+
+  it('returns 504 Gateway Timeout when a request exceeds the timeout', async () => {
+    const app = express();
+    app.get('/slow', createTimeoutMiddleware({ timeoutMs: 50 }), () => {
+      // Intentionally never respond
+    });
+    app.use(errorHandler);
+
+    const res = await request(app).get('/slow');
+    expect(res.status).toBe(504);
+    expect(res.body.code).toBe('GATEWAY_TIMEOUT');
+    expect(res.body.message).toMatch(/timed out after 50ms/i);
+  });
+
+  it('includes requestId in the 504 response when available', async () => {
+    const app = express();
+    app.get('/slow', (req, _res, next) => {
+      (req as Record<string, unknown>).id = 'test-req-123';
+      next();
+    }, createTimeoutMiddleware({ timeoutMs: 50 }), () => { /* never respond */ });
+    app.use(errorHandler);
+
+    const res = await request(app).get('/slow');
+    expect(res.status).toBe(504);
+    expect(res.body.requestId).toBe('test-req-123');
+  });
+
+  it('sets req.abortSignal for cooperative cancellation', async () => {
+    const app = express();
+    let capturedSignal: AbortSignal | undefined;
+
+    app.get('/check-signal',
+      createTimeoutMiddleware({ timeoutMs: 50 }),
+      (req, res) => {
+        capturedSignal = req.abortSignal;
+        res.json({ signalPresent: !!req.abortSignal });
+      }
+    );
+    app.use(errorHandler);
+
+    // Complete within timeout
+    await request(app).get('/check-signal').expect(200);
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+  });
+
+  it('aborts the signal when the timeout fires', async () => {
+    const app = express();
+    let capturedSignal: AbortSignal | undefined;
+
+    app.get('/check-abort',
+      createTimeoutMiddleware({ timeoutMs: 50 }),
+      (req, _res) => {
+        capturedSignal = req.abortSignal;
+        // never respond
+      }
+    );
+    app.use(errorHandler);
+
+    await request(app).get('/check-abort');
+
+    // After the timeout the signal should be aborted.
+    // Use a small delay to let the timer fire.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  it('does not send a duplicate response when the handler sends after timeout', async () => {
+    const app = express();
+
+    app.get('/race',
+      createTimeoutMiddleware({ timeoutMs: 50 }),
+      async (_req, res) => {
+        // Wait longer than the timeout, then try to respond
+        await new Promise((r) => setTimeout(r, 100));
+        res.status(200).json({ status: 'too-late' });
+      }
+    );
+    app.use(errorHandler);
+
+    const res = await request(app).get('/race');
+    // The timeout should fire first and send 504, so the 200 is never sent
+    expect(res.status).toBe(504);
+  });
+
+  it('cleans up the timer on normal completion', async () => {
+    const app = express();
+    app.get('/fast', createTimeoutMiddleware({ timeoutMs: 5_000 }), (_req, res) => {
+      res.json({ status: 'ok' });
+    });
+    app.use(errorHandler);
+
+    // Should complete normally without firing the timer
+    const res = await request(app).get('/fast');
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -1,0 +1,49 @@
+import type { Request, Response, NextFunction } from 'express';
+import { logger } from '../logger.js';
+
+export interface TimeoutMiddlewareOptions {
+  timeoutMs: number;
+}
+
+export function createTimeoutMiddleware(
+  options: TimeoutMiddlewareOptions
+): (req: Request, res: Response, next: NextFunction) => void {
+  const { timeoutMs } = options;
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const controller = new AbortController();
+    req.abortSignal = controller.signal;
+
+    const timer = setTimeout(() => {
+      controller.abort();
+
+      if (!res.headersSent) {
+        const requestId = (req as Request & { id?: string }).id ?? 'unknown';
+
+        logger.warn('[timeout] request timed out', {
+          requestId,
+          method: req.method,
+          path: req.path,
+          timeoutMs,
+        });
+
+        res.status(504).json({
+          code: 'GATEWAY_TIMEOUT',
+          message: `Request timed out after ${timeoutMs}ms`,
+          requestId,
+        });
+      }
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      res.removeListener('finish', cleanup);
+      res.removeListener('close', cleanup);
+    };
+
+    res.on('finish', cleanup);
+    res.on('close', cleanup);
+
+    next();
+  };
+}

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -3,8 +3,11 @@ import { AuthController } from '../controllers/authController.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { bodyValidator } from '../middleware/validate.js';
 import { createLoginThrottle } from '../middleware/loginThrottle.js';
+import { createTimeoutMiddleware } from '../middleware/timeout.js';
 import { config } from '../config/index.js';
 import { z } from 'zod';
+
+const authTimeout = createTimeoutMiddleware({ timeoutMs: config.authTimeoutMs });
 
 const refreshTokenSchema = z.object({
   refreshToken: z.string().min(1, 'Refresh token is required')
@@ -25,6 +28,12 @@ const walletLoginSchema = z.object({
 
 export function createAuthRoutes(authController: AuthController): Router {
   const router = Router();
+
+  // Apply graceful per-request timeout to all auth routes.
+  // If a request exceeds the timeout the middleware sends a 504 Gateway
+  // Timeout and provides an AbortSignal on req.abortSignal for cooperative
+  // cancellation downstream.
+  router.use(authTimeout);
 
   // POST /auth/wallet - Wallet-based login with IP throttling
   // Rate limited to prevent brute force attacks

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -24,6 +24,8 @@ declare global {
       apiKeyValue?: string;
       /** Enriched forensic context attached by auditEnrichMiddleware. */
       auditContext: AuditContext;
+      /** AbortSignal provided by the timeout middleware for cooperative cancellation. */
+      abortSignal?: AbortSignal;
     }
   }
 }


### PR DESCRIPTION
## Overview

This PR adds a configurable graceful per-request timeout middleware to all \/api/auth\ routes. When a request exceeds the configured timeout, the middleware sends a **504 Gateway Timeout** response and provides an \AbortSignal\ on \eq.abortSignal\ for cooperative cancellation downstream. This prevents auth operations from hanging indefinitely and ensures predictable response times.

## Related Issue

Closes #744

## Changes

### 📦 Timeout Middleware

- **\[ADD\]** \src/middleware/timeout.ts\ — Express middleware factory accepting \{ timeoutMs }\
  - Uses \AbortController\ for cooperative cancellation
  - Returns \504 Gateway Timeout\ with standard error envelope when exceeded
  - Exposes \eq.abortSignal\ for downstream cooperative abort checks
  - Structured logging with correlation ID, method, path, and timeout value
  - Automatic cleanup of timer on normal \inish\/\close\ events
- **\[MODIFY\]** \src/routes/authRoutes.ts\ — Apply timeout middleware to all auth routes (\/wallet\, \/refresh\, \/revoke\, \/revoke-all\, \/tokens\)
- **\[MODIFY\]** \src/config/env.ts\ — Add \AUTH_TIMEOUT_MS\ env variable (default 10_000ms)
- **\[MODIFY\]** \src/config/index.ts\ — Wire \uthTimeoutMs\ into config
- **\[MODIFY\]** \src/types/express.d.ts\ — Add \bortSignal\ to Express \Request\ type
- **\[ADD\]** \src/middleware/timeout.test.ts\ — 7 focused tests covering:
  - Fast requests pass through normally (no false positives)
  - Slow requests receive 504 Gateway Timeout
  - Request ID propagation in timeout response
  - \eq.abortSignal\ is set for cooperative cancellation
  - Signal is aborted when timeout fires
  - No duplicate response when handler sends after timeout
  - Timer cleanup on normal completion

## Verification Results

| Acceptance Criteria | Status |
|--|--|
| Requests completing within timeout succeed normally | ✅ All 7 tests pass |
| Requests exceeding timeout receive 504 Gateway Timeout | ✅ Verified with 50ms timeout |
| \eq.abortSignal\ available for cooperative cancellation | ✅ Signal present and aborted on timeout |
| No duplicate responses when handler sends after timeout | ✅ Headers-sent guard prevents double-write |
| Lint passes | ✅ No ESLint errors |
| TypeScript compiles | ✅ No type errors in changed files |