### PR TITLE
Add Zod validation for webhooks API

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -19,6 +19,37 @@ when specific events occur on the Callora platform.
 | url         | string     | ✅       | HTTPS endpoint to receive events   |
 | events      | string[]   | ✅       | One or more event types (see below)|
 | secret      | string     | ❌       | Used to sign payloads (recommended)|
+| retryPolicy | object     | optional | Optional per-subscription retry override |
+
+Request bodies are Zod-validated before registration logic runs. Unknown fields
+are rejected.
+
+### Validation errors
+
+Invalid registration and retry-policy requests return HTTP 400 using the
+standard error envelope:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": [
+      {
+        "field": "body.url",
+        "message": "url must be a valid absolute URL",
+        "code": "INVALID_FORMAT"
+      }
+    ]
+  },
+  "requestId": "req-webhook-create",
+  "timestamp": "2026-07-28T00:00:00.000Z"
+}
+```
+
+`developerId` path parameters on management routes are also validated and return
+the same envelope when malformed.
 
 ### Supported Events
 
@@ -238,6 +269,26 @@ Failed deliveries (non-2xx, timeout, DNS failure) are retried with **exponential
 
 After 5 failures, the event is dropped and logged server-side.
 
+Override retry behavior for a single subscription with:
+
+```http
+PATCH /api/webhooks/:developerId/retry-policy
+Content-Type: application/json
+```
+
+```json
+{
+  "retryPolicy": {
+    "maxRetries": 3,
+    "baseDelayMs": 500
+  }
+}
+```
+
+`retryPolicy` is optional; sending `{}` clears the override. When provided,
+`maxRetries` must be an integer from 0 to 10 and `baseDelayMs` must be an
+integer from 100 to 60000.
+
 ---
 
 ## Manage Webhooks
@@ -247,6 +298,7 @@ After 5 failures, the event is dropped and logged server-side.
 | POST   | `/api/webhooks`                   | Register webhook         |
 | GET    | `/api/webhooks/:developerId`      | View current webhook     |
 | POST   | `/api/webhooks/:developerId/rotate-secret` | Rotate signing secret |
+| PATCH  | `/api/webhooks/:developerId/retry-policy` | Update retry policy |
 | DELETE | `/api/webhooks/:developerId`      | Remove webhook           |
 
 ---

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -5,7 +5,6 @@ import type { ValidationErrorDetail } from './validate.js';
 import { ValidationError } from './validate.js';
 import { buildErrorEnvelope } from './envelope.js';
 import type { ErrorEnvelope } from '../types/ResponseEnvelope.js';
-import { buildErrorEnvelope } from './envelope.js';
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -100,7 +99,7 @@ export function errorHandler(
   }
 
   const details = extractValidationDetails(err);
-  const body = errorEnvelope(code, finalMessage, requestId, details);
+  const body = buildErrorEnvelope(code, finalMessage, requestId, details);
 
   if (!res.headersSent) {
     res.status(statusCode).json(body);

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -1,0 +1,262 @@
+import express from 'express';
+import request from 'supertest';
+import webhookRoutes from './webhooks.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { requestIdMiddleware } from '../middleware/requestId.js';
+import { WebhookStore } from '../webhooks/webhook.store.js';
+import { logger } from '../logger.js';
+
+var mockDnsLookup = jest.fn();
+jest.mock('dns/promises', () => {
+  const lookup = (...args: unknown[]) => mockDnsLookup(...args);
+  return { __esModule: true, default: { lookup }, lookup };
+});
+
+function buildApp() {
+  const app = express();
+  app.use(requestIdMiddleware);
+  app.use('/api/webhooks', webhookRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('validated /api/webhooks routes', () => {
+  let app: express.Express;
+  let infoSpy: jest.SpyInstance;
+  let auditSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    app = buildApp();
+    WebhookStore.clear();
+    WebhookStore.clearDlq();
+    WebhookStore.clearFailedDeliveries();
+    mockDnsLookup.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+    auditSpy = jest.spyOn(logger, 'audit').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+    auditSpy.mockRestore();
+  });
+
+  it('returns structured 400 for invalid registration payloads', async () => {
+    const res = await request(app)
+      .post('/api/webhooks')
+      .set('x-request-id', 'req-webhook-invalid')
+      .send({ url: 'not-a-url', events: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Request validation failed',
+      },
+      requestId: 'req-webhook-invalid',
+    });
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body.developerId' }),
+        expect.objectContaining({ field: 'body.url' }),
+        expect.objectContaining({ field: 'body.events' }),
+      ]),
+    );
+  });
+
+  it('rejects unknown registration fields before storing anything', async () => {
+    const res = await request(app)
+      .post('/api/webhooks')
+      .send({
+        developerId: 'dev-123',
+        url: 'https://example.com/webhook',
+        events: ['new_api_call'],
+        secret: 'super-secret',
+        role: 'admin',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body', code: 'UNRECOGNIZED_KEYS' }),
+      ]),
+    );
+    expect(WebhookStore.get('dev-123')).toBeUndefined();
+  });
+
+  it('registers a valid webhook and logs non-secret correlation metadata', async () => {
+    const res = await request(app)
+      .post('/api/webhooks')
+      .set('x-request-id', 'req-webhook-create')
+      .set('x-correlation-id', 'corr-webhook-create')
+      .send({
+        developerId: 'dev-123',
+        url: 'https://example.com/webhook',
+        events: ['new_api_call'],
+        secret: 'super-secret',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      message: 'Webhook registered successfully.',
+      developerId: 'dev-123',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call'],
+    });
+    expect(res.body).not.toHaveProperty('secret');
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[webhooks] webhook registered',
+      expect.objectContaining({
+        requestId: 'req-webhook-create',
+        correlationId: 'corr-webhook-create',
+        developerId: 'dev-123',
+        hasSecret: true,
+      }),
+    );
+    expect(JSON.stringify(infoSpy.mock.calls)).not.toContain('super-secret');
+  });
+
+  it('returns structured 400 for invalid developerId params', async () => {
+    const res = await request(app)
+      .get('/api/webhooks/no')
+      .set('x-request-id', 'req-webhook-param');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      error: { code: 'VALIDATION_ERROR' },
+      requestId: 'req-webhook-param',
+    });
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'params.developerId' }),
+      ]),
+    );
+  });
+
+  it('returns structured 400 for invalid retry policy update body', async () => {
+    WebhookStore.register({
+      developerId: 'dev-retry',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call'],
+      createdAt: new Date(),
+    });
+
+    const res = await request(app)
+      .patch('/api/webhooks/dev-retry/retry-policy')
+      .set('x-request-id', 'req-webhook-retry')
+      .send({ retryPolicy: { maxRetries: 11 }, extra: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.requestId).toBe('req-webhook-retry');
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body.retryPolicy.maxRetries' }),
+        expect.objectContaining({ field: 'body', code: 'UNRECOGNIZED_KEYS' }),
+      ]),
+    );
+  });
+
+  it('validates params and returns a safe webhook config without secrets', async () => {
+    WebhookStore.register({
+      developerId: 'dev-get',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call'],
+      secret: 'super-secret',
+      createdAt: new Date(),
+    });
+
+    const res = await request(app).get('/api/webhooks/dev-get');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        developerId: 'dev-get',
+        url: 'https://example.com/webhook',
+        events: ['new_api_call'],
+      }),
+    );
+    expect(res.body).not.toHaveProperty('secret');
+    expect(res.body).not.toHaveProperty('secret_current');
+    expect(res.body).not.toHaveProperty('secret_previous');
+  });
+
+  it('rotates secrets with correlation metadata in the audit event', async () => {
+    WebhookStore.register({
+      developerId: 'dev-rotate',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call'],
+      secret: 'old-secret',
+      createdAt: new Date(),
+    });
+
+    const res = await request(app)
+      .post('/api/webhooks/dev-rotate/rotate-secret')
+      .set('x-correlation-id', 'corr-rotate');
+
+    expect(res.status).toBe(200);
+    expect(res.body.secret).toMatch(/^[a-f0-9]{64}$/);
+    expect(auditSpy).toHaveBeenCalledWith(
+      'WEBHOOK_SECRET_ROTATED',
+      'dev-rotate',
+      expect.objectContaining({
+        developerId: 'dev-rotate',
+        correlationId: 'corr-rotate',
+        hadPreviousSecret: true,
+      }),
+    );
+  });
+
+  it('updates retry policy and audits correlation metadata', async () => {
+    WebhookStore.register({
+      developerId: 'dev-retry-ok',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call'],
+      createdAt: new Date(),
+    });
+
+    const res = await request(app)
+      .patch('/api/webhooks/dev-retry-ok/retry-policy')
+      .set('x-correlation-id', 'corr-retry-ok')
+      .send({ retryPolicy: { maxRetries: 2, baseDelayMs: 500 } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.retryPolicy).toEqual({ maxRetries: 2, baseDelayMs: 500 });
+    expect(auditSpy).toHaveBeenCalledWith(
+      'WEBHOOK_RETRY_POLICY_UPDATED',
+      'dev-retry-ok',
+      expect.objectContaining({
+        developerId: 'dev-retry-ok',
+        correlationId: 'corr-retry-ok',
+        retryPolicy: { maxRetries: 2, baseDelayMs: 500 },
+      }),
+    );
+  });
+
+  it('deletes webhooks with structured non-secret logs', async () => {
+    WebhookStore.register({
+      developerId: 'dev-delete',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call'],
+      secret: 'super-secret',
+      createdAt: new Date(),
+    });
+
+    const res = await request(app)
+      .delete('/api/webhooks/dev-delete')
+      .set('x-request-id', 'req-delete')
+      .set('x-correlation-id', 'corr-delete');
+
+    expect(res.status).toBe(200);
+    expect(WebhookStore.get('dev-delete')).toBeUndefined();
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[webhooks] webhook removed',
+      expect.objectContaining({
+        requestId: 'req-delete',
+        correlationId: 'corr-delete',
+        developerId: 'dev-delete',
+      }),
+    );
+    expect(JSON.stringify(infoSpy.mock.calls)).not.toContain('super-secret');
+  });
+});

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,0 +1,1 @@
+export { default } from '../webhooks/webhook.routes.js';

--- a/src/validators/webhooks.test.ts
+++ b/src/validators/webhooks.test.ts
@@ -1,0 +1,88 @@
+import {
+  registerWebhookSchema,
+  updateWebhookRetryPolicySchema,
+  webhookDeliveryPayloadSchema,
+  webhookDeveloperParamsSchema,
+} from './webhooks.js';
+
+describe('webhook validators', () => {
+  it('accepts a valid registration payload', () => {
+    const parsed = registerWebhookSchema.parse({
+      developerId: 'dev-123',
+      url: ' https://example.com/webhook ',
+      events: ['new_api_call', 'usage_event.created'],
+      secret: 'super-secret',
+      retryPolicy: { maxRetries: 3, baseDelayMs: 500 },
+    });
+
+    expect(parsed).toEqual({
+      developerId: 'dev-123',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call', 'usage_event.created'],
+      secret: 'super-secret',
+      retryPolicy: { maxRetries: 3, baseDelayMs: 500 },
+    });
+  });
+
+  it('rejects missing registration fields', () => {
+    const result = registerWebhookSchema.safeParse({});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((issue) => issue.path.join('.'));
+      expect(paths).toEqual(expect.arrayContaining(['developerId', 'url', 'events']));
+    }
+  });
+
+  it('rejects duplicate or unsupported events', () => {
+    expect(registerWebhookSchema.safeParse({
+      developerId: 'dev-123',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call', 'new_api_call'],
+    }).success).toBe(false);
+
+    expect(registerWebhookSchema.safeParse({
+      developerId: 'dev-123',
+      url: 'https://example.com/webhook',
+      events: ['not_real'],
+    }).success).toBe(false);
+  });
+
+  it('rejects unknown registration fields and short secrets', () => {
+    const result = registerWebhookSchema.safeParse({
+      developerId: 'dev-123',
+      url: 'https://example.com/webhook',
+      events: ['new_api_call'],
+      secret: 'short',
+      admin: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('validates developer route params', () => {
+    expect(webhookDeveloperParamsSchema.parse({ developerId: 'dev_123' })).toEqual({ developerId: 'dev_123' });
+    expect(webhookDeveloperParamsSchema.safeParse({ developerId: 'x' }).success).toBe(false);
+  });
+
+  it('accepts omitted retry policy and validates provided retry limits', () => {
+    expect(updateWebhookRetryPolicySchema.parse({})).toEqual({});
+    expect(updateWebhookRetryPolicySchema.parse({ retryPolicy: { maxRetries: 0 } })).toEqual({
+      retryPolicy: { maxRetries: 0 },
+    });
+    expect(updateWebhookRetryPolicySchema.safeParse({ retryPolicy: { maxRetries: 11 } }).success).toBe(false);
+    expect(updateWebhookRetryPolicySchema.safeParse({ retryPolicy: {} }).success).toBe(false);
+  });
+
+  it('validates signed delivery payload shape', () => {
+    const payload = {
+      event: 'invoice_created',
+      timestamp: '2026-07-28T00:00:00.000Z',
+      developerId: 'dev-123',
+      data: { invoiceId: 'inv-1' },
+    };
+
+    expect(webhookDeliveryPayloadSchema.parse(payload)).toEqual(payload);
+    expect(webhookDeliveryPayloadSchema.safeParse({ ...payload, timestamp: 'today' }).success).toBe(false);
+  });
+});

--- a/src/validators/webhooks.ts
+++ b/src/validators/webhooks.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+
+export const webhookManagementEvents = [
+  'new_api_call',
+  'settlement_completed',
+  'low_balance_alert',
+  'usage_event.created',
+] as const;
+
+export const webhookDeliveryEvents = [
+  ...webhookManagementEvents,
+  'quota.threshold.reached',
+  'invoice_created',
+  'usage.anomaly.detected',
+  'fee_abstraction.executed',
+] as const;
+
+const developerIdPattern = /^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$/;
+
+export const webhookDeveloperIdSchema = z
+  .string({
+    required_error: 'developerId is required',
+    invalid_type_error: 'developerId must be a string',
+  })
+  .trim()
+  .regex(
+    developerIdPattern,
+    'developerId must be 3-128 characters using letters, numbers, underscores, or hyphens',
+  );
+
+export const webhookDeveloperParamsSchema = z.object({
+  developerId: webhookDeveloperIdSchema,
+});
+
+export const webhookRetryPolicySchema = z
+  .object({
+    maxRetries: z
+      .number({ invalid_type_error: 'maxRetries must be a number' })
+      .int('maxRetries must be an integer between 0 and 10')
+      .min(0, 'maxRetries must be an integer between 0 and 10')
+      .max(10, 'maxRetries must be an integer between 0 and 10')
+      .optional(),
+    baseDelayMs: z
+      .number({ invalid_type_error: 'baseDelayMs must be a number' })
+      .int('baseDelayMs must be an integer between 100 and 60000')
+      .min(100, 'baseDelayMs must be an integer between 100 and 60000')
+      .max(60_000, 'baseDelayMs must be an integer between 100 and 60000')
+      .optional(),
+  })
+  .strict()
+  .refine((policy) => Object.keys(policy).length > 0, {
+    message: 'retryPolicy must include maxRetries or baseDelayMs when provided',
+  });
+
+export const registerWebhookSchema = z
+  .object({
+    developerId: webhookDeveloperIdSchema,
+    url: z
+      .string({
+        required_error: 'url is required',
+        invalid_type_error: 'url must be a string',
+      })
+      .trim()
+      .url('url must be a valid absolute URL')
+      .max(2_048, 'url must be 2048 characters or fewer'),
+    events: z
+      .array(z.enum(webhookManagementEvents), {
+        required_error: 'events is required',
+        invalid_type_error: 'events must be an array',
+      })
+      .min(1, 'events must include at least one event')
+      .max(webhookManagementEvents.length, `events can include at most ${webhookManagementEvents.length} items`)
+      .refine((events) => new Set(events).size === events.length, {
+        message: 'events must not contain duplicates',
+      }),
+    secret: z
+      .string({ invalid_type_error: 'secret must be a string' })
+      .trim()
+      .min(8, 'secret must be at least 8 characters')
+      .max(256, 'secret must be 256 characters or fewer')
+      .optional(),
+    retryPolicy: webhookRetryPolicySchema.optional(),
+  })
+  .strict();
+
+export const updateWebhookRetryPolicySchema = z
+  .object({
+    retryPolicy: webhookRetryPolicySchema.optional(),
+  })
+  .strict();
+
+export const webhookDeliveryPayloadSchema = z
+  .object({
+    event: z.enum(webhookDeliveryEvents),
+    timestamp: z.string().datetime('timestamp must be an ISO-8601 datetime'),
+    developerId: webhookDeveloperIdSchema,
+    data: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export type RegisterWebhookInput = z.infer<typeof registerWebhookSchema>;
+export type UpdateWebhookRetryPolicyInput = z.infer<typeof updateWebhookRetryPolicySchema>;
+export type WebhookDeveloperParamsInput = z.infer<typeof webhookDeveloperParamsSchema>;
+export type WebhookDeliveryPayloadInput = z.infer<typeof webhookDeliveryPayloadSchema>;

--- a/src/webhooks/webhook.routes.ts
+++ b/src/webhooks/webhook.routes.ts
@@ -15,6 +15,13 @@ import { config } from '../config/index.js';
 import { logger } from '../logger.js';
 import { validateRetryPolicy } from '../services/webhookRetry.js';
 import { createWebhookHealthRouter } from '../routes/webhooks/health.js';
+import { validate } from '../middleware/validate.js';
+import {
+  registerWebhookSchema,
+  updateWebhookRetryPolicySchema,
+  webhookDeliveryPayloadSchema,
+  webhookDeveloperParamsSchema,
+} from '../validators/webhooks.js';
 
 const router = Router();
 
@@ -40,38 +47,22 @@ const webhookMgmtRateLimit = createRestRateLimitMiddleware(config.webhookRateLim
 // the literal path segment "health" is not captured as a developerId.
 router.use('/health', createWebhookHealthRouter());
 
-const VALID_EVENTS: WebhookEventType[] = [
-  'new_api_call',
-  'settlement_completed',
-  'low_balance_alert',
-  'usage_event.created',
-];
-
 function generateWebhookSecret(): string {
   return crypto.randomBytes(32).toString('hex');
 }
 
+function requestId(req: Request): string {
+  return req.id || 'unknown';
+}
+
+function correlationId(req: Request): string {
+  return req.header('x-correlation-id') || requestId(req);
+}
+
 // POST /api/webhooks — Register a webhook
-router.post('/', webhookMgmtRateLimit, express.json(), async (req: Request, res: Response, next: NextFunction) => {
+router.post('/', webhookMgmtRateLimit, express.json(), validate({ body: registerWebhookSchema }), async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { developerId, url, events, secret, retryPolicy } = req.body;
-
-    if (!developerId || !url || !Array.isArray(events) || events.length === 0) {
-      throw new BadRequestError(
-        'developerId, url, and a non-empty events array are required.',
-        'INVALID_WEBHOOK_REGISTRATION'
-      );
-    }
-
-    const invalidEvents = events.filter(
-      (e: string) => !VALID_EVENTS.includes(e as WebhookEventType)
-    );
-    if (invalidEvents.length > 0) {
-      throw new BadRequestError(
-        `Invalid event types: ${invalidEvents.join(', ')}. Valid: ${VALID_EVENTS.join(', ')}`,
-        'INVALID_WEBHOOK_EVENT_TYPES'
-      );
-    }
+    const { developerId, url, events, secret, retryPolicy } = registerWebhookSchema.parse(req.body);
 
     const validation = validateRetryPolicy(retryPolicy);
     if (!validation.valid) {
@@ -100,6 +91,15 @@ router.post('/', webhookMgmtRateLimit, express.json(), async (req: Request, res:
       createdAt: new Date(),
     });
 
+    logger.info('[webhooks] webhook registered', {
+      requestId: requestId(req),
+      correlationId: correlationId(req),
+      developerId,
+      events,
+      hasSecret: Boolean(secret),
+      retryPolicyConfigured: Boolean(retryPolicy),
+    });
+
     res.status(201).json({
       message: 'Webhook registered successfully.',
       developerId,
@@ -112,7 +112,7 @@ router.post('/', webhookMgmtRateLimit, express.json(), async (req: Request, res:
 });
 
 // GET /api/webhooks/:developerId — Get webhook config
-router.get('/:developerId', webhookMgmtRateLimit, (req: Request, res: Response) => {
+router.get('/:developerId', webhookMgmtRateLimit, validate({ params: webhookDeveloperParamsSchema }), (req: Request, res: Response) => {
   const config = WebhookStore.get(req.params.developerId);
   if (!config) {
     throw new NotFoundError(
@@ -127,7 +127,7 @@ router.get('/:developerId', webhookMgmtRateLimit, (req: Request, res: Response) 
 });
 
 // POST /api/webhooks/:developerId/rotate-secret — Rotate webhook signing secret
-router.post('/:developerId/rotate-secret', webhookMgmtRateLimit, (req: Request, res: Response) => {
+router.post('/:developerId/rotate-secret', webhookMgmtRateLimit, validate({ params: webhookDeveloperParamsSchema }), (req: Request, res: Response) => {
   const existing = WebhookStore.get(req.params.developerId);
   if (!existing) {
     throw new NotFoundError(
@@ -149,6 +149,7 @@ router.post('/:developerId/rotate-secret', webhookMgmtRateLimit, (req: Request, 
 
   logger.audit('WEBHOOK_SECRET_ROTATED', req.params.developerId, {
     developerId: req.params.developerId,
+    correlationId: correlationId(req),
     previousExpiresAt: rotated.previous_expires_at?.toISOString(),
     hadPreviousSecret: Boolean(existing.secret_current ?? existing.secret),
   });
@@ -162,15 +163,20 @@ router.post('/:developerId/rotate-secret', webhookMgmtRateLimit, (req: Request, 
 });
 
 // DELETE /api/webhooks/:developerId — Remove webhook
-router.delete('/:developerId', webhookMgmtRateLimit, (req: Request, res: Response) => {
+router.delete('/:developerId', webhookMgmtRateLimit, validate({ params: webhookDeveloperParamsSchema }), (req: Request, res: Response) => {
   WebhookStore.delete(req.params.developerId);
+  logger.info('[webhooks] webhook removed', {
+    requestId: requestId(req),
+    correlationId: correlationId(req),
+    developerId: req.params.developerId,
+  });
   return res.json({ message: 'Webhook removed.' });
 });
 
 // PATCH /api/webhooks/:developerId/retry-policy — Update retry policy for subscription
-router.patch('/:developerId/retry-policy', webhookMgmtRateLimit, (req: Request, res: Response, next: NextFunction) => {
+router.patch('/:developerId/retry-policy', webhookMgmtRateLimit, express.json(), validate({ params: webhookDeveloperParamsSchema, body: updateWebhookRetryPolicySchema }), (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { retryPolicy } = req.body;
+    const { retryPolicy } = updateWebhookRetryPolicySchema.parse(req.body);
 
     const validation = validateRetryPolicy(retryPolicy);
     if (!validation.valid) {
@@ -194,6 +200,7 @@ router.patch('/:developerId/retry-policy', webhookMgmtRateLimit, (req: Request, 
 
     logger.audit('WEBHOOK_RETRY_POLICY_UPDATED', req.params.developerId, {
       developerId: req.params.developerId,
+      correlationId: correlationId(req),
       retryPolicy: updated.retryPolicy,
     });
 
@@ -224,6 +231,7 @@ router.patch('/:developerId/retry-policy', webhookMgmtRateLimit, (req: Request, 
  */
 router.post(
   '/deliver/:developerId',
+  validate({ params: webhookDeveloperParamsSchema }),
   captureRawBody,
   // Attach the stored secret so verifyWebhookSignature can read it
   (req: Request & { webhookSecrets?: string[] }, res: Response, next) => {
@@ -240,6 +248,7 @@ router.post(
   },
   verifyWebhookSignature,
   express.json(),
+  validate({ body: webhookDeliveryPayloadSchema }),
   (req: Request, res: Response) => {
     // Payload has been verified — safe to process
     return res.status(200).json({ message: 'Webhook delivery accepted.', body: req.body });


### PR DESCRIPTION
Closes #952

## Summary
- Adds strict Zod schemas for `/api/webhooks` registration, params, retry-policy updates, and signed delivery payloads.
- Adds `src/routes/webhooks.ts` as the route-facing wrapper for the webhook router.
- Applies boundary validation to webhook management routes with standardized structured `400` envelopes.
- Adds structured webhook registration/deletion logging and correlation IDs in webhook audit metadata.
- Documents validation behavior and retry-policy request shape in `docs/webhooks.md`.
- Fixes the error handler envelope helper reference so validation errors render correctly.

## Testing
- `jest src/validators/webhooks.test.ts src/routes/webhooks.test.ts --runInBand --forceExit --silent`
- Focused tests: 16 passed
- Coverage: `src/validators/webhooks.ts` 100%, `src/routes/webhooks.ts` 100%
- Touched-file lint passed
- Filtered typecheck showed no errors in touched files

