### PR TITLE
Add Zod input validation for /api/admin/audit

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -5,7 +5,6 @@ import type { ValidationErrorDetail } from './validate.js';
 import { ValidationError } from './validate.js';
 import { buildErrorEnvelope } from './envelope.js';
 import type { ErrorEnvelope } from '../types/ResponseEnvelope.js';
-import { buildErrorEnvelope } from './envelope.js';
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -100,7 +99,7 @@ export function errorHandler(
   }
 
   const details = extractValidationDetails(err);
-  const body = errorEnvelope(code, finalMessage, requestId, details);
+  const body = buildErrorEnvelope(code, finalMessage, requestId, details);
 
   if (!res.headersSent) {
     res.status(statusCode).json(body);

--- a/src/routes/admin/audit.test.ts
+++ b/src/routes/admin/audit.test.ts
@@ -207,8 +207,8 @@ describe('GET /api/admin/audit', () => {
       .set('x-admin-api-key', ADMIN_KEY);
 
     expect(res.status).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_ERROR');
-    expect(res.body.details).toEqual(
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.details).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ field: 'query.cursor' }),
       ]),
@@ -224,7 +224,7 @@ describe('GET /api/admin/audit', () => {
       .set('x-admin-api-key', ADMIN_KEY);
 
     expect(res.status).toBe(400);
-    expect(res.body.details).toEqual(
+    expect(res.body.error.details).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ field: 'query.limit' }),
       ]),
@@ -240,7 +240,11 @@ describe('GET /api/admin/audit', () => {
       .set('x-admin-api-key', ADMIN_KEY);
 
     expect(res.status).toBe(400);
-    expect(res.body.message).toContain('from');
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'query.from' }),
+      ]),
+    );
   });
 
   it('rejects when from is after to', async () => {
@@ -256,7 +260,11 @@ describe('GET /api/admin/audit', () => {
       .set('x-admin-api-key', ADMIN_KEY);
 
     expect(res.status).toBe(400);
-    expect(res.body.message).toContain('from');
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'query.from' }),
+      ]),
+    );
   });
 
   it('requires admin authentication', async () => {

--- a/src/routes/admin/audit.ts
+++ b/src/routes/admin/audit.ts
@@ -1,67 +1,18 @@
-/**
- * Admin audit-log listing with cursor pagination and action replay.
- *
- * Routes:
- *   GET  /api/admin/audit
- *   POST /api/admin/audit/replay
- *
- * Pagination uses stable keyset ordering over (created_at DESC, id DESC).
- * The opaque `cursor` query param encodes the last row's timestamp and id.
- *
- * Replay re-executes a previously logged admin action using the original
- * parameters stored in the audit row's `details` JSON blob.
- */
-
 import { Router } from 'express';
 import { getClientIp } from '../../lib/clientIp.js';
 import { encodeCursor, parseCursor } from '../../lib/cursorPagination.js';
-import {
-  cursorPaginatedResponse,
-} from '../../lib/pagination.js';
-import {
-  AppError,
-  InternalServerError,
-} from '../../errors/index.js';
-import { ValidationError } from '../../middleware/validate.js';
+import { cursorPaginatedResponse } from '../../lib/pagination.js';
+import { AppError, InternalServerError } from '../../errors/index.js';
+import { validate, ValidationError } from '../../middleware/validate.js';
 import { etagMiddleware } from '../../middleware/etag.js';
 import { logger } from '../../logger.js';
-import {
-  PgAuditLogRepository,
-  type AuditLogRepository,
-} from '../../repositories/auditLogRepository.js';
-import {
-  createAdminAuditReplayRouter,
-  type AdminAuditReplayRouterDeps,
-} from './audit/replay.js';
+import { PgAuditLogRepository, type AuditLogRepository } from '../../repositories/auditLogRepository.js';
+import { auditQuerySchema } from '../../validators/audit.js';
+import { createAdminAuditReplayRouter, type AdminAuditReplayRouterDeps } from './audit/replay.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 
-const parseOptionalDate = (value: unknown, field: string): Date | undefined => {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== 'string' || value.trim() === '') {
-    throw new BadRequestError(`Invalid "${field}" date`);
-  }
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    throw new BadRequestError(`Invalid "${field}" date`);
-  }
-
-  return date;
-};
-
-const parseOptionalString = (value: unknown): string | undefined => {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed === '' ? undefined : trimmed;
-};
-
-export interface AdminAuditRouterDeps
-  extends AdminAuditReplayRouterDeps {
+export interface AdminAuditRouterDeps extends AdminAuditReplayRouterDeps {
   auditLogRepository?: AuditLogRepository;
 }
 
@@ -71,81 +22,72 @@ export function createAdminAuditRouter(deps: AdminAuditRouterDeps = {}): Router 
 
   router.use('/replay', createAdminAuditReplayRouter(deps));
 
-  router.get('/', async (req, res, next) => {
-    try {
-      const parsedQuery = auditQuerySchema.safeParse(req.query);
+  router.get(
+    '/',
+    validate({ query: auditQuerySchema }),
+    etagMiddleware,
+    async (req, res, next) => {
+      try {
+        const { limit, cursor: rawCursor, event, tenant_id: tenantId, actor, from, to } = auditQuerySchema.parse(req.query);
 
-      if (!parsedQuery.success) {
-        const details = parsedQuery.error.issues.map((issue) => {
-          const field = `query.${issue.path.join('.')}`;
-          return {
-            field,
-            message: issue.message,
-            code: issue.code.toUpperCase(),
-          };
-        });
-        throw new ValidationError(details);
-      }
-
-      const { limit, cursor: rawCursor, event, tenant_id: tenantId, actor, from, to } = parsedQuery.data;
-
-      let afterCursor;
-      if (rawCursor !== undefined) {
-        afterCursor = parseCursor(rawCursor);
-        if (!afterCursor) {
-          throw new ValidationError([
-            {
-              field: 'query.cursor',
-              message: 'Invalid cursor format',
-              code: 'INVALID_VALUE',
-            },
-          ]);
+        let afterCursor;
+        if (rawCursor !== undefined) {
+          afterCursor = parseCursor(rawCursor);
+          if (!afterCursor) {
+            throw new ValidationError([
+              {
+                field: 'query.cursor',
+                message: 'Invalid cursor format',
+                code: 'INVALID_VALUE',
+              },
+            ]);
+          }
         }
+
+        const { entries, hasMore } = await auditLogRepository.findCursor({
+          limit,
+          afterCursor,
+          event,
+          tenantId,
+          actor,
+          from,
+          to,
+        });
+
+        const nextCursor = hasMore && entries.length > 0
+          ? encodeCursor(new Date(entries[entries.length - 1]!.createdAt), entries[entries.length - 1]!.id)
+          : undefined;
+
+        const correlationId =
+          (typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : undefined) ??
+          (typeof req.headers['x-correlation-id'] === 'string' ? req.headers['x-correlation-id'] : undefined);
+
+        logger.audit('LIST_AUDIT_LOGS', res.locals.adminActor, {
+          clientIp: getClientIp(req, TRUST_PROXY),
+          userAgent: req.get('User-Agent'),
+          correlationId,
+          filters: { event, tenantId, actor, from, to },
+          limit,
+          cursorProvided: rawCursor !== undefined,
+          count: entries.length,
+          hasMore,
+        });
+
+        res.json(cursorPaginatedResponse(entries, {
+          limit,
+          hasMore,
+          nextCursor,
+        }));
+      } catch (error) {
+        if (error instanceof AppError || error instanceof ValidationError) {
+          next(error);
+          return;
+        }
+        logger.error('Failed to list audit logs:', error);
+        next(new InternalServerError());
       }
-
-      const { entries, hasMore } = await auditLogRepository.findCursor({
-        limit,
-        afterCursor,
-        event,
-        tenantId,
-        actor,
-        from,
-        to,
-      });
-
-      const nextCursor = hasMore && entries.length > 0
-        ? encodeCursor(new Date(entries[entries.length - 1]!.createdAt), entries[entries.length - 1]!.id)
-        : undefined;
-
-      const correlationId =
-        (typeof req.headers['x-request-id'] === 'string' ? req.headers['x-request-id'] : undefined) ??
-        (typeof req.headers['x-correlation-id'] === 'string' ? req.headers['x-correlation-id'] : undefined);
-
-      logger.audit('LIST_AUDIT_LOGS', res.locals.adminActor, {
-        clientIp: getClientIp(req, TRUST_PROXY),
-        userAgent: req.get('User-Agent'),
-        correlationId,
-        filters: { event, tenantId, actor, from, to },
-        limit,
-        cursorProvided: rawCursor !== undefined,
-        count: entries.length,
-        hasMore,
-      });
-
-      res.json(cursorPaginatedResponse(entries, {
-        limit,
-        hasMore,
-        nextCursor,
-      }));
-    } catch (error) {
-      if (error instanceof AppError || error instanceof ValidationError) {
-        next(error);
-        return;
-      }
-      logger.error('Failed to list audit logs:', error);
-      next(new InternalServerError());
-    }
-  });
+    },
+  );
 
   return router;
 }

--- a/src/services/quotaService.ts
+++ b/src/services/quotaService.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../logger.js';
-import { NotFoundError, ConflictError } from '../errors/index.js';
+import { BadRequestError, NotFoundError, ConflictError } from '../errors/index.js';
 import { quotasCache } from './quotasCacheWarm.js';
 
 // ---------------------------------------------------------------------------

--- a/src/validators/audit.test.ts
+++ b/src/validators/audit.test.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import { auditQuerySchema } from './audit.js';
 
 describe('auditQuerySchema', () => {

--- a/src/validators/audit.ts
+++ b/src/validators/audit.ts
@@ -1,45 +1,45 @@
 import { z } from 'zod';
 
+const coerceInt = (val: string | undefined): number => {
+  if (val === undefined) return 20;
+  const num = Number(val);
+  if (Number.isNaN(num) || !Number.isInteger(num)) {
+    return NaN;
+  }
+  return num;
+};
+
 export const auditQuerySchema = z.object({
   limit: z
     .string()
     .optional()
-    .transform((val) => {
-      if (val === undefined) return 20;
-      const num = Number(val);
-      if (Number.isNaN(num) || !Number.isInteger(num)) {
-        throw new Error('Limit must be an integer');
-      }
-      return num;
-    })
-    .refine((val) => val >= 1 && val <= 100, {
-      message: 'Limit must be between 1 and 100',
-    }),
+    .default('20')
+    .transform(coerceInt)
+    .refine((val) => !Number.isNaN(val), { message: 'Limit must be an integer' })
+    .refine((val) => val >= 1 && val <= 100, { message: 'Limit must be between 1 and 100' }),
   cursor: z.string().optional(),
-  event: z.string().optional().transform((val) => (val && val.trim() !== '' ? val.trim() : undefined)),
-  tenant_id: z.string().optional().transform((val) => (val && val.trim() !== '' ? val.trim() : undefined)),
-  actor: z.string().optional().transform((val) => (val && val.trim() !== '' ? val.trim() : undefined)),
+  event: z.string().optional().transform((val) => val?.trim() || undefined),
+  tenant_id: z.string().optional().transform((val) => val?.trim() || undefined),
+  actor: z.string().optional().transform((val) => val?.trim() || undefined),
   from: z
     .string()
     .optional()
+    .refine((val) => val === undefined || val.trim() === '' || !Number.isNaN(new Date(val).getTime()), {
+      message: 'Invalid "from" date',
+    })
     .transform((val) => {
       if (val === undefined || val.trim() === '') return undefined;
-      const date = new Date(val);
-      if (Number.isNaN(date.getTime())) {
-        throw new Error('Invalid "from" date');
-      }
-      return date;
+      return new Date(val);
     }),
   to: z
     .string()
     .optional()
+    .refine((val) => val === undefined || val.trim() === '' || !Number.isNaN(new Date(val).getTime()), {
+      message: 'Invalid "to" date',
+    })
     .transform((val) => {
       if (val === undefined || val.trim() === '') return undefined;
-      const date = new Date(val);
-      if (Number.isNaN(date.getTime())) {
-        throw new Error('Invalid "to" date');
-      }
-      return date;
+      return new Date(val);
     }),
 }).refine((data) => {
   if (data.from && data.to && data.from.getTime() > data.to.getTime()) {


### PR DESCRIPTION
## Overview

This PR adds proper Zod input validation for the `/api/admin/audit` endpoint using the centralized `validate()` middleware pattern, consistent with the rest of the admin routes. It replaces the manual `safeParse()` + `ValidationError` construction in the route handler with an early-validation middleware at the route boundary, producing standardized 400 error responses.

## Related Issue
Closes #932

## Changes

### Zod Input Validation
- **[REFACTOR]** `src/validators/audit.ts` — Replaced `throw new Error()` inside `.transform()` with proper `.refine()` calls. The schema now produces standard Zod issues instead of raw thrown errors.
- **[REFACTOR]** `src/routes/admin/audit.ts` — Moved query validation to `validate()` middleware at the route boundary. Removed unused helper functions. Applied `etagMiddleware`.

### Bug Fixes
- **[FIX]** `src/middleware/errorHandler.ts` — Fixed undefined function call and duplicate import.
- **[FIX]** `src/services/quotaService.ts` — Added missing `BadRequestError` import.

### Tests
- **[UPDATE]** `src/routes/admin/audit.test.ts` — Updated error assertions for envelope format.
- **[CLEANUP]** `src/validators/audit.test.ts` — Removed unused import.

## Verification

```
npm run lint ✅ completed (existing repo warnings only)
npm run typecheck ✅ passed
npm test -- src/validators/audit.test.ts src/routes/admin/audit.test.ts --runInBand ✅ passed (23/23)
```