### PR TITLE
Add OpenAPI examples for apis

### DIFF
--- a/docs/openapi-contract-testing.md
+++ b/docs/openapi-contract-testing.md
@@ -8,9 +8,14 @@ Runtime request and response payloads are validated against the OpenAPI specific
 
 `docs/openapi.json`
 
-## Covered Endpoint
+## Covered Endpoints
 
-`POST /api/billing/deduct`
+- `POST /api/billing/deduct`
+- OpenAPI example regression checks for:
+  - `GET /api/apis`
+  - `POST /api/apis`
+  - `GET /api/apis/{id}`
+  - `POST /api/apis/{id}/endpoints/bulk`
 
 ## Contract Test Coverage
 
@@ -24,6 +29,10 @@ The contract suite verifies:
 **Location:**
 
 `tests/contract/billing.test.ts`
+
+OpenAPI example regression coverage for API marketplace routes lives in:
+
+`src/routes/apis.openapi.test.ts`
 
 ## Running Tests
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -107,7 +107,9 @@
       "get": {
         "summary": "Application health check",
         "description": "Returns the health status of the application and its dependencies (database, Soroban RPC, Horizon). Public endpoint — no authentication required.",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": {
           "200": {
             "description": "Application is healthy or partially degraded",
@@ -1180,6 +1182,70 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApisListResponse"
+                },
+                "examples": {
+                  "activeListings": {
+                    "summary": "Active API listings page",
+                    "value": {
+                      "data": [
+                        {
+                          "id": 101,
+                          "name": "GrantFox Scoring API",
+                          "description": "Scores FWC26 grant applications against program rules.",
+                          "base_url": "https://api.grantfox.example",
+                          "logo_url": "https://cdn.grantfox.example/logo.png",
+                          "category": "grants",
+                          "status": "active",
+                          "developer": {
+                            "id": 11,
+                            "name": "GrantFox Labs"
+                          },
+                          "endpoints": [
+                            {
+                              "id": 501,
+                              "api_id": 101,
+                              "path": "/applications/{applicationId}/score",
+                              "method": "POST",
+                              "price_per_call_usdc": "0.2500000",
+                              "description": "Score a single grant application.",
+                              "created_at": "2026-07-27T09:00:00.000Z",
+                              "updated_at": "2026-07-27T09:00:00.000Z"
+                            }
+                          ]
+                        },
+                        {
+                          "id": 102,
+                          "name": "GrantFox Eligibility API",
+                          "description": "Validates applicant eligibility before scoring.",
+                          "base_url": "https://api.grantfox.example",
+                          "logo_url": null,
+                          "category": "grants",
+                          "status": "active",
+                          "developer": {
+                            "id": 11,
+                            "name": "GrantFox Labs"
+                          },
+                          "endpoints": [
+                            {
+                              "id": 502,
+                              "api_id": 102,
+                              "path": "/applications/{applicationId}/eligibility",
+                              "method": "GET",
+                              "price_per_call_usdc": "0.0500000",
+                              "description": "Return eligibility checks for an application.",
+                              "created_at": "2026-07-27T09:05:00.000Z",
+                              "updated_at": "2026-07-27T09:05:00.000Z"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "limit": 20,
+                        "offset": 0,
+                        "total": 2
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -1201,6 +1267,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "internalServerError": {
+                    "summary": "Unexpected repository error",
+                    "value": {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "Internal server error",
+                      "requestId": "req-apis-list-500"
+                    }
+                  }
                 }
               }
             }
@@ -1221,6 +1297,31 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ApiCreateRequest"
+              },
+              "examples": {
+                "publishApi": {
+                  "summary": "Publish a grant review API",
+                  "value": {
+                    "name": "GrantFox Review API",
+                    "description": "Automates FWC26 application review workflows.",
+                    "base_url": "https://api.grantfox.example",
+                    "category": "grants",
+                    "endpoints": [
+                      {
+                        "path": "/applications/{applicationId}/review",
+                        "method": "POST",
+                        "price_per_call_usdc": "0.3000000",
+                        "description": "Run the full review pipeline for one application."
+                      },
+                      {
+                        "path": "/applications/{applicationId}/status",
+                        "method": "GET",
+                        "price_per_call_usdc": "0.0200000",
+                        "description": "Fetch the latest review status."
+                      }
+                    ]
+                  }
+                }
               }
             }
           }
@@ -1232,6 +1333,45 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiCreateResponse"
+                },
+                "examples": {
+                  "createdApi": {
+                    "summary": "API published successfully",
+                    "value": {
+                      "id": 301,
+                      "developer_id": 11,
+                      "name": "GrantFox Review API",
+                      "description": "Automates FWC26 application review workflows.",
+                      "base_url": "https://api.grantfox.example",
+                      "logo_url": null,
+                      "category": "grants",
+                      "status": "active",
+                      "created_at": "2026-07-27T10:00:00.000Z",
+                      "updated_at": "2026-07-27T10:00:00.000Z",
+                      "endpoints": [
+                        {
+                          "id": 801,
+                          "api_id": 301,
+                          "path": "/applications/{applicationId}/review",
+                          "method": "POST",
+                          "price_per_call_usdc": "0.3000000",
+                          "description": "Run the full review pipeline for one application.",
+                          "created_at": "2026-07-27T10:00:00.000Z",
+                          "updated_at": "2026-07-27T10:00:00.000Z"
+                        },
+                        {
+                          "id": 802,
+                          "api_id": 301,
+                          "path": "/applications/{applicationId}/status",
+                          "method": "GET",
+                          "price_per_call_usdc": "0.0200000",
+                          "description": "Fetch the latest review status.",
+                          "created_at": "2026-07-27T10:00:00.000Z",
+                          "updated_at": "2026-07-27T10:00:00.000Z"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -1242,6 +1382,31 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidPayload": {
+                    "summary": "Validation failed",
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "message": "Path must start with /",
+                      "requestId": "req-apis-create-400",
+                      "details": [
+                        {
+                          "field": "endpoints.0.path",
+                          "message": "Path must start with /",
+                          "code": "custom"
+                        }
+                      ]
+                    }
+                  },
+                  "developerProfileMissing": {
+                    "summary": "Developer profile missing",
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "message": "Developer profile not found. Create a developer profile first.",
+                      "requestId": "req-apis-create-dev-missing"
+                    }
+                  }
                 }
               }
             }
@@ -1252,6 +1417,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "summary": "Missing authentication",
+                    "value": {
+                      "code": "UNAUTHORIZED",
+                      "message": "Unauthorized",
+                      "requestId": "req-apis-create-401"
+                    }
+                  }
                 }
               }
             }
@@ -1262,6 +1437,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "internalServerError": {
+                    "summary": "Unexpected persistence error",
+                    "value": {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "Internal server error",
+                      "requestId": "req-apis-create-500"
+                    }
+                  }
                 }
               }
             }
@@ -1290,6 +1475,46 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiDetailsResponse"
+                },
+                "examples": {
+                  "apiDetails": {
+                    "summary": "Detailed API record",
+                    "value": {
+                      "id": 101,
+                      "name": "GrantFox Scoring API",
+                      "description": "Scores FWC26 grant applications against program rules.",
+                      "base_url": "https://api.grantfox.example",
+                      "logo_url": "https://cdn.grantfox.example/logo.png",
+                      "category": "grants",
+                      "status": "active",
+                      "developer": {
+                        "id": 11,
+                        "name": "GrantFox Labs"
+                      },
+                      "endpoints": [
+                        {
+                          "id": 501,
+                          "api_id": 101,
+                          "path": "/applications/{applicationId}/score",
+                          "method": "POST",
+                          "price_per_call_usdc": "0.2500000",
+                          "description": "Score a single grant application.",
+                          "created_at": "2026-07-27T09:00:00.000Z",
+                          "updated_at": "2026-07-27T09:00:00.000Z"
+                        },
+                        {
+                          "id": 503,
+                          "api_id": 101,
+                          "path": "/applications/{applicationId}/score/explain",
+                          "method": "GET",
+                          "price_per_call_usdc": "0.0400000",
+                          "description": "Fetch scoring rationale for the latest run.",
+                          "created_at": "2026-07-27T09:10:00.000Z",
+                          "updated_at": "2026-07-27T09:10:00.000Z"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -1300,6 +1525,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidId": {
+                    "summary": "Invalid API id",
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "message": "id must be a positive integer",
+                      "requestId": "req-api-details-400"
+                    }
+                  }
                 }
               }
             }
@@ -1310,6 +1545,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "apiNotFound": {
+                    "summary": "API not found",
+                    "value": {
+                      "code": "NOT_FOUND",
+                      "message": "API not found or not active",
+                      "requestId": "req-api-details-404"
+                    }
+                  }
                 }
               }
             }
@@ -1320,6 +1565,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "internalServerError": {
+                    "summary": "Unexpected lookup error",
+                    "value": {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "Internal server error",
+                      "requestId": "req-api-details-500"
+                    }
+                  }
                 }
               }
             }
@@ -1723,6 +1978,27 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/BulkEndpointRegistrationRequest"
+              },
+              "examples": {
+                "bulkRegisterEndpoints": {
+                  "summary": "Add two endpoints to an API",
+                  "value": {
+                    "endpoints": [
+                      {
+                        "path": "/applications/{applicationId}/decision",
+                        "method": "POST",
+                        "price_per_call_usdc": "0.1800000",
+                        "description": "Create a funding decision recommendation."
+                      },
+                      {
+                        "path": "/applications/{applicationId}/timeline",
+                        "method": "GET",
+                        "price_per_call_usdc": "0.0150000",
+                        "description": "Return review timeline milestones."
+                      }
+                    ]
+                  }
+                }
               }
             }
           }
@@ -1734,6 +2010,31 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BulkEndpointRegistrationResponse"
+                },
+                "examples": {
+                  "createdEndpoints": {
+                    "summary": "Endpoints added successfully",
+                    "value": {
+                      "endpoints": [
+                        {
+                          "id": 901,
+                          "api_id": 301,
+                          "path": "/applications/{applicationId}/decision",
+                          "method": "POST",
+                          "price_per_call_usdc": "0.1800000",
+                          "description": "Create a funding decision recommendation."
+                        },
+                        {
+                          "id": 902,
+                          "api_id": 301,
+                          "path": "/applications/{applicationId}/timeline",
+                          "method": "GET",
+                          "price_per_call_usdc": "0.0150000",
+                          "description": "Return review timeline milestones."
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -1744,6 +2045,31 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidEndpoint": {
+                    "summary": "Invalid endpoint payload",
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "message": "Price per call must be a non-negative decimal string",
+                      "requestId": "req-bulk-endpoints-400",
+                      "details": [
+                        {
+                          "field": "endpoints.0.price_per_call_usdc",
+                          "message": "Price per call must be a non-negative decimal string",
+                          "code": "custom"
+                        }
+                      ]
+                    }
+                  },
+                  "tooManyEndpoints": {
+                    "summary": "Too many endpoints submitted",
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "message": "Cannot register more than 50 endpoints at once",
+                      "requestId": "req-bulk-endpoints-too-many"
+                    }
+                  }
                 }
               }
             }
@@ -1754,6 +2080,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "summary": "Missing authentication",
+                    "value": {
+                      "code": "UNAUTHORIZED",
+                      "message": "Unauthorized",
+                      "requestId": "req-bulk-endpoints-401"
+                    }
+                  }
                 }
               }
             }
@@ -1764,6 +2100,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "apiNotFound": {
+                    "summary": "Owned API not found",
+                    "value": {
+                      "code": "NOT_FOUND",
+                      "message": "API not found",
+                      "requestId": "req-bulk-endpoints-404"
+                    }
+                  }
                 }
               }
             }
@@ -1774,6 +2120,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "internalServerError": {
+                    "summary": "Unexpected persistence error",
+                    "value": {
+                      "code": "INTERNAL_SERVER_ERROR",
+                      "message": "Internal server error",
+                      "requestId": "req-bulk-endpoints-500"
+                    }
+                  }
                 }
               }
             }
@@ -4091,26 +4447,44 @@
       "HealthChecks": {
         "type": "object",
         "description": "Per-dependency health check statuses.",
-        "required": ["api"],
+        "required": [
+          "api"
+        ],
         "properties": {
           "api": {
             "type": "string",
-            "enum": ["ok", "degraded", "down"],
+            "enum": [
+              "ok",
+              "degraded",
+              "down"
+            ],
             "description": "API server health"
           },
           "database": {
             "type": "string",
-            "enum": ["ok", "degraded", "down"],
+            "enum": [
+              "ok",
+              "degraded",
+              "down"
+            ],
             "description": "Database connection health"
           },
           "soroban_rpc": {
             "type": "string",
-            "enum": ["ok", "degraded", "down"],
+            "enum": [
+              "ok",
+              "degraded",
+              "down"
+            ],
             "description": "Soroban RPC connectivity"
           },
           "horizon": {
             "type": "string",
-            "enum": ["ok", "degraded", "down"],
+            "enum": [
+              "ok",
+              "degraded",
+              "down"
+            ],
             "description": "Horizon API connectivity"
           }
         }
@@ -4118,18 +4492,29 @@
       "HealthResponse": {
         "type": "object",
         "description": "Health check response in success envelope.",
-        "required": ["success", "data", "requestId", "timestamp"],
+        "required": [
+          "success",
+          "data",
+          "requestId",
+          "timestamp"
+        ],
         "properties": {
           "success": {
             "type": "boolean"
           },
           "data": {
             "type": "object",
-            "required": ["status"],
+            "required": [
+              "status"
+            ],
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["ok", "degraded", "down"],
+                "enum": [
+                  "ok",
+                  "degraded",
+                  "down"
+                ],
                 "description": "Aggregate health status"
               },
               "service": {

--- a/src/routes/apis.openapi.test.ts
+++ b/src/routes/apis.openapi.test.ts
@@ -1,0 +1,145 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type JsonObject = Record<string, unknown>;
+
+describe('OpenAPI examples for API marketplace routes', () => {
+  const openApiPath = path.join(process.cwd(), 'docs', 'openapi.json');
+
+  function readSpec(): JsonObject {
+    return JSON.parse(fs.readFileSync(openApiPath, 'utf8')) as JsonObject;
+  }
+
+  function asObject(value: unknown): JsonObject {
+    return value as JsonObject;
+  }
+
+  function responseJson(responses: JsonObject, status: string): JsonObject {
+    return asObject(asObject(asObject(responses[status]).content)['application/json']);
+  }
+
+  function exampleFromResponse(
+    responses: JsonObject,
+    status: string,
+    exampleKey: string,
+  ): JsonObject {
+    return asObject(asObject(responseJson(responses, status).examples)[exampleKey]);
+  }
+
+  test('documents examples for listing and publishing APIs', () => {
+    const spec = readSpec();
+    const apisPath = asObject(asObject(spec.paths)['/api/apis']);
+    const listOperation = asObject(apisPath.get);
+    const listResponses = asObject(listOperation.responses);
+    const listResponse200 = asObject(listResponses['200']);
+    const listJson = asObject(asObject(listResponse200.content)['application/json']);
+
+    const listExample = asObject(asObject(listJson.examples).activeListings);
+    expect(listExample).toBeDefined();
+    expect(listExample.summary).toBe('Active API listings page');
+    const listExampleValue = asObject(listExample.value);
+    expect(listExampleValue.pagination).toEqual({
+      limit: 20,
+      offset: 0,
+      total: 2,
+    });
+    expect((listExampleValue.data as unknown[])[0]).toEqual(
+      expect.objectContaining({
+        id: 101,
+        name: 'GrantFox Scoring API',
+        category: 'grants',
+      }),
+    );
+
+    const postOperation = asObject(apisPath.post);
+    const requestBody = asObject(postOperation.requestBody);
+    const postJson = asObject(asObject(requestBody.content)['application/json']);
+    const createRequest = asObject(asObject(postJson.examples).publishApi);
+    expect(createRequest).toBeDefined();
+    const createRequestValue = asObject(createRequest.value);
+    expect(createRequestValue.endpoints).toHaveLength(2);
+    expect((createRequestValue.endpoints as unknown[])[0]).toEqual(
+      expect.objectContaining({
+        path: '/applications/{applicationId}/review',
+        method: 'POST',
+      }),
+    );
+
+    const postResponses = asObject(postOperation.responses);
+    const createdApi = exampleFromResponse(postResponses, '201', 'createdApi');
+    expect(createdApi).toBeDefined();
+    const createdApiValue = asObject(createdApi.value);
+    expect(createdApiValue.status).toBe('active');
+    expect(createdApiValue.endpoints).toHaveLength(2);
+
+    const invalidPayload = exampleFromResponse(postResponses, '400', 'invalidPayload');
+    expect(invalidPayload).toBeDefined();
+    expect(asObject(invalidPayload.value).code).toBe('BAD_REQUEST');
+
+    const unauthorized = exampleFromResponse(postResponses, '401', 'unauthorized');
+    expect(unauthorized).toBeDefined();
+    expect(asObject(unauthorized.value).code).toBe('UNAUTHORIZED');
+  });
+
+  test('documents detail lookup examples for a single API', () => {
+    const spec = readSpec();
+    const singlePath = asObject(asObject(spec.paths)['/api/apis/{id}']);
+    const getOperation = asObject(singlePath.get);
+    const getResponses = asObject(getOperation.responses);
+
+    const detailExample = exampleFromResponse(getResponses, '200', 'apiDetails');
+    expect(detailExample).toBeDefined();
+    expect(asObject(asObject(detailExample.value).developer)).toEqual({
+      id: 11,
+      name: 'GrantFox Labs',
+    });
+    expect(asObject(detailExample.value).endpoints).toHaveLength(2);
+
+    const invalidId = exampleFromResponse(getResponses, '400', 'invalidId');
+    expect(invalidId).toBeDefined();
+    expect(asObject(invalidId.value).message).toBe('id must be a positive integer');
+
+    const notFound = exampleFromResponse(getResponses, '404', 'apiNotFound');
+    expect(notFound).toBeDefined();
+    expect(asObject(notFound.value).code).toBe('NOT_FOUND');
+  });
+
+  test('documents bulk endpoint registration examples', () => {
+    const spec = readSpec();
+    const bulkPath = asObject(asObject(spec.paths)['/api/apis/{id}/endpoints/bulk']);
+    const postOperation = asObject(bulkPath.post);
+    const requestBody = asObject(postOperation.requestBody);
+    const postJson = asObject(asObject(requestBody.content)['application/json']);
+    const responses = asObject(postOperation.responses);
+
+    const requestExample = asObject(asObject(postJson.examples).bulkRegisterEndpoints);
+    expect(requestExample).toBeDefined();
+    expect(asObject(requestExample.value).endpoints).toHaveLength(2);
+
+    const createdEndpoints = exampleFromResponse(responses, '201', 'createdEndpoints');
+    expect(createdEndpoints).toBeDefined();
+    expect((asObject(createdEndpoints.value).endpoints as unknown[])[0]).toEqual(
+      expect.objectContaining({
+        api_id: 301,
+        method: 'POST',
+      }),
+    );
+
+    const invalidEndpoint = exampleFromResponse(responses, '400', 'invalidEndpoint');
+    expect(invalidEndpoint).toBeDefined();
+    expect((asObject(invalidEndpoint.value).details as JsonObject[])[0].field).toBe(
+      'endpoints.0.price_per_call_usdc',
+    );
+
+    const tooManyEndpoints = exampleFromResponse(responses, '400', 'tooManyEndpoints');
+    expect(tooManyEndpoints).toBeDefined();
+    expect(asObject(tooManyEndpoints.value).message).toContain('more than 50 endpoints');
+
+    const unauthorized = exampleFromResponse(responses, '401', 'unauthorized');
+    expect(unauthorized).toBeDefined();
+
+    const notFound = exampleFromResponse(responses, '404', 'apiNotFound');
+    expect(notFound).toBeDefined();
+    expect(asObject(notFound.value).message).toBe('API not found');
+  });
+});


### PR DESCRIPTION
close #643 
Implemented the API marketplace OpenAPI example work and kept it scoped to spec/docs plus a focused regression test. The updated files are the [OpenAPI spec](computer://c:%5CUsers%5CDELL%5CCallora-Backend%5Cdocs%5Copenapi.json), the new [API OpenAPI example test](computer://c:%5CUsers%5CDELL%5CCallora-Backend%5Csrc%5Croutes%5Capis.openapi.test.ts), and the [contract testing note](computer://c:%5CUsers%5CDELL%5CCallora-Backend%5Cdocs%5Copenapi-contract-testing.md).

What changed
Added request/response examples for GET /api/apis
Added request/response examples for POST /api/apis
Added response examples for GET /api/apis/{id}
Added request/response examples for POST /api/apis/{id}/endpoints/bulk
Documented that API marketplace OpenAPI examples now have regression coverage
There are no runtime API behavior changes here. This is a documentation/spec improvement only.

Checks
npm run test:serial -- src/routes/apis.openapi.test.ts passed
npx eslint 'src/routes/apis.openapi.test.ts' passed
Note
When I ran a broader OpenAPI example suite earlier, an existing unrelated failure showed up in src/routes/billing.openapi.test.ts because the billing spec is missing a 429 example. I did not change that endpoint as part of this task.

Review note
Everything requested here is implemented except Code review approved, which is an external workflow step rather than something I can complete inside the repo.