### PR TITLE
feat(auth): Zod-validated request schemas for /api/auth with structur…

### DIFF
--- a/docs/auth-api.md
+++ b/docs/auth-api.md
@@ -1,0 +1,259 @@
+# /api/auth — Authentication Endpoints
+
+This document describes request validation, success shapes, and error shapes for the
+`/api/auth` route group.  All routes apply Zod-validated request schemas via
+`bodyValidator` from `src/middleware/validate.ts`.  Any validation failure produces a
+structured HTTP 400 response before the request reaches the controller.
+
+---
+
+## Common response envelope
+
+### Success
+
+```json
+{
+  "success": true,
+  "data": { ... },
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "timestamp": "2026-07-27T15:00:00.000Z"
+}
+```
+
+### Validation error (HTTP 400)
+
+Whenever the request body does not satisfy the schema, the global error handler
+returns a structured 400:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": [
+      {
+        "field": "body.walletAddress",
+        "message": "Wallet address is required",
+        "code": "TOO_SMALL"
+      }
+    ]
+  },
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "timestamp": "2026-07-27T15:00:00.000Z"
+}
+```
+
+| Envelope field | Description |
+|---|---|
+| `error.code` | `VALIDATION_ERROR` — stable machine-readable code |
+| `error.message` | Human-readable summary |
+| `error.details[]` | One entry per invalid field |
+| `error.details[].field` | Dot-path from `body.*` (e.g., `body.walletAddress`) |
+| `error.details[].message` | Per-field message from the Zod schema |
+| `error.details[].code` | Zod issue code uppercased (e.g., `TOO_SMALL`, `INVALID_TYPE`) |
+| `requestId` | Propagated or generated request correlation ID |
+
+---
+
+## POST /auth/wallet
+
+Wallet-based login. Returns a JWT access token and a refresh token on success.
+
+Rate-limited to prevent brute-force attacks (configurable via `LOGIN_RATE_LIMIT_*` env vars).
+
+### Request body
+
+Validated by `walletLoginSchema` in `src/validators/auth.ts`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `walletAddress` | string | ✅ | The Stellar public key (G… address) initiating the login |
+| `signature` | string | ✅ | Signature produced by the wallet over `message` |
+| `message` | string | ✅ | The exact message that was signed |
+
+```json
+{
+  "walletAddress": "GDTEST123STELLARADDRESS",
+  "signature": "abc123signaturehex",
+  "message": "Login to Callora at 2026-07-27T15:00:00Z"
+}
+```
+
+### Validation errors
+
+| Condition | `field` | `message` |
+|---|---|---|
+| `walletAddress` absent or empty | `body.walletAddress` | `Wallet address is required` |
+| `signature` absent or empty | `body.signature` | `Signature is required` |
+| `message` absent or empty | `body.message` | `Message is required` |
+
+### Success response (200)
+
+```json
+{
+  "success": true,
+  "data": {
+    "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+    "refreshToken": "eyJhbGciOiJIUzI1NiJ9...",
+    "tokenType": "Bearer"
+  },
+  "requestId": "...",
+  "timestamp": "..."
+}
+```
+
+---
+
+## POST /auth/refresh
+
+Rotates a refresh token.  The consumed token is revoked; a new access token and
+refresh token are returned.
+
+Presenting a token that has already been rotated (replay) is treated as a theft
+signal — all tokens for that user are immediately revoked.
+
+### Request body
+
+Validated by `refreshTokenSchema` in `src/validators/auth.ts`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `refreshToken` | string | ✅ | The opaque refresh token issued at login or a previous rotation |
+
+```json
+{
+  "refreshToken": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+### Validation errors
+
+| Condition | `field` | `message` |
+|---|---|---|
+| `refreshToken` absent or empty | `body.refreshToken` | `Refresh token is required` |
+
+### Success response (200)
+
+```json
+{
+  "success": true,
+  "data": {
+    "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+    "refreshToken": "eyJhbGciOiJIUzI1NiJ9...",
+    "tokenType": "Bearer"
+  },
+  "requestId": "...",
+  "timestamp": "..."
+}
+```
+
+### Auth error responses
+
+| HTTP | `error.code` | Cause |
+|---|---|---|
+| 401 | `INVALID_REFRESH_TOKEN` | Token not found, signature invalid, or expired |
+| 401 | `REVOKED_TOKEN` | Token was already consumed — all user tokens revoked (theft signal) |
+| 401 | `EXPIRED_TOKEN` | Token has passed its expiry |
+
+---
+
+## POST /auth/revoke
+
+Revokes a single refresh token.  Returns 200 regardless of whether the token was
+found, to prevent token enumeration.
+
+### Request body
+
+Validated by `refreshTokenSchema` in `src/validators/auth.ts`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `refreshToken` | string | ✅ | The refresh token to revoke |
+
+```json
+{
+  "refreshToken": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+### Validation errors
+
+Same as `/auth/refresh`.
+
+### Success response (200)
+
+```json
+{
+  "success": true,
+  "data": { "message": "Token revoked successfully" },
+  "requestId": "...",
+  "timestamp": "..."
+}
+```
+
+---
+
+## POST /auth/revoke-all
+
+Revokes **all** refresh tokens for the authenticated user.
+
+### Authentication
+
+Requires `Authorization: Bearer <accessToken>` (or `x-user-id` header in
+server-to-server flows).
+
+### Request body
+
+No body required.
+
+### Success response (200)
+
+```json
+{
+  "success": true,
+  "data": { "message": "All tokens revoked successfully" },
+  "requestId": "...",
+  "timestamp": "..."
+}
+```
+
+---
+
+## GET /auth/tokens
+
+Returns the count of active refresh tokens for the authenticated user.
+
+### Authentication
+
+Requires `Authorization: Bearer <accessToken>`.
+
+### Success response (200)
+
+```json
+{
+  "success": true,
+  "data": {
+    "activeRefreshTokens": 2,
+    "maxAllowedTokens": 5
+  },
+  "requestId": "...",
+  "timestamp": "..."
+}
+```
+
+---
+
+## Schema source
+
+All request schemas live in `src/validators/auth.ts` and are referenced from
+`src/routes/authRoutes.ts` via `bodyValidator(schema)`.  The `bodyValidator` wrapper
+calls `validate({ body: schema })` which throws a `ValidationError` on failure;
+`errorHandler` converts that into the structured 400 envelope documented above.
+
+```
+src/validators/auth.ts        ← Zod schemas (walletLoginSchema, refreshTokenSchema)
+src/routes/authRoutes.ts      ← Routes + bodyValidator middleware
+src/middleware/validate.ts    ← bodyValidator / ValidationError
+src/middleware/errorHandler.ts← HTTP 400 envelope production
+```

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -3,8 +3,8 @@ import { isAppError } from '../errors/index.js';
 import { logger } from '../logger.js';
 import type { ValidationErrorDetail } from './validate.js';
 import { ValidationError } from './validate.js';
-import { errorEnvelope } from '../lib/envelope.js';
 import type { ErrorEnvelope } from '../types/ResponseEnvelope.js';
+import { buildErrorEnvelope } from './envelope.js';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -14,9 +14,6 @@ export interface ErrorResponseBody {
   requestId: string;
   details?: ValidationErrorDetail[];
 }
-
-import { errorEnvelope } from '../lib/envelope.js';
-import type { ErrorEnvelope } from '../types/ResponseEnvelope.js';
 
 function extractValidationDetails(err: unknown): ValidationErrorDetail[] | undefined {
   if (err instanceof ValidationError) {

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -4,30 +4,22 @@ import { requireAuth } from '../middleware/requireAuth.js';
 import { bodyValidator } from '../middleware/validate.js';
 import { createLoginThrottle } from '../middleware/loginThrottle.js';
 import { createTimeoutMiddleware } from '../middleware/timeout.js';
+import { refreshTokenHistogramMiddleware } from '../middleware/metricsHistogram.js';
 import { config } from '../config/index.js';
-import { z } from 'zod';
+import { walletLoginSchema, refreshTokenSchema } from '../validators/auth.js';
 
 const authTimeout = createTimeoutMiddleware({ timeoutMs: config.authTimeoutMs });
 
-const refreshTokenSchema = z.object({
-  refreshToken: z.string().min(1, 'Refresh token is required')
-});
-
-// Login throttle with proxy support for accurate IP detection behind load balancers
-const loginThrottle = createLoginThrottle({
-  windowMs: config.loginRateLimit.windowMs,
-  maxRequests: config.loginRateLimit.maxRequests,
-  trustProxy: process.env.TRUST_PROXY_HEADERS === 'true',
-});
-
-const walletLoginSchema = z.object({
-  walletAddress: z.string().min(1, 'Wallet address is required'),
-  signature: z.string().min(1, 'Signature is required'),
-  message: z.string().min(1, 'Message is required'),
-});
-
 export function createAuthRoutes(authController: AuthController): Router {
   const router = Router();
+
+  // Each router instance gets its own login throttle so that test-app instances
+  // do not share a single rate-limit bucket across test suites.
+  const loginThrottle = createLoginThrottle({
+    windowMs: config.loginRateLimit.windowMs,
+    maxRequests: config.loginRateLimit.maxRequests,
+    trustProxy: process.env.TRUST_PROXY_HEADERS === 'true',
+  });
 
   // Apply graceful per-request timeout to all auth routes.
   // If a request exceeds the timeout the middleware sends a 504 Gateway
@@ -43,27 +35,27 @@ export function createAuthRoutes(authController: AuthController): Router {
     (req, res, next) => authController.walletLogin(req, res, next)
   );
 
-  // Refresh access token
-  router.post('/refresh', 
+  // POST /auth/refresh - Refresh access token using a valid refresh token
+  router.post('/refresh',
     refreshTokenHistogramMiddleware,
     bodyValidator(refreshTokenSchema),
     (req, res, next) => authController.refreshToken(req, res, next)
   );
 
-  // Revoke a specific refresh token
-  router.post('/revoke', 
+  // POST /auth/revoke - Revoke a specific refresh token
+  router.post('/revoke',
     bodyValidator(refreshTokenSchema),
     (req, res, next) => authController.revokeToken(req, res, next)
   );
 
-  // Revoke all refresh tokens for authenticated user
-  router.post('/revoke-all', 
+  // POST /auth/revoke-all - Revoke all refresh tokens for authenticated user
+  router.post('/revoke-all',
     requireAuth,
     (req, res, next) => authController.revokeAllTokens(req, res, next)
   );
 
-  // Get token information for authenticated user
-  router.get('/tokens', 
+  // GET /auth/tokens - Get token information for authenticated user
+  router.get('/tokens',
     requireAuth,
     (req, res, next) => authController.getTokenInfo(req, res, next)
   );

--- a/src/validators/auth.ts
+++ b/src/validators/auth.ts
@@ -1,0 +1,60 @@
+/**
+ * Zod validation schemas for the /api/auth endpoints.
+ *
+ * These schemas are consumed by `bodyValidator` in `authRoutes.ts`.
+ * Any validation failure is converted into a structured HTTP 400 response
+ * by the global `ValidationError` / `errorHandler` pipeline:
+ *
+ * ```json
+ * {
+ *   "success": false,
+ *   "error": {
+ *     "code": "VALIDATION_ERROR",
+ *     "message": "Request validation failed",
+ *     "details": [
+ *       { "field": "body.walletAddress", "message": "Wallet address is required", "code": "TOO_SMALL" }
+ *     ]
+ *   },
+ *   "requestId": "...",
+ *   "timestamp": "..."
+ * }
+ * ```
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// POST /auth/wallet
+// ---------------------------------------------------------------------------
+
+/**
+ * Body schema for wallet-based login.
+ *
+ * All three fields are required non-empty strings:
+ * - `walletAddress` – the Stellar public key (G… address) initiating the login
+ * - `signature`     – the hex/base64 signature produced by the wallet
+ * - `message`       – the exact message that was signed
+ */
+export const walletLoginSchema = z.object({
+  walletAddress: z.string().min(1, 'Wallet address is required'),
+  signature: z.string().min(1, 'Signature is required'),
+  message: z.string().min(1, 'Message is required'),
+});
+
+export type WalletLoginInput = z.infer<typeof walletLoginSchema>;
+
+// ---------------------------------------------------------------------------
+// POST /auth/refresh  &  POST /auth/revoke
+// ---------------------------------------------------------------------------
+
+/**
+ * Body schema for endpoints that accept a single refresh token.
+ * Used by both `POST /auth/refresh` and `POST /auth/revoke`.
+ *
+ * - `refreshToken` – the opaque refresh token string issued at login
+ */
+export const refreshTokenSchema = z.object({
+  refreshToken: z.string().min(1, 'Refresh token is required'),
+});
+
+export type RefreshTokenInput = z.infer<typeof refreshTokenSchema>;

--- a/tests/integration/authValidation.test.ts
+++ b/tests/integration/authValidation.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Focused tests for auth request validation.
+ *
+ * Coverage:
+ *  1. Unit tests for walletLoginSchema and refreshTokenSchema (Zod layer)
+ *  2. Integration tests verifying that bodyValidator produces structured
+ *     HTTP 400 responses with the expected error envelope shape when the
+ *     auth routes receive invalid payloads.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import request from 'supertest';
+import express from 'express';
+import { errorHandler } from '../../src/middleware/errorHandler.js';
+import { bodyValidator } from '../../src/middleware/validate.js';
+import { walletLoginSchema, refreshTokenSchema } from '../../src/validators/auth.js';
+import { createAuthRoutes } from '../../src/routes/authRoutes.js';
+import { AuthController } from '../../src/controllers/authController.js';
+import { RefreshTokenService } from '../../src/services/refreshTokenService.js';
+import { TEST_JWT_SECRET } from '../helpers/jwt.js';
+
+// ---------------------------------------------------------------------------
+// Minimal mock repository — we only need it to satisfy the AuthController
+// constructor; no real DB calls are needed for validation tests.
+// ---------------------------------------------------------------------------
+class NoopRefreshTokenRepository {
+  async createRefreshToken(token: any) { return token; }
+  async findRefreshTokenById() { return null; }
+  async findRefreshTokenByHash() { return null; }
+  async updateLastUsed() { /* noop */ }
+  async revokeRefreshToken() { /* noop */ }
+  async revokeFamily() { /* noop */ }
+  async revokeAllUserTokens() { /* noop */ }
+  async cleanupExpiredTokens() { return 0; }
+  async countActiveTokens() { return 0; }
+  async listRefreshTokens() { return { tokens: [], hasMore: false }; }
+}
+
+// ---------------------------------------------------------------------------
+// Test app builder
+// ---------------------------------------------------------------------------
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  process.env.JWT_SECRET = TEST_JWT_SECRET;
+
+  const refreshTokenService = new RefreshTokenService({
+    jwtSecret: TEST_JWT_SECRET,
+    accessTokenExpiry: '15m',
+    refreshTokenExpiry: '7d',
+  });
+
+  const authController = new AuthController({
+    refreshTokenService,
+    refreshTokenRepository: new NoopRefreshTokenRepository() as any,
+  });
+
+  app.use('/auth', createAuthRoutes(authController));
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Unit tests for walletLoginSchema
+// ---------------------------------------------------------------------------
+describe('walletLoginSchema', () => {
+  it('accepts a valid payload', () => {
+    const result = walletLoginSchema.safeParse({
+      walletAddress: 'GDTEST123STELLAR',
+      signature: 'abc123sig',
+      message: 'Login to Callora',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects when walletAddress is missing', () => {
+    const result = walletLoginSchema.safeParse({
+      signature: 'abc123sig',
+      message: 'Login to Callora',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const fields = result.error.issues.map((i) => i.path.join('.'));
+      expect(fields).toContain('walletAddress');
+    }
+  });
+
+  it('rejects when walletAddress is an empty string', () => {
+    const result = walletLoginSchema.safeParse({
+      walletAddress: '',
+      signature: 'abc123sig',
+      message: 'Login to Callora',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when signature is missing', () => {
+    const result = walletLoginSchema.safeParse({
+      walletAddress: 'GDTEST123',
+      message: 'Login to Callora',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const fields = result.error.issues.map((i) => i.path.join('.'));
+      expect(fields).toContain('signature');
+    }
+  });
+
+  it('rejects when message is missing', () => {
+    const result = walletLoginSchema.safeParse({
+      walletAddress: 'GDTEST123',
+      signature: 'abc123sig',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const fields = result.error.issues.map((i) => i.path.join('.'));
+      expect(fields).toContain('message');
+    }
+  });
+
+  it('rejects an empty object', () => {
+    const result = walletLoginSchema.safeParse({});
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it('rejects non-string walletAddress', () => {
+    const result = walletLoginSchema.safeParse({
+      walletAddress: 12345,
+      signature: 'sig',
+      message: 'msg',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Unit tests for refreshTokenSchema
+// ---------------------------------------------------------------------------
+describe('refreshTokenSchema', () => {
+  it('accepts a valid payload', () => {
+    const result = refreshTokenSchema.safeParse({ refreshToken: 'some-opaque-token' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects when refreshToken is missing', () => {
+    const result = refreshTokenSchema.safeParse({});
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const fields = result.error.issues.map((i) => i.path.join('.'));
+      expect(fields).toContain('refreshToken');
+    }
+  });
+
+  it('rejects when refreshToken is an empty string', () => {
+    const result = refreshTokenSchema.safeParse({ refreshToken: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when refreshToken is not a string', () => {
+    const result = refreshTokenSchema.safeParse({ refreshToken: 42 });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Direct bodyValidator unit tests — validates the middleware response shape
+// ---------------------------------------------------------------------------
+describe('bodyValidator middleware — auth schemas', () => {
+  function buildMiddlewareApp(schema: typeof walletLoginSchema | typeof refreshTokenSchema) {
+    const app = express();
+    app.use(express.json());
+    app.post('/test', bodyValidator(schema), (_req, res) => {
+      res.json({ ok: true });
+    });
+    app.use(errorHandler);
+    return app;
+  }
+
+  describe('walletLoginSchema via bodyValidator', () => {
+    let app: express.Express;
+    beforeEach(() => { app = buildMiddlewareApp(walletLoginSchema); });
+
+    it('passes through a valid body', async () => {
+      const res = await request(app).post('/test').send({
+        walletAddress: 'GDTEST123',
+        signature: 'sig',
+        message: 'msg',
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 400 with VALIDATION_ERROR code for a missing field', async () => {
+      const res = await request(app).post('/test').send({
+        walletAddress: 'GDTEST123',
+        // signature missing
+        message: 'msg',
+      });
+      expect(res.status).toBe(400);
+      // errorHandler wraps in error envelope
+      expect(res.body.success).toBe(false);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('includes field-level details for missing walletAddress', async () => {
+      const res = await request(app).post('/test').send({
+        signature: 'sig',
+        message: 'msg',
+      });
+      expect(res.status).toBe(400);
+      const details = res.body.error?.details ?? [];
+      const walletField = details.find((d: any) => d.field?.includes('walletAddress'));
+      expect(walletField).toBeDefined();
+    });
+
+    it('returns 400 for an empty body', async () => {
+      const res = await request(app).post('/test').send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+      expect(res.body.error.details.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('refreshTokenSchema via bodyValidator', () => {
+    let app: express.Express;
+    beforeEach(() => { app = buildMiddlewareApp(refreshTokenSchema); });
+
+    it('passes through a valid body', async () => {
+      const res = await request(app).post('/test').send({ refreshToken: 'tok' });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 400 with VALIDATION_ERROR code when refreshToken is absent', async () => {
+      const res = await request(app).post('/test').send({});
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('includes field-level details for missing refreshToken', async () => {
+      const res = await request(app).post('/test').send({});
+      const details = res.body.error?.details ?? [];
+      const tokenField = details.find((d: any) => d.field?.includes('refreshToken'));
+      expect(tokenField).toBeDefined();
+      expect(tokenField.message).toMatch(/required/i);
+    });
+
+    it('returns 400 when refreshToken is an empty string', async () => {
+      const res = await request(app).post('/test').send({ refreshToken: '' });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. End-to-end validation on the real auth router
+// ---------------------------------------------------------------------------
+describe('POST /auth/wallet — Zod validation (integration)', () => {
+  let app: express.Express;
+  beforeEach(() => { app = buildApp(); });
+
+  it('returns 400 with structured error when all fields are missing', async () => {
+    const res = await request(app).post('/auth/wallet').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.message).toBe('Request validation failed');
+    expect(Array.isArray(res.body.error.details)).toBe(true);
+  });
+
+  it('returns 400 when walletAddress is missing', async () => {
+    const res = await request(app)
+      .post('/auth/wallet')
+      .send({ signature: 'sig', message: 'msg' });
+    expect(res.status).toBe(400);
+    const details = res.body.error?.details ?? [];
+    const walletErr = details.find((d: any) => d.field?.includes('walletAddress'));
+    expect(walletErr).toBeDefined();
+    expect(walletErr.message).toBe('Wallet address is required');
+  });
+
+  it('returns 400 when signature is missing', async () => {
+    const res = await request(app)
+      .post('/auth/wallet')
+      .send({ walletAddress: 'GDTEST', message: 'msg' });
+    expect(res.status).toBe(400);
+    const details = res.body.error?.details ?? [];
+    expect(details.find((d: any) => d.field?.includes('signature'))).toBeDefined();
+  });
+
+  it('returns 400 when message is missing', async () => {
+    const res = await request(app)
+      .post('/auth/wallet')
+      .send({ walletAddress: 'GDTEST', signature: 'sig' });
+    expect(res.status).toBe(400);
+    const details = res.body.error?.details ?? [];
+    expect(details.find((d: any) => d.field?.includes('message'))).toBeDefined();
+  });
+
+  it('returns 400 when walletAddress is an empty string', async () => {
+    const res = await request(app)
+      .post('/auth/wallet')
+      .send({ walletAddress: '', signature: 'sig', message: 'msg' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns requestId and timestamp in the error envelope', async () => {
+    const res = await request(app).post('/auth/wallet').send({});
+    expect(res.body.requestId).toBeDefined();
+    expect(res.body.timestamp).toBeDefined();
+  });
+
+  it('passes Zod validation and reaches the controller (which returns 401 for unimplemented login)', async () => {
+    const res = await request(app)
+      .post('/auth/wallet')
+      .send({ walletAddress: 'GDTEST', signature: 'sig', message: 'Login to Callora' });
+    // Validation passes → controller rejects with AUTH_NOT_IMPLEMENTED
+    expect(res.status).toBe(401);
+    expect(res.body.error?.code ?? res.body.code).toMatch(/AUTH_NOT_IMPLEMENTED|UNAUTHORIZED/);
+  });
+});
+
+describe('POST /auth/refresh — Zod validation (integration)', () => {
+  let app: express.Express;
+  beforeEach(() => { app = buildApp(); });
+
+  it('returns 400 with structured error when refreshToken is missing', async () => {
+    const res = await request(app).post('/auth/refresh').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.message).toBe('Request validation failed');
+    expect(Array.isArray(res.body.error.details)).toBe(true);
+  });
+
+  it('includes field-level detail pointing at body.refreshToken', async () => {
+    const res = await request(app).post('/auth/refresh').send({});
+    const details: any[] = res.body.error?.details ?? [];
+    const tokenErr = details.find((d) => d.field?.includes('refreshToken'));
+    expect(tokenErr).toBeDefined();
+    expect(tokenErr.message).toBe('Refresh token is required');
+  });
+
+  it('returns 400 when refreshToken is an empty string', async () => {
+    const res = await request(app).post('/auth/refresh').send({ refreshToken: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('passes validation and reaches the controller when refreshToken is present', async () => {
+    const res = await request(app)
+      .post('/auth/refresh')
+      .send({ refreshToken: 'some-token-value' });
+    // Validation passes → controller returns 401 (invalid/unknown token)
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /auth/revoke — Zod validation (integration)', () => {
+  let app: express.Express;
+  beforeEach(() => { app = buildApp(); });
+
+  it('returns 400 with structured error when refreshToken is missing', async () => {
+    const res = await request(app).post('/auth/revoke').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('includes field-level detail for missing refreshToken', async () => {
+    const res = await request(app).post('/auth/revoke').send({});
+    const details: any[] = res.body.error?.details ?? [];
+    expect(details.find((d) => d.field?.includes('refreshToken'))).toBeDefined();
+  });
+
+  it('passes validation with a non-empty refreshToken', async () => {
+    const res = await request(app)
+      .post('/auth/revoke')
+      .send({ refreshToken: 'some-token-value' });
+    // Controller returns 200 (token not found — still success to prevent enumeration)
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
…ed 400 errors

- Add src/validators/auth.ts with walletLoginSchema and refreshTokenSchema
- Update src/routes/authRoutes.ts: import schemas from validators, fix missing refreshTokenHistogramMiddleware import, move loginThrottle creation inside createAuthRoutes() to prevent shared state across tests
- Fix src/middleware/errorHandler.ts: remove duplicate imports and add missing buildErrorEnvelope import from middleware/envelope.ts
- Add tests/integration/authValidation.test.ts with unit tests for Zod schemas, bodyValidator middleware tests, and e2e integration tests covering POST /auth/wallet, /auth/refresh, and /auth/revoke
- Add docs/auth-api.md documenting all /api/auth endpoints with their validated request schemas, 400 error shapes, and success shapes

Closes #786