### PR TITLE
feat: usage aggregate by hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The migration is in `migrations/0019_disputes.sql` (rollback: `migrations/0019_d
   - `POST /api/apis` for authenticated developers to register an API with priced endpoints
 - Usage route: `GET /api/usage`
 - Top-N endpoints per developer: `GET /api/usage/by-endpoint` — returns the authenticated developer's most-called endpoints ranked by call volume, filterable by `from`/`to`/`apiId`/`limit` (see [docs/usage-by-endpoint.md](./docs/usage-by-endpoint.md))
+- Hourly usage aggregation: `GET /api/usage/aggregate` — returns per-hour call counts and revenue for the authenticated developer, optionally filtered by `from`/`to`/`apiId`; defaults to the last 24 hours when dates are omitted (see [docs/usage-aggregate.md](./docs/usage-aggregate.md))
 - Live usage stream: `GET /api/usage/sse` for authenticated developer dashboards
 - Admin usage anomalies: `GET /api/admin/usage/anomalies` returns per-API daily usage anomalies (z-score spikes/drops) for admin review, filterable by `from`/`to`/`apiId`/`threshold`/`limit` (admin auth + IP allowlist)
 - Admin usage export: `GET /api/admin/usage/export` streams usage events as CSV or JSON for reporting, with optional `from`/`to`/`developerId`/`apiId`/`format` filters (admin auth + IP allowlist); see [docs/admin-usage-export.md](./docs/admin-usage-export.md)

--- a/docs/usage-aggregate.md
+++ b/docs/usage-aggregate.md
@@ -1,0 +1,120 @@
+# Hourly Usage Aggregation — `GET /api/usage/aggregate`
+
+Returns per-hour call counts and revenue for the authenticated developer, optionally scoped to a single API. Buckets are ordered chronologically (ascending). This endpoint is suited for building time-series charts on developer dashboards.
+
+## Authentication
+
+Requires a valid developer session. Pass either:
+
+- `Authorization: Bearer <jwt>` — standard JWT issued by `POST /api/auth/login`
+- `x-user-id: <userId>` — development/test bypass (non-production only)
+
+Returns `401 Unauthorized` if no valid credentials are provided.
+
+## Request
+
+```
+GET /api/usage/aggregate
+```
+
+### Query Parameters
+
+| Parameter | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `from`    | string | No       | ISO 8601 datetime (inclusive). Defaults to 24 hours before `to`. |
+| `to`      | string | No       | ISO 8601 datetime (inclusive). Defaults to the current UTC time. |
+| `apiId`   | string | No       | Restrict results to a single registered API. |
+
+- When both `from` and `to` are omitted the endpoint defaults to the **last 24 hours**.
+- `from` must be ≤ `to`; supplying a reversed range returns `400 Bad Request`.
+- Invalid date strings return `400 Bad Request`.
+
+## Response
+
+HTTP `200 OK`:
+
+```json
+{
+  "data": [
+    {
+      "hour": "2026-07-28T09:00:00.000Z",
+      "calls": 17,
+      "revenue": "170000"
+    },
+    {
+      "hour": "2026-07-28T10:00:00.000Z",
+      "calls": 42,
+      "revenue": "420000"
+    }
+  ],
+  "totals": {
+    "totalCalls": 59,
+    "totalRevenue": "590000"
+  },
+  "period": {
+    "from": "2026-07-28T09:00:00.000Z",
+    "to": "2026-07-28T10:59:59.000Z"
+  }
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | array | Hourly buckets, sorted ascending by `hour`. Empty when no events match. |
+| `data[].hour` | string | ISO 8601 UTC datetime truncated to the hour boundary (e.g. `"2026-07-28T10:00:00.000Z"`). |
+| `data[].calls` | integer | Number of API calls in this hour. |
+| `data[].revenue` | string | Aggregated revenue (smallest USDC units) as a decimal string. Returned as a string to avoid JavaScript `Number` precision loss on large values. |
+| `totals.totalCalls` | integer | Sum of `calls` across all buckets. |
+| `totals.totalRevenue` | string | Sum of `revenue` across all buckets, as a decimal string. |
+| `period.from` | string | Effective start of the query window (ISO 8601). |
+| `period.to` | string | Effective end of the query window (ISO 8601). |
+
+Hours with no calls are **not** included in `data`; only non-zero buckets are returned.
+
+## Error Responses
+
+All errors use the standard error envelope:
+
+```json
+{
+  "code": "BAD_REQUEST",
+  "message": "...",
+  "requestId": "req_..."
+}
+```
+
+| HTTP Status | `code` | Cause |
+|-------------|--------|-------|
+| `400` | `BAD_REQUEST` | `from` or `to` is not a valid ISO 8601 date. |
+| `400` | `BAD_REQUEST` | `from` is after `to`. |
+| `401` | `UNAUTHORIZED` | Missing or invalid authentication credentials. |
+| `500` | `INTERNAL_SERVER_ERROR` | Unexpected server-side error. |
+
+## Examples
+
+### Last 24 hours (default window)
+
+```
+GET /api/usage/aggregate
+Authorization: Bearer eyJ...
+```
+
+### Specific date range
+
+```
+GET /api/usage/aggregate?from=2026-07-01T00:00:00Z&to=2026-07-01T23:59:59Z
+```
+
+### Filtered by API
+
+```
+GET /api/usage/aggregate?from=2026-07-28T00:00:00Z&to=2026-07-28T23:59:59Z&apiId=api_abc123
+```
+
+## Implementation Notes
+
+- The PostgreSQL backend uses `DATE_TRUNC('hour', created_at AT TIME ZONE 'UTC')` so hour boundaries are always in UTC regardless of server timezone.
+- Revenue values are stored and returned as smallest-unit `bigint`-compatible strings (no decimal point) to avoid floating-point drift.
+- Results are scoped strictly to the authenticated user's own events; events belonging to other developers are never returned.

--- a/src/repositories/usageEventsRepository.pg.ts
+++ b/src/repositories/usageEventsRepository.pg.ts
@@ -760,4 +760,59 @@ export class PgUsageEventsRepository implements UsageEventsPgRepository {
       revenue: toBigInt(row.revenue, 'revenue'),
     }));
   }
+
+  /**
+   * Returns per-hour aggregation of call counts and revenue for a user.
+   *
+   * Uses `DATE_TRUNC('hour', created_at)` so the grouping is done entirely in
+   * PostgreSQL. Buckets are returned in ascending chronological order.
+   *
+   * The hour label is returned as an ISO 8601 string (UTC) to match the shape
+   * produced by InMemoryUsageEventsRepository.
+   */
+  async aggregateByHour(query: {
+    userId: string;
+    from: Date;
+    to: Date;
+    apiId?: string;
+  }): Promise<{
+    buckets: import('./usageEventsRepository.js').UsageHourBucket[];
+    totalCalls: number;
+    totalRevenue: bigint;
+  }> {
+    assertValidRange(query.from, query.to);
+
+    const params: unknown[] = [assertNonEmpty(query.userId, 'userId')];
+    const clauses: string[] = ['user_id = $1'];
+    appendDateFilters(params, clauses, query.from, query.to);
+
+    if (query.apiId) {
+      params.push(query.apiId);
+      clauses.push(`api_id = $${params.length}`);
+    }
+
+    const sql = `
+      SELECT
+        TO_CHAR(DATE_TRUNC('hour', created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD"T"HH24":00:00.000Z"') AS hour,
+        COUNT(*)::int                                                                                  AS calls,
+        COALESCE(SUM(amount_usdc), 0)::text                                                           AS revenue
+      FROM usage_events
+      WHERE ${clauses.join(' AND ')}
+      GROUP BY DATE_TRUNC('hour', created_at AT TIME ZONE 'UTC')
+      ORDER BY 1 ASC
+    `;
+
+    const result = await this.readDb.query<{ hour: string; calls: number; revenue: string }>(sql, params);
+
+    let totalCalls = 0;
+    let totalRevenue = 0n;
+    const buckets = result.rows.map((row) => {
+      const revenue = toBigInt(row.revenue, 'revenue');
+      totalCalls += row.calls;
+      totalRevenue += revenue;
+      return { hour: row.hour, calls: row.calls, revenue };
+    });
+
+    return { buckets, totalCalls, totalRevenue };
+  }
 } 

--- a/src/repositories/usageEventsRepository.ts
+++ b/src/repositories/usageEventsRepository.ts
@@ -1,4 +1,4 @@
-export type GroupBy = 'day' | 'week' | 'month';
+export type GroupBy = 'hour' | 'day' | 'week' | 'month';
 
 export interface UsageEvent {
   id: string;
@@ -39,6 +39,13 @@ export interface UsageBucket {
   revenue: bigint;
 }
 
+export interface UsageHourBucket {
+  /** ISO 8601 datetime truncated to the hour, e.g. "2026-07-28T10:00:00.000Z" */
+  hour: string;
+  calls: number;
+  revenue: bigint;
+}
+
 export interface UsageEventsRepository {
   findByDeveloper(query: UsageEventQuery): Promise<UsageEvent[]>;
   findByUser(query: UserUsageEventQuery): Promise<UsageEvent[]>;
@@ -49,6 +56,20 @@ export interface UsageEventsRepository {
     totalCalls: number;
     breakdownByApi: UsageStats[];
     buckets?: UsageBucket[];
+  }>;
+  /**
+   * Returns per-hour call counts and revenue for the authenticated user
+   * within [from, to]. Buckets are sorted ascending by hour.
+   */
+  aggregateByHour(query: {
+    userId: string;
+    from: Date;
+    to: Date;
+    apiId?: string;
+  }): Promise<{
+    buckets: UsageHourBucket[];
+    totalCalls: number;
+    totalRevenue: bigint;
   }>;
   getTopEndpoints(query: {
     userId: string;
@@ -205,6 +226,40 @@ export class InMemoryUsageEventsRepository implements UsageEventsRepository {
     };
   }
 
+  async aggregateByHour(query: {
+    userId: string;
+    from: Date;
+    to: Date;
+    apiId?: string;
+  }): Promise<{
+    buckets: UsageHourBucket[];
+    totalCalls: number;
+    totalRevenue: bigint;
+  }> {
+    const bucketMap = new Map<string, { calls: number; revenue: bigint }>();
+    let totalCalls = 0;
+    let totalRevenue = 0n;
+
+    for (const event of this.events) {
+      if (event.userId !== query.userId) continue;
+      if (query.apiId && event.apiId !== query.apiId) continue;
+      if (event.occurredAt < query.from || event.occurredAt > query.to) continue;
+
+      totalCalls += 1;
+      totalRevenue += event.revenue;
+
+      const hour = this.getPeriodString(event.occurredAt, 'hour');
+      const bucket = bucketMap.get(hour) ?? { calls: 0, revenue: 0n };
+      bucketMap.set(hour, { calls: bucket.calls + 1, revenue: bucket.revenue + event.revenue });
+    }
+
+    const buckets: UsageHourBucket[] = [...bucketMap.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([hour, stats]) => ({ hour, calls: stats.calls, revenue: stats.revenue }));
+
+    return { buckets, totalCalls, totalRevenue };
+  }
+
   async getTopEndpoints(query: {
     userId: string;
     from: Date;
@@ -248,6 +303,9 @@ export class InMemoryUsageEventsRepository implements UsageEventsRepository {
 
   private getPeriodString(date: Date, groupBy: GroupBy): string {
     const d = new Date(date);
+    if (groupBy === 'hour') {
+      return d.toISOString().slice(0, 13) + ':00:00.000Z';
+    }
     if (groupBy === 'day') {
       return d.toISOString().slice(0, 10);
     }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -15,6 +15,7 @@ import { createLimitsRouter } from "./limits.js";
 import { InMemoryRestRateLimiter } from "../middleware/restRateLimit.js";
 import { createUsageCsvRouter } from "./usage/csv.js";
 import { createUsageByEndpointRouter } from "./usage/byEndpoint.js";
+import { createUsageAggregateRouter } from "./usage/aggregate.js";
 import { createExportSchedulesRouter } from "./exports/schedules.js";
 import { createExportsRouter } from "./exports.js";
 import type { ScheduledExportsService } from "../services/scheduledExports.js";
@@ -69,6 +70,13 @@ export function createApiRouter(deps: ApiRouterDeps = {}): Router {
   router.use(
     "/usage/by-endpoint",
     createUsageByEndpointRouter({
+      usageEventsRepository: deps.usageEventsRepository!,
+    }),
+  );
+
+  router.use(
+    "/usage/aggregate",
+    createUsageAggregateRouter({
       usageEventsRepository: deps.usageEventsRepository!,
     }),
   );

--- a/src/routes/usage/aggregate.test.ts
+++ b/src/routes/usage/aggregate.test.ts
@@ -1,0 +1,335 @@
+import express from 'express';
+import request from 'supertest';
+import { createUsageAggregateRouter } from './aggregate.js';
+import {
+  InMemoryUsageEventsRepository,
+  type UsageEvent,
+} from '../../repositories/usageEventsRepository.js';
+import { errorHandler } from '../../middleware/errorHandler.js';
+import { requestIdMiddleware } from '../../middleware/requestId.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const USER_ID = 'user-1';
+const OTHER_USER = 'user-2';
+
+let nextId = 1;
+const makeEvent = (overrides: Partial<UsageEvent> = {}): UsageEvent => ({
+  id: `evt-${nextId++}`,
+  developerId: USER_ID,
+  apiId: 'api-1',
+  endpoint: '/v1/resource',
+  userId: USER_ID,
+  occurredAt: new Date('2026-07-28T10:30:00.000Z'),
+  revenue: 1000n,
+  ...overrides,
+});
+
+function createTestApp(repo: InMemoryUsageEventsRepository): express.Express {
+  const app = express();
+  app.use(requestIdMiddleware);
+  app.use('/api/usage/aggregate', createUsageAggregateRouter({ usageEventsRepository: repo }));
+  app.use(errorHandler);
+  return app;
+}
+
+const auth = (req: request.Test): request.Test => req.set('x-user-id', USER_ID);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/usage/aggregate', () => {
+  beforeEach(() => { nextId = 1; });
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  it('requires authentication – returns 401 without credentials', async () => {
+    const app = createTestApp(new InMemoryUsageEventsRepository([]));
+    const res = await request(app).get('/api/usage/aggregate');
+    expect(res.status).toBe(401);
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path: basic aggregation
+  // -------------------------------------------------------------------------
+
+  it('returns hourly buckets for the authenticated user', async () => {
+    const repo = new InMemoryUsageEventsRepository([
+      makeEvent({ occurredAt: new Date('2026-07-28T10:05:00.000Z'), revenue: 500n }),
+      makeEvent({ occurredAt: new Date('2026-07-28T10:45:00.000Z'), revenue: 1500n }),
+      makeEvent({ occurredAt: new Date('2026-07-28T11:20:00.000Z'), revenue: 2000n }),
+    ]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-28T00:00:00.000Z',
+        to: '2026-07-29T00:00:00.000Z',
+      })
+    );
+
+    expect(res.status).toBe(200);
+
+    // Two distinct hours
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0]).toEqual({
+      hour: '2026-07-28T10:00:00.000Z',
+      calls: 2,
+      revenue: '2000',
+    });
+    expect(res.body.data[1]).toEqual({
+      hour: '2026-07-28T11:00:00.000Z',
+      calls: 1,
+      revenue: '2000',
+    });
+
+    // Totals
+    expect(res.body.totals).toEqual({ totalCalls: 3, totalRevenue: '4000' });
+
+    // Period echoed back
+    expect(res.body.period.from).toBe('2026-07-28T00:00:00.000Z');
+    expect(res.body.period.to).toBe('2026-07-29T00:00:00.000Z');
+  });
+
+  it('returns an empty data array when there are no events in the window', async () => {
+    const repo = new InMemoryUsageEventsRepository([
+      makeEvent({ occurredAt: new Date('2026-07-20T10:00:00.000Z') }),
+    ]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-28T00:00:00.000Z',
+        to: '2026-07-28T23:59:59.000Z',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.totals).toEqual({ totalCalls: 0, totalRevenue: '0' });
+  });
+
+  // -------------------------------------------------------------------------
+  // Data isolation
+  // -------------------------------------------------------------------------
+
+  it("does not expose another user's data", async () => {
+    const repo = new InMemoryUsageEventsRepository([
+      makeEvent({ userId: OTHER_USER, developerId: OTHER_USER }),
+      makeEvent({ userId: USER_ID, revenue: 999n }),
+    ]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-07-31T00:00:00.000Z',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.totals.totalCalls).toBe(1);
+    expect(res.body.totals.totalRevenue).toBe('999');
+  });
+
+  // -------------------------------------------------------------------------
+  // apiId filter
+  // -------------------------------------------------------------------------
+
+  it('filters by apiId when supplied', async () => {
+    const repo = new InMemoryUsageEventsRepository([
+      makeEvent({ apiId: 'api-1', revenue: 100n }),
+      makeEvent({ apiId: 'api-2', revenue: 200n }),
+      makeEvent({ apiId: 'api-1', revenue: 300n }),
+    ]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-07-31T00:00:00.000Z',
+        apiId: 'api-1',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.totals.totalCalls).toBe(2);
+    expect(res.body.totals.totalRevenue).toBe('400');
+  });
+
+  // -------------------------------------------------------------------------
+  // Default time window (no from/to)
+  // -------------------------------------------------------------------------
+
+  it('defaults to the last 24 hours when from and to are omitted', async () => {
+    const now = new Date();
+    const recent = new Date(now.getTime() - 30 * 60 * 1000); // 30 min ago
+    const old = new Date(now.getTime() - 48 * 60 * 60 * 1000); // 48 h ago (out of window)
+
+    const repo = new InMemoryUsageEventsRepository([
+      makeEvent({ occurredAt: recent }),
+      makeEvent({ occurredAt: old }),
+    ]);
+    const app = createTestApp(repo);
+
+    const res = await auth(request(app).get('/api/usage/aggregate'));
+
+    expect(res.status).toBe(200);
+    // Only the recent event falls within the default 24-h window
+    expect(res.body.totals.totalCalls).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Input validation
+  // -------------------------------------------------------------------------
+
+  it('returns 400 for an invalid "from" date', async () => {
+    const app = createTestApp(new InMemoryUsageEventsRepository([]));
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({ from: 'not-a-date' })
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toMatch(/from/);
+  });
+
+  it('returns 400 for an invalid "to" date', async () => {
+    const app = createTestApp(new InMemoryUsageEventsRepository([]));
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({ to: 'not-a-date' })
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toMatch(/to/);
+  });
+
+  it('returns 400 when "from" is after "to"', async () => {
+    const app = createTestApp(new InMemoryUsageEventsRepository([]));
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-29T00:00:00.000Z',
+        to: '2026-07-28T00:00:00.000Z',
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toMatch(/from.*to|to.*from/i);
+  });
+
+  it('accepts equal "from" and "to" timestamps', async () => {
+    const ts = '2026-07-28T10:00:00.000Z';
+    const repo = new InMemoryUsageEventsRepository([]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({ from: ts, to: ts })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Bucket ordering
+  // -------------------------------------------------------------------------
+
+  it('returns buckets in ascending chronological order', async () => {
+    // Insert events out of order
+    const repo = new InMemoryUsageEventsRepository([
+      makeEvent({ occurredAt: new Date('2026-07-28T15:00:00.000Z') }),
+      makeEvent({ occurredAt: new Date('2026-07-28T09:00:00.000Z') }),
+      makeEvent({ occurredAt: new Date('2026-07-28T12:00:00.000Z') }),
+    ]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-28T00:00:00.000Z',
+        to: '2026-07-29T00:00:00.000Z',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const hours = res.body.data.map((b: { hour: string }) => b.hour);
+    expect(hours).toEqual([...hours].sort());
+  });
+
+  // -------------------------------------------------------------------------
+  // Revenue serialisation (bigint → string)
+  // -------------------------------------------------------------------------
+
+  it('serialises large revenue values as strings', async () => {
+    const repo = new InMemoryUsageEventsRepository([
+      makeEvent({ revenue: BigInt('9007199254740992') }), // > Number.MAX_SAFE_INTEGER
+    ]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-07-31T00:00:00.000Z',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.totals.totalRevenue).toBe('string');
+    expect(res.body.totals.totalRevenue).toBe('9007199254740992');
+  });
+
+  // -------------------------------------------------------------------------
+  // Response shape contract
+  // -------------------------------------------------------------------------
+
+  it('always includes data, totals, and period in the response', async () => {
+    const repo = new InMemoryUsageEventsRepository([]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-28T00:00:00.000Z',
+        to: '2026-07-28T23:59:59.000Z',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('data');
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body).toHaveProperty('totals');
+    expect(res.body.totals).toHaveProperty('totalCalls');
+    expect(res.body.totals).toHaveProperty('totalRevenue');
+    expect(res.body).toHaveProperty('period');
+    expect(res.body.period).toHaveProperty('from');
+    expect(res.body.period).toHaveProperty('to');
+  });
+
+  it('each bucket has the expected shape', async () => {
+    const repo = new InMemoryUsageEventsRepository([
+      makeEvent({ occurredAt: new Date('2026-07-28T14:05:00.000Z'), revenue: 250n }),
+    ]);
+    const app = createTestApp(repo);
+
+    const res = await auth(
+      request(app).get('/api/usage/aggregate').query({
+        from: '2026-07-28T00:00:00.000Z',
+        to: '2026-07-28T23:59:59.000Z',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    const bucket = res.body.data[0];
+    expect(typeof bucket.hour).toBe('string');
+    expect(typeof bucket.calls).toBe('number');
+    expect(typeof bucket.revenue).toBe('string');
+    // Hour must be truncated to the hour boundary
+    expect(bucket.hour).toBe('2026-07-28T14:00:00.000Z');
+  });
+});

--- a/src/routes/usage/aggregate.ts
+++ b/src/routes/usage/aggregate.ts
@@ -1,0 +1,147 @@
+/**
+ * GET /api/usage/aggregate
+ *
+ * Returns hourly time-bucketed aggregation of API calls and revenue for the
+ * authenticated developer.
+ *
+ * Query parameters:
+ *   from    – ISO 8601 datetime (inclusive). Defaults to 24 hours ago.
+ *   to      – ISO 8601 datetime (inclusive). Defaults to now.
+ *   apiId   – Optional. Restrict results to a single API.
+ *
+ * Response shape:
+ * {
+ *   "data": [
+ *     { "hour": "2026-07-28T10:00:00.000Z", "calls": 42, "revenue": "420000" },
+ *     ...
+ *   ],
+ *   "totals": { "totalCalls": 42, "totalRevenue": "420000" },
+ *   "period": { "from": "...", "to": "..." }
+ * }
+ */
+
+import { Router, type Response } from 'express';
+import { requireAuth, type AuthenticatedLocals } from '../../middleware/requireAuth.js';
+import type { UsageEventsRepository } from '../../repositories/usageEventsRepository.js';
+import { BadRequestError, InternalServerError, UnauthorizedError } from '../../errors/index.js';
+import { logger } from '../../logger.js';
+
+export interface UsageAggregateRouterDeps {
+  usageEventsRepository: UsageEventsRepository;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an ISO 8601 date string from a query parameter.
+ * Returns:
+ *   - `undefined`  if the value was not provided
+ *   - `null`       if the value is present but cannot be parsed as a valid date
+ *   - `Date`       if parsing succeeded
+ */
+const parseDateParam = (value: unknown): Date | null | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export function createUsageAggregateRouter(deps: UsageAggregateRouterDeps): Router {
+  const router = Router();
+  const { usageEventsRepository } = deps;
+
+  router.get('/', requireAuth, async (req, res: Response<unknown, AuthenticatedLocals>, next) => {
+    const user = res.locals.authenticatedUser;
+    if (!user) {
+      next(new UnauthorizedError());
+      return;
+    }
+
+    // --- Input validation ---
+
+    const from = parseDateParam(req.query.from);
+    if (from === null) {
+      next(new BadRequestError('Invalid "from" date. Expected an ISO 8601 datetime string.'));
+      return;
+    }
+
+    const to = parseDateParam(req.query.to);
+    if (to === null) {
+      next(new BadRequestError('Invalid "to" date. Expected an ISO 8601 datetime string.'));
+      return;
+    }
+
+    if (req.query.apiId !== undefined && typeof req.query.apiId !== 'string') {
+      next(new BadRequestError('apiId must be a single string value'));
+      return;
+    }
+    const apiId =
+      typeof req.query.apiId === 'string' && req.query.apiId.length > 0
+        ? req.query.apiId
+        : undefined;
+
+    // --- Default time window: last 24 hours ---
+
+    const now = new Date();
+    const queryTo = to ?? now;
+    const queryFrom = from ?? new Date(queryTo.getTime() - 24 * 60 * 60 * 1000);
+
+    if (queryFrom > queryTo) {
+      next(new BadRequestError('"from" must be before or equal to "to"'));
+      return;
+    }
+
+    // --- Fetch and format ---
+
+    try {
+      const { buckets, totalCalls, totalRevenue } =
+        await usageEventsRepository.aggregateByHour({
+          userId: user.id,
+          from: queryFrom,
+          to: queryTo,
+          apiId,
+        });
+
+      logger.info('[usage.aggregate] retrieved hourly aggregation', {
+        userId: user.id,
+        apiId,
+        from: queryFrom.toISOString(),
+        to: queryTo.toISOString(),
+        bucketCount: buckets.length,
+        totalCalls,
+      });
+
+      res.json({
+        data: buckets.map((b) => ({
+          hour: b.hour,
+          calls: b.calls,
+          revenue: b.revenue.toString(),
+        })),
+        totals: {
+          totalCalls,
+          totalRevenue: totalRevenue.toString(),
+        },
+        period: {
+          from: queryFrom.toISOString(),
+          to: queryTo.toISOString(),
+        },
+      });
+    } catch (error) {
+      logger.error('[usage.aggregate] failed to retrieve hourly aggregation', {
+        userId: user.id,
+        error,
+      });
+      next(new InternalServerError());
+    }
+  });
+
+  return router;
+}
+
+export default createUsageAggregateRouter;


### PR DESCRIPTION
Implement GET /api/usage/aggregate — returns per-hour call counts and revenue for the authenticated developer, optionally filtered by from/to/apiId. Defaults to the last 24 hours when no dates are supplied.

Changes:
- src/routes/usage/aggregate.ts         new route handler
- src/routes/usage/aggregate.test.ts    14 focused tests (all passing)
- src/routes/index.ts                   mount /usage/aggregate
- src/repositories/usageEventsRepository.ts
    add UsageHourBucket type, aggregateByHour to interface + InMemory impl
    extend GroupBy union with 'hour'
- src/repositories/usageEventsRepository.pg.ts
    PgUsageEventsRepository.aggregateByHour using DATE_TRUNC('hour')
- docs/usage-aggregate.md               full API reference
- README.md                             add endpoint to What's included

Closes #602