### PR TITLE
Feat: Add OpenAPI examples for /api/rate-limit

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -194,6 +194,143 @@
         }
       }
     },
+    "/api/rate-limit/health": {
+      "get": {
+        "summary": "Check rate-limit subsystem health",
+        "description": "Returns the operational status of the rate-limit subsystem and its configured dependencies. This public probe does not consume rate-limit budget and does not require a request body.",
+        "responses": {
+          "200": {
+            "description": "Rate-limit subsystem is operational",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitHealthResponse"
+                },
+                "examples": {
+                  "operational": {
+                    "summary": "In-memory limiter is operational",
+                    "value": {
+                      "status": "ok",
+                      "timestamp": "2026-07-28T10:00:00.000Z",
+                      "dependencies": {
+                        "in_memory_store": {
+                          "status": "ok",
+                          "responseTime": 0.123,
+                          "details": {
+                            "windowMs": 60000,
+                            "maxRequests": 100
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "notConfigured": {
+                    "summary": "No limiter configured",
+                    "value": {
+                      "status": "ok",
+                      "timestamp": "2026-07-28T10:00:00.000Z",
+                      "dependencies": {
+                        "in_memory_store": {
+                          "status": "ok",
+                          "details": {
+                            "note": "No rate limiter configured for probing"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Rate-limit subsystem is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitHealthResponse"
+                },
+                "examples": {
+                  "unavailable": {
+                    "summary": "Rate-limit store probe failed",
+                    "value": {
+                      "status": "down",
+                      "timestamp": "2026-07-28T10:00:00.000Z",
+                      "dependencies": {
+                        "in_memory_store": {
+                          "status": "down",
+                          "responseTime": 0.456,
+                          "error": "unavailable"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/limits/check": {
+      "get": {
+        "summary": "Check the authenticated user's rate-limit budget",
+        "description": "Peeks at the authenticated user's REST rate-limit bucket without consuming a token. No request body is required.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rate-limit budget status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitCheckResponse"
+                },
+                "examples": {
+                  "allowed": {
+                    "summary": "Requests are currently allowed",
+                    "value": {
+                      "status": "ok"
+                    }
+                  },
+                  "denied": {
+                    "summary": "Rate-limit budget is exhausted",
+                    "value": {
+                      "status": "deny",
+                      "reason": "rate_limit_exceeded",
+                      "retryAfterMs": 42300
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication is required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "summary": "Missing or invalid authentication",
+                    "value": {
+                      "code": "UNAUTHORIZED",
+                      "message": "Authentication required",
+                      "requestId": "req-rate-limit-check"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/gateway/health/{apiSlug}": {
       "get": {
         "summary": "Get gateway health for an API",
@@ -4669,6 +4806,90 @@
                 ]
               }
             }
+          }
+        }
+      },
+      "RateLimitHealthResponse": {
+        "type": "object",
+        "description": "Operational health response for the rate-limit subsystem.",
+        "required": [
+          "status",
+          "timestamp",
+          "dependencies"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "degraded",
+              "down"
+            ]
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RateLimitDependencyStatus"
+            }
+          }
+        }
+      },
+      "RateLimitCheckResponse": {
+        "type": "object",
+        "description": "Non-consuming rate-limit budget check for the authenticated user.",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "deny"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "rate_limit_exceeded"
+            ]
+          },
+          "retryAfterMs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Milliseconds until the current rate-limit window resets"
+          }
+        }
+      },
+      "RateLimitDependencyStatus": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "degraded",
+              "down"
+            ]
+          },
+          "responseTime": {
+            "type": "number",
+            "description": "Probe response time in milliseconds"
+          },
+          "error": {
+            "type": "string",
+            "description": "Safe error identifier when the dependency is unavailable"
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           }
         }
       },

--- a/docs/rate-limit-health.md
+++ b/docs/rate-limit-health.md
@@ -1,0 +1,14 @@
+# Rate-limit health probe
+
+`GET /api/rate-limit/health` reports whether the rate-limit subsystem can perform
+its non-consuming probe. It is a public operational endpoint and accepts no
+request body.
+
+Authenticated clients can use `GET /api/limits/check` to peek at their own
+rate-limit budget without consuming a token. It returns either `{ "status":
+"ok" }` or a denial with `reason: "rate_limit_exceeded"` and `retryAfterMs`.
+
+An operational limiter returns `200` with `status: "ok"`. If the limiter store
+cannot be probed, the endpoint returns `503` with `status: "down"` and the safe
+error identifier `unavailable`. The complete request and response examples are
+in [the OpenAPI contract](./openapi.json).

--- a/src/app.ts
+++ b/src/app.ts
@@ -351,6 +351,16 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
     createDependenciesRouter(dependencies?.healthCheckConfig),
   );
 
+  // Rate-limit health dependency probe - operational status of the rate-limit subsystem
+  app.use(
+    "/api/rate-limit/health",
+    createRateLimitHealthRouter({
+      limiter: restRateLimiter,
+      windowMs: restRateLimitOptions.windowMs,
+      maxRequests: restRateLimitOptions.maxRequests,
+    }),
+  );
+
   app.get("/api/health", async (req, res) => {
     const requestId = getRequestId(req);
     // If no health check config provided, return simple health check

--- a/src/routes/rate-limit/health.openapi.test.ts
+++ b/src/routes/rate-limit/health.openapi.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type JsonObject = Record<string, unknown>;
+
+describe('OpenAPI examples for /api/rate-limit/health', () => {
+  const openApiPath = path.join(process.cwd(), 'docs', 'openapi.json');
+
+  function readSpec(): JsonObject {
+    return JSON.parse(fs.readFileSync(openApiPath, 'utf8')) as JsonObject;
+  }
+
+  function asObject(value: unknown): JsonObject {
+    return value as JsonObject;
+  }
+
+  test('documents operational and unconfigured 200 response examples', () => {
+    const spec = readSpec();
+    const operation = asObject(asObject(spec.paths)['/api/rate-limit/health']).get as JsonObject;
+    const response200 = asObject(asObject(operation.responses)['200']);
+    const examples = asObject(
+      asObject(asObject(response200.content)['application/json']).examples,
+    );
+
+    expect(examples.operational).toBeDefined();
+    expect(asObject(asObject(examples.operational).value)).toEqual(
+      expect.objectContaining({ status: 'ok' }),
+    );
+    expect(examples.notConfigured).toBeDefined();
+    expect(
+      asObject(
+        asObject(
+          asObject(asObject(examples.notConfigured).value).dependencies,
+        ).in_memory_store,
+      ).details,
+    ).toEqual({ note: 'No rate limiter configured for probing' });
+  });
+
+  test('documents the unavailable 503 response example', () => {
+    const spec = readSpec();
+    const operation = asObject(asObject(spec.paths)['/api/rate-limit/health']).get as JsonObject;
+    const response503 = asObject(asObject(operation.responses)['503']);
+    const examples = asObject(
+      asObject(asObject(response503.content)['application/json']).examples,
+    );
+    const unavailable = asObject(examples.unavailable);
+
+    expect(unavailable.summary).toBe('Rate-limit store probe failed');
+    expect(
+      asObject(
+        asObject(asObject(unavailable.value).dependencies).in_memory_store,
+      ),
+    ).toEqual(
+      expect.objectContaining({ status: 'down', error: 'unavailable' }),
+    );
+  });
+
+  test('documents allowed and denied examples for the authenticated pre-check', () => {
+    const spec = readSpec();
+    const operation = asObject(asObject(spec.paths)['/api/limits/check']).get as JsonObject;
+    const response200 = asObject(asObject(operation.responses)['200']);
+    const examples = asObject(
+      asObject(asObject(response200.content)['application/json']).examples,
+    );
+
+    expect(asObject(examples.allowed).value).toEqual({ status: 'ok' });
+    expect(asObject(examples.denied).value).toEqual({
+      status: 'deny',
+      reason: 'rate_limit_exceeded',
+      retryAfterMs: 42300,
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Closes #725 

- Added OpenAPI documentation for:
  - `GET /api/rate-limit/health`
  - `GET /api/limits/check`
- Added request/response examples for successful, denied, unavailable, and unauthorized cases.
- Added reusable OpenAPI schemas for rate-limit responses.
- Mounted the rate-limit health router in `src/app.ts`.
- Added focused OpenAPI contract tests.
- Added `docs/rate-limit-health.md`.
- Verified that the OpenAPI JSON is valid.

