### PR TITLE
feat(maintenance): enforce CORS allowlist on /api/admin/maintenance

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -101,6 +101,9 @@ export const envSchema = z
     // CORS
     CORS_ALLOWED_ORIGINS: z.string().default("http://localhost:5173"),
 
+    // Maintenance CORS allowlist (comma-separated origins; deny by default when empty)
+    MAINTENANCE_CORS_ALLOWED_ORIGINS: z.string().default(""),
+
     // Soroban RPC (optional)
     SOROBAN_RPC_ENABLED: z
       .string()

--- a/src/middleware/cors.test.ts
+++ b/src/middleware/cors.test.ts
@@ -1,0 +1,113 @@
+import express from 'express';
+import request from 'supertest';
+import { createCorsAllowlistMiddleware } from './cors.js';
+import { errorHandler } from './errorHandler.js';
+
+function buildApp(allowedOrigins: string[]) {
+  const app = express();
+  app.use(express.json());
+  const corsMw = createCorsAllowlistMiddleware({
+    allowedOrigins,
+    allowCredentials: true,
+    maxAgeSeconds: 600,
+  });
+  app.use('/test', corsMw, (_req, res) => {
+    res.json({ success: true });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe('createCorsAllowlistMiddleware', () => {
+  describe('origin validation', () => {
+    it('allows requests from an allowed origin', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app)
+        .post('/test')
+        .set('Origin', 'https://trusted.example.com')
+        .send({});
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('sets Access-Control-Allow-Origin header for allowed origins', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app)
+        .post('/test')
+        .set('Origin', 'https://trusted.example.com')
+        .send({});
+      expect(res.headers['access-control-allow-origin']).toBe('https://trusted.example.com');
+    });
+
+    it('denies requests from an origin not in the allowlist', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app)
+        .post('/test')
+        .set('Origin', 'https://evil.example.com')
+        .send({});
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('ORIGIN_NOT_ALLOWED');
+    });
+
+    it('denies requests with no Origin header', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app).post('/test').send({});
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('ORIGIN_NOT_ALLOWED');
+    });
+
+    it('denies all origins when allowlist is empty (deny by default)', async () => {
+      const app = buildApp([]);
+      const res = await request(app)
+        .post('/test')
+        .set('Origin', 'https://trusted.example.com')
+        .send({});
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('preflight handling', () => {
+    it('responds with 204 for allowed OPTIONS preflight', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app)
+        .options('/test')
+        .set('Origin', 'https://trusted.example.com');
+      expect(res.status).toBe(204);
+    });
+
+    it('sets Access-Control-Max-Age header on preflight', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app)
+        .options('/test')
+        .set('Origin', 'https://trusted.example.com');
+      expect(res.headers['access-control-max-age']).toBe('600');
+    });
+
+    it('sets Access-Control-Allow-Methods on preflight', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app)
+        .options('/test')
+        .set('Origin', 'https://trusted.example.com');
+      expect(res.headers['access-control-allow-methods']).toBeDefined();
+    });
+
+    it('denies preflight from disallowed origin', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app)
+        .options('/test')
+        .set('Origin', 'https://evil.example.com');
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('credentials support', () => {
+    it('sets Access-Control-Allow-Credentials when enabled', async () => {
+      const app = buildApp(['https://trusted.example.com']);
+      const res = await request(app)
+        .post('/test')
+        .set('Origin', 'https://trusted.example.com')
+        .send({});
+      expect(res.headers['access-control-allow-credentials']).toBe('true');
+    });
+  });
+});

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,0 +1,124 @@
+import type { Request, Response, NextFunction } from 'express';
+import { logger } from '../logger.js';
+
+export interface CorsAllowlistOptions {
+  allowedOrigins: string[];
+  allowCredentials?: boolean;
+  maxAgeSeconds?: number;
+}
+
+const DEFAULT_MAX_AGE = 600;
+const CORS_ERROR_CODE = 'ORIGIN_NOT_ALLOWED';
+
+function parseOriginHeader(req: Request): string | undefined {
+  const origin = req.header('Origin');
+  if (!origin || typeof origin !== 'string') return undefined;
+  return origin.trim();
+}
+
+function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
+  return allowedOrigins.includes(origin);
+}
+
+function sendCorsDenied(res: Response, origin: string, requestId: string): void {
+  res.status(403).json({
+    success: false,
+    error: {
+      code: CORS_ERROR_CODE,
+      message: `Origin "${origin}" is not allowed`,
+    },
+    requestId,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function setCorsHeaders(res: Response, origin: string, options: CorsAllowlistOptions): void {
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  if (options.allowCredentials) {
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
+}
+
+function handlePreflight(res: Response, origin: string, options: CorsAllowlistOptions): void {
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-admin-api-key, x-request-id');
+  res.setHeader('Access-Control-Max-Age', String(options.maxAgeSeconds ?? DEFAULT_MAX_AGE));
+  if (options.allowCredentials) {
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
+  res.status(204).end();
+}
+
+export function createCorsAllowlistMiddleware(
+  options: CorsAllowlistOptions,
+): (req: Request, res: Response, next: NextFunction) => void {
+  const { allowedOrigins } = options;
+
+  if (!Array.isArray(allowedOrigins) || allowedOrigins.length === 0) {
+    logger.warn('[cors] allowlist is empty — all origins will be denied');
+  }
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const origin = parseOriginHeader(req);
+
+    if (!origin) {
+      logger.warn('[cors] missing Origin header', {
+        method: req.method,
+        path: req.path,
+      });
+      res.status(403).json({
+        success: false,
+        error: {
+          code: CORS_ERROR_CODE,
+          message: 'Origin header is required',
+        },
+        requestId: (req as Request & { id?: string }).id ?? 'unknown',
+        timestamp: new Date().toISOString(),
+      });
+      return;
+    }
+
+    if (!isOriginAllowed(origin, allowedOrigins)) {
+      const requestId = (req as Request & { id?: string }).id ?? 'unknown';
+      logger.warn('[cors] origin not allowed', {
+        origin,
+        method: req.method,
+        path: req.path,
+        requestId,
+      });
+      sendCorsDenied(res, origin, requestId);
+      return;
+    }
+
+    setCorsHeaders(res, origin, options);
+
+    if (req.method === 'OPTIONS') {
+      handlePreflight(res, origin, options);
+      return;
+    }
+
+    next();
+  };
+}
+
+export function createMaintenanceCorsMiddleware() {
+  let middleware: ReturnType<typeof createCorsAllowlistMiddleware> | null = null;
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!middleware) {
+      const rawOrigins = process.env.MAINTENANCE_CORS_ALLOWED_ORIGINS ?? '';
+      const allowedOrigins = rawOrigins
+        .split(',')
+        .map((o) => o.trim())
+        .filter((o) => o.length > 0);
+
+      middleware = createCorsAllowlistMiddleware({
+        allowedOrigins,
+        allowCredentials: true,
+        maxAgeSeconds: 600,
+      });
+    }
+    middleware(req, res, next);
+  };
+}

--- a/src/routes/__tests__/maintenance.test.ts
+++ b/src/routes/__tests__/maintenance.test.ts
@@ -3,16 +3,22 @@ import request from 'supertest';
 import { maintenanceRouter } from '../admin/maintenance.js';
 import { healthzRouter } from '../healthz.js';
 
+// Set expected origin so CORS middleware permits the test requests
+process.env.MAINTENANCE_CORS_ALLOWED_ORIGINS = 'http://localhost:5173,https://admin.callora.dev';
+
 const app = express();
 app.use(express.json());
 app.use('/api/admin', maintenanceRouter);
 app.use(healthzRouter);
 
 describe('Maintenance Configuration & Health Tracking Integration', () => {
-  
+
+  const origin = 'http://localhost:5173';
+
   it('should successfully modify operational parameters via the admin POST endpoint', async () => {
     const res = await request(app)
       .post('/api/admin/maintenance')
+      .set('Origin', origin)
       .send({
         isEnabled: true,
         startTime: '2026-01-01T00:00:00.000Z',
@@ -27,6 +33,7 @@ describe('Maintenance Configuration & Health Tracking Integration', () => {
   it('should reject requests missing crucial window fields when activation is set to true', async () => {
     const res = await request(app)
       .post('/api/admin/maintenance')
+      .set('Origin', origin)
       .send({ isEnabled: true });
 
     expect(res.status).toBe(400);
@@ -36,6 +43,7 @@ describe('Maintenance Configuration & Health Tracking Integration', () => {
     // Inject active global maintenance state boundaries
     await request(app)
       .post('/api/admin/maintenance')
+      .set('Origin', origin)
       .send({
         isEnabled: true,
         startTime: new Date(Date.now() - 60000).toISOString(), // 1 minute ago

--- a/src/routes/admin/maintenance.ts
+++ b/src/routes/admin/maintenance.ts
@@ -1,6 +1,11 @@
 import { Router, Request, Response } from 'express';
+import { createMaintenanceCorsMiddleware } from '../../middleware/cors.js';
+
+const maintenanceCors = createMaintenanceCorsMiddleware();
 
 export const maintenanceRouter = Router();
+
+maintenanceRouter.use(maintenanceCors);
 
 // Global runtime state store tracking scheduled maintenance window configuration parameters
 export let activeMaintenanceWindow = {


### PR DESCRIPTION
## Overview

This PR adds a dedicated CORS allowlist enforcement middleware and applies it to the /api/admin/maintenance endpoint. Requests from origins not present in the MAINTENANCE_CORS_ALLOWED_ORIGINS environment variable are denied with a **403 Forbidden** response. The middleware handles OPTIONS preflight with caching headers and defaults to denying all origins when the allowlist is empty.

## Related Issue

Closes #734

## Changes

### 🔒 CORS Allowlist Middleware

- **\[ADD\]** \src/middleware/cors.ts\ — Express middleware factory \createCorsAllowlistMiddleware\ with:
  - Origin validation against a configurable allowlist
  - Deny-by-default when allowlist is empty
  - 403 \ORIGIN_NOT_ALLOWED\ error envelope for denied origins
  - OPTIONS preflight handling with \Access-Control-Max-Age\ caching (10 min default)
  - \Access-Control-Allow-Credentials\ support
  - Structured logging with correlation IDs
  - Pre-configured \createMaintenanceCorsMiddleware\ reading from \MAINTENANCE_CORS_ALLOWED_ORIGINS\ env var
- **\[MODIFY\]** \src/routes/admin/maintenance.ts\ — Apply pre-configured CORS middleware to all maintenance routes
- **\[MODIFY\]** \src/config/env.ts\ — Add \MAINTENANCE_CORS_ALLOWED_ORIGINS\ env variable (default empty, denying all)
- **\[ADD\]** \src/middleware/cors.test.ts\ — 10 focused tests covering:
  - Allowed origins pass through
  - Denied origins receive 403
  - Missing origin header receives 403
  - Empty allowlist denies all by default
  - OPTIONS preflight returns 204 with caching headers
  - Preflight from disallowed origin denied
  - Credentials header set when enabled
- **\[MODIFY\]** \src/routes/__tests__/maintenance.test.ts\ — Added \Origin\ header to existing tests (required by new CORS enforcement)

## Verification Results

| Acceptance Criteria | Status |
|--|--|
| Allowed origins pass CORS check | ✅ 10/10 CORS middleware tests pass |
| Denied origins receive 403 | ✅ Verified with expected error envelope |
| Empty allowlist denies all by default | ✅ Verified (deny-by-default) |
| Preflight cached with \Access-Control-Max-Age\ | ✅ 204 + max-age=600 |
| Existing maintenance tests still pass | ✅ 3/3 with Origin header added |
| Lint passes | ✅ No ESLint errors |
| TypeScript compiles | ✅ No type errors in changed files |