### PR TITLE
Add security header sweep for /api/audit

### DIFF
--- a/src/middleware/securityHeaders.test.ts
+++ b/src/middleware/securityHeaders.test.ts
@@ -1,0 +1,76 @@
+import type { Request, Response, NextFunction } from 'express';
+import { EventEmitter } from 'node:events';
+import {
+  securityHeaders,
+  AUDIT_CSP_POLICY,
+  AUDIT_X_CONTENT_TYPE_OPTIONS,
+  AUDIT_REFERRER_POLICY,
+} from './securityHeaders.js';
+
+describe('securityHeaders middleware', () => {
+  test('sets Content-Security-Policy header', () => {
+    const req = {} as Request;
+    const res = Object.assign(new EventEmitter(), {
+      setHeader: jest.fn(),
+    }) as unknown as Response & { setHeader: jest.Mock };
+    const next: NextFunction = jest.fn();
+
+    securityHeaders(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Security-Policy', AUDIT_CSP_POLICY);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('sets X-Content-Type-Options header', () => {
+    const req = {} as Request;
+    const res = Object.assign(new EventEmitter(), {
+      setHeader: jest.fn(),
+    }) as unknown as Response & { setHeader: jest.Mock };
+    const next: NextFunction = jest.fn();
+
+    securityHeaders(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', AUDIT_X_CONTENT_TYPE_OPTIONS);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('sets Referrer-Policy header', () => {
+    const req = {} as Request;
+    const res = Object.assign(new EventEmitter(), {
+      setHeader: jest.fn(),
+    }) as unknown as Response & { setHeader: jest.Mock };
+    const next: NextFunction = jest.fn();
+
+    securityHeaders(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Referrer-Policy', AUDIT_REFERRER_POLICY);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('sets all three security headers in a single invocation', () => {
+    const req = {} as Request;
+    const res = Object.assign(new EventEmitter(), {
+      setHeader: jest.fn(),
+    }) as unknown as Response & { setHeader: jest.Mock };
+    const next: NextFunction = jest.fn();
+
+    securityHeaders(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledTimes(3);
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Security-Policy', AUDIT_CSP_POLICY);
+    expect(res.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', AUDIT_X_CONTENT_TYPE_OPTIONS);
+    expect(res.setHeader).toHaveBeenCalledWith('Referrer-Policy', AUDIT_REFERRER_POLICY);
+  });
+
+  test('calls next to pass control to subsequent middleware', () => {
+    const req = {} as Request;
+    const res = Object.assign(new EventEmitter(), {
+      setHeader: jest.fn(),
+    }) as unknown as Response & { setHeader: jest.Mock };
+    const next: NextFunction = jest.fn();
+
+    securityHeaders(req, res, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+});

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export const AUDIT_CSP_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "object-src 'none'",
+  "frame-src 'none'",
+].join('; ');
+
+export const AUDIT_X_CONTENT_TYPE_OPTIONS = 'nosniff';
+export const AUDIT_REFERRER_POLICY = 'strict-origin-when-cross-origin';
+
+export function securityHeaders(req: Request, res: Response, next: NextFunction): void {
+  res.setHeader('Content-Security-Policy', AUDIT_CSP_POLICY);
+  res.setHeader('X-Content-Type-Options', AUDIT_X_CONTENT_TYPE_OPTIONS);
+  res.setHeader('Referrer-Policy', AUDIT_REFERRER_POLICY);
+  next();
+}

--- a/src/routes/admin/audit.test.ts
+++ b/src/routes/admin/audit.test.ts
@@ -404,3 +404,91 @@ describe('GET /api/admin/audit — ETag / 304 caching', () => {
     expect(res.headers.etag).toBeUndefined();
   });
 });
+
+describe('GET /api/admin/audit — security headers', () => {
+  it('sets Content-Security-Policy on audit responses', async () => {
+    const repo = new MockAuditLogRepository(() => ({
+      entries: [baseEntry()],
+      hasMore: false,
+    }));
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .get('/api/admin/audit')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-security-policy']).toBeDefined();
+    expect(res.headers['content-security-policy']).toContain("default-src 'self'");
+    expect(res.headers['content-security-policy']).toContain("script-src 'self'");
+    expect(res.headers['content-security-policy']).toContain("object-src 'none'");
+    expect(res.headers['content-security-policy']).toContain("frame-src 'none'");
+  });
+
+  it('sets X-Content-Type-Options: nosniff on audit responses', async () => {
+    const repo = new MockAuditLogRepository(() => ({
+      entries: [baseEntry()],
+      hasMore: false,
+    }));
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .get('/api/admin/audit')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets Referrer-Policy on audit responses', async () => {
+    const repo = new MockAuditLogRepository(() => ({
+      entries: [baseEntry()],
+      hasMore: false,
+    }));
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .get('/api/admin/audit')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  });
+
+  it('applies security headers even on error responses from the audit route', async () => {
+    const repo = new MockAuditLogRepository(() => {
+      throw new Error('unexpected');
+    });
+    const app = buildApp(repo);
+
+    const res = await request(app)
+      .get('/api/admin/audit')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    // Should return a 500 but still have security headers
+    expect(res.status).toBe(500);
+    expect(res.headers['content-security-policy']).toBeDefined();
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  });
+
+  it('applies security headers on the replay sub-route', async () => {
+    const repo = new MockAuditLogRepository(() => ({
+      entries: [baseEntry()],
+      hasMore: false,
+    }));
+    const app = buildApp(repo);
+
+    // Authenticated request to replay with an empty body — should reach the
+    // router and get a 400 validation error, but security headers are set
+    const res = await request(app)
+      .post('/api/admin/audit/replay')
+      .set('x-admin-api-key', ADMIN_KEY)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.headers['content-security-policy']).toBeDefined();
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  });
+});

--- a/src/routes/admin/audit.ts
+++ b/src/routes/admin/audit.ts
@@ -5,6 +5,7 @@ import { cursorPaginatedResponse } from '../../lib/pagination.js';
 import { AppError, InternalServerError } from '../../errors/index.js';
 import { validate, ValidationError } from '../../middleware/validate.js';
 import { etagMiddleware } from '../../middleware/etag.js';
+import { securityHeaders } from '../../middleware/securityHeaders.js';
 import { logger } from '../../logger.js';
 import { PgAuditLogRepository, type AuditLogRepository } from '../../repositories/auditLogRepository.js';
 import { auditQuerySchema } from '../../validators/audit.js';
@@ -20,6 +21,7 @@ export function createAdminAuditRouter(deps: AdminAuditRouterDeps = {}): Router 
   const router = Router();
   const auditLogRepository = deps.auditLogRepository ?? new PgAuditLogRepository();
 
+  router.use(securityHeaders);
   router.use('/replay', createAdminAuditReplayRouter(deps));
 
   router.get(


### PR DESCRIPTION
## Summary

Set/verify CSP, X-Content-Type-Options, Referrer-Policy on /api/audit responses with a dedicated route-level middleware for defense-in-depth.

## Changes

- **src/middleware/securityHeaders.ts** (new): Middleware that sets `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` on every response from the audit route
- **src/routes/admin/audit.ts**: Wired `securityHeaders` via `router.use` so all sub-routes (including `/replay`) inherit the headers
- **src/middleware/securityHeaders.test.ts** (new): 5 unit tests covering each header individually, all three together, and `next()` delegation
- **src/routes/admin/audit.test.ts**: 5 integration tests verifying headers on success responses, error responses, and the replay sub-route

## Testing

```
PASS src/middleware/securityHeaders.test.ts (5/5)
PASS src/routes/admin/audit.test.ts (20/20, 5 new + 15 existing)
```

Closes #905