### PR TITLE
Feat/930 refresh token rate limit

### DIFF
--- a/src/routes/refresh-token.test.ts
+++ b/src/routes/refresh-token.test.ts
@@ -182,11 +182,22 @@ class MockRefreshTokenRepository implements RefreshTokenRepository {
   }
 }
 
-function buildApp(repository: RefreshTokenRepository) {
+import { TokenBucketRateLimiter } from '../middleware/rateLimit.js';
+
+function buildApp(
+  repository: RefreshTokenRepository,
+  rateLimiter?: TokenBucketRateLimiter,
+) {
   const app = express();
   app.use(requestIdMiddleware);
   app.use(express.json());
-  app.use('/api/refresh-token', createRefreshTokenRouter({ refreshTokenRepository: repository }));
+  app.use(
+    '/api/refresh-token',
+    createRefreshTokenRouter({
+      refreshTokenRepository: repository,
+      rateLimiter,
+    }),
+  );
   app.use(errorHandler);
   return app;
 }
@@ -454,5 +465,116 @@ describe('GET /api/refresh-token', () => {
         hasMore: false,
       }),
     );
+  });
+
+  describe('Token-Bucket Rate Limiting (issue #930)', () => {
+    it('allows requests within capacity and rejects with HTTP 429 when capacity is exceeded', async () => {
+      const repo = new MockRefreshTokenRepository([makeToken()]);
+      // Limiter with capacity 2, refill rate 1 token/sec
+      const limiter = new TokenBucketRateLimiter(2, 1);
+      const app = buildApp(repo, limiter);
+
+      // First 2 requests succeed (capacity: 2)
+      const res1 = await request(app).get('/api/refresh-token').set(authHeader);
+      expect(res1.status).toBe(200);
+
+      const res2 = await request(app).get('/api/refresh-token').set(authHeader);
+      expect(res2.status).toBe(200);
+
+      // 3rd request exceeds capacity
+      const res3 = await request(app).get('/api/refresh-token').set(authHeader);
+      expect(res3.status).toBe(429);
+      expect(res3.body).toEqual(
+        expect.objectContaining({
+          code: 'TOO_MANY_REQUESTS',
+          message: 'Too Many Requests',
+        }),
+      );
+      expect(res3.body).toHaveProperty('requestId');
+      expect(res3.body).toHaveProperty('retryAfterMs');
+    });
+
+    it('returns Retry-After header in whole seconds reflecting refill time', async () => {
+      const repo = new MockRefreshTokenRepository([]);
+      // Capacity 1, refill rate 0.5 (takes 2 seconds to refill 1 token)
+      const limiter = new TokenBucketRateLimiter(1, 0.5);
+      const app = buildApp(repo, limiter);
+
+      const res1 = await request(app).get('/api/refresh-token').set(authHeader);
+      expect(res1.status).toBe(200);
+
+      const res2 = await request(app).get('/api/refresh-token').set(authHeader);
+      expect(res2.status).toBe(429);
+
+      // Retry-After header must be present and formatted as whole seconds string
+      const retryAfterHeader = res2.headers['retry-after'];
+      expect(retryAfterHeader).toBeDefined();
+      expect(/^\d+$/.test(retryAfterHeader)).toBe(true);
+      const seconds = parseInt(retryAfterHeader, 10);
+      expect(seconds).toBeGreaterThanOrEqual(1);
+    });
+
+    it('enforces rate limit per-user in isolation', async () => {
+      const repo = new MockRefreshTokenRepository([
+        makeToken({ userId: 'user-A' }),
+        makeToken({ userId: 'user-B' }),
+      ]);
+      const limiter = new TokenBucketRateLimiter(1, 1);
+      const app = buildApp(repo, limiter);
+
+      // User A consumes their token
+      const resA1 = await request(app).get('/api/refresh-token').set('x-user-id', 'user-A');
+      expect(resA1.status).toBe(200);
+
+      const resA2 = await request(app).get('/api/refresh-token').set('x-user-id', 'user-A');
+      expect(resA2.status).toBe(429);
+
+      // User B should NOT be blocked by User A's rate limit
+      const resB1 = await request(app).get('/api/refresh-token').set('x-user-id', 'user-B');
+      expect(resB1.status).toBe(200);
+    });
+
+    it('falls back to client IP for rate limiting key when no user auth is present', async () => {
+      const repo = new MockRefreshTokenRepository([]);
+      const limiter = new TokenBucketRateLimiter(1, 1);
+      const app = buildApp(repo, limiter);
+
+      // First unauthenticated request consumes IP bucket, proceeds to auth middleware and returns 401
+      const res1 = await request(app).get('/api/refresh-token');
+      expect(res1.status).toBe(401);
+
+      // Second request from same IP exceeds bucket capacity and returns 429
+      const res2 = await request(app).get('/api/refresh-token');
+      expect(res2.status).toBe(429);
+      expect(res2.headers['retry-after']).toBeDefined();
+    });
+
+    it('logs structured warning with correlation ID when rate limit is exceeded', async () => {
+      const repo = new MockRefreshTokenRepository([]);
+      const limiter = new TokenBucketRateLimiter(1, 1);
+      const app = buildApp(repo, limiter);
+
+      await request(app).get('/api/refresh-token').set(authHeader).set('x-request-id', 'req-corr-999');
+      await request(app).get('/api/refresh-token').set(authHeader).set('x-request-id', 'req-corr-999');
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[tokenBucketRateLimit] request limit exceeded',
+        expect.objectContaining({
+          key: `user:${USER_ID}`,
+          requestId: 'req-corr-999',
+        }),
+      );
+    });
+
+    it('returns 500 InternalServerError when repository listRefreshTokens throws unexpected error', async () => {
+      const repo = new MockRefreshTokenRepository([]);
+      jest.spyOn(repo, 'listRefreshTokens').mockRejectedValue(new Error('DB Connection Failed'));
+      const app = buildApp(repo);
+
+      const res = await request(app).get('/api/refresh-token').set(authHeader);
+
+      expect(res.status).toBe(500);
+      expect(res.body.error.code).toBe('INTERNAL_SERVER_ERROR');
+    });
   });
 });

--- a/src/routes/refresh-token.ts
+++ b/src/routes/refresh-token.ts
@@ -33,15 +33,29 @@ import { getRequestId } from '../utils/asyncContext.js';
 import type { RefreshTokenRepository } from '../repositories/refreshTokenRepository.js';
 import { DatabaseRefreshTokenRepository } from '../repositories/refreshTokenRepository.js';
 
+import {
+  createTokenBucketRateLimitMiddleware,
+  TokenBucketRateLimiter,
+} from '../middleware/rateLimit.js';
+import type { RequestHandler } from 'express';
+
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 
 export interface RefreshTokenRouterDeps {
   refreshTokenRepository?: RefreshTokenRepository;
+  rateLimitMiddleware?: RequestHandler;
+  rateLimiter?: TokenBucketRateLimiter;
 }
 
 export function createRefreshTokenRouter(deps: RefreshTokenRouterDeps = {}): Router {
   const router = Router();
   const refreshTokenRepository = deps.refreshTokenRepository ?? new DatabaseRefreshTokenRepository();
+  const rateLimitMiddleware =
+    deps.rateLimitMiddleware ??
+    createTokenBucketRateLimitMiddleware(
+      { capacity: 10, refillRate: 1 },
+      deps.rateLimiter,
+    );
 
   /**
    * GET /api/refresh-token
@@ -74,7 +88,7 @@ export function createRefreshTokenRouter(deps: RefreshTokenRouterDeps = {}): Rou
    *     "timestamp": "2026-..."
    *   }
    */
-  router.get('/', requireAuth, async (req, res, next) => {
+  router.get('/', rateLimitMiddleware, requireAuth, async (req, res, next) => {
     const requestId = getRequestId();
     const userId = req.developerId || res.locals.authenticatedUser?.id;
 


### PR DESCRIPTION
## Description

Adds a per-user token-bucket rate limiter to `GET /api/refresh-token`, returning **HTTP 429 Too Many Requests** with a `Retry-After` header when the configured rate limit is exceeded.

Closes #930

## Changes

- Applied token-bucket rate limiting to `GET /api/refresh-token`.
- Keyed rate limits by authenticated user ID, with client IP fallback when unavailable.
- Added support for injecting a custom rate limiter to enable deterministic testing.
- Returned `429 Too Many Requests` with a `Retry-After` header when requests exceed bucket capacity.
- Added focused tests covering rate limiting behavior, per-user isolation, IP fallback, and retry timing.

## Validation

- {x} 21/21 tests passing.
- [x] `npm run error-codes:check` passing.
- [x] 94.87% coverage on `refresh-token.ts`.

## Notes

- Rate limits are enforced independently for each user.
- Requests without an authenticated user fall back to IP-based rate limiting.
- `Retry-After` is returned in whole seconds based on the token bucket refill time.
```