### PR TITLE
feat(webhooks): add security header sweep for /api/webhooks

### DIFF
--- a/src/__tests__/security-headers-webhooks.test.ts
+++ b/src/__tests__/security-headers-webhooks.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Security Headers Tests for /api/webhooks
+ *
+ * Verifies that webhook responses include the required security headers:
+ * - Content-Security-Policy
+ * - X-Content-Type-Options
+ * - Referrer-Policy
+ */
+
+import request from 'supertest';
+import express from 'express';
+import { requestIdMiddleware } from '../middleware/requestId.js';
+import { errorHandler } from '../middleware/errorHandler.js';
+import webhookRoutes from '../webhooks/webhook.routes.js';
+import webhooksRouter from '../routes/webhooks.js';
+import { createSecurityHeadersMiddleware } from '../middleware/securityHeaders.js';
+import { WebhookStore } from '../webhooks/webhook.store.js';
+
+// Mock better-sqlite3 to prevent native binding errors
+jest.mock('better-sqlite3', () => {
+  return class MockDatabase {
+    prepare() { return { get: () => null }; }
+    exec() {}
+    close() {}
+  };
+});
+
+describe('Security Headers on /api/webhooks', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(requestIdMiddleware);
+    app.use(express.json());
+    app.use('/api/webhooks', webhookRoutes);
+    app.use(errorHandler);
+
+    WebhookStore.clear();
+    WebhookStore.clearDlq();
+    WebhookStore.clearFailedDeliveries();
+  });
+
+  describe('POST /api/webhooks', () => {
+    it('returns Content-Security-Policy header', async () => {
+      const res = await request(app)
+        .post('/api/webhooks')
+        .send({
+          developerId: 'dev-test',
+          url: 'https://example.com/webhook',
+          events: ['new_api_call'],
+        });
+
+      expect(res.headers['content-security-policy']).toBeDefined();
+      expect(res.headers['content-security-policy']).toContain("default-src 'self'");
+    });
+
+    it('returns X-Content-Type-Options header', async () => {
+      const res = await request(app)
+        .post('/api/webhooks')
+        .send({
+          developerId: 'dev-test',
+          url: 'https://example.com/webhook',
+          events: ['new_api_call'],
+        });
+
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+    });
+
+    it('returns Referrer-Policy header', async () => {
+      const res = await request(app)
+        .post('/api/webhooks')
+        .send({
+          developerId: 'dev-test',
+          url: 'https://example.com/webhook',
+          events: ['new_api_call'],
+        });
+
+      expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    });
+  });
+
+  describe('GET /api/webhooks/:developerId', () => {
+    it('returns security headers on error response', async () => {
+      const res = await request(app)
+        .get('/api/webhooks/nonexistent-dev');
+
+      expect(res.headers['content-security-policy']).toBeDefined();
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    });
+  });
+
+  describe('DELETE /api/webhooks/:developerId', () => {
+    it('returns security headers on response', async () => {
+      const res = await request(app)
+        .delete('/api/webhooks/nonexistent-dev');
+
+      expect(res.headers['content-security-policy']).toBeDefined();
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    });
+  });
+
+  describe('src/routes/webhooks.ts export router', () => {
+    it('applies security headers when mounted via src/routes/webhooks.js', async () => {
+      const routeApp = express();
+      routeApp.use(requestIdMiddleware);
+      routeApp.use(express.json());
+      routeApp.use('/api/webhooks', webhooksRouter);
+      routeApp.use(errorHandler);
+
+      const res = await request(routeApp).get('/api/webhooks/nonexistent-dev');
+      expect(res.headers['content-security-policy']).toBeDefined();
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    });
+  });
+
+  describe('createSecurityHeadersMiddleware unit tests', () => {
+    it('allows custom security header options', async () => {
+      const customApp = express();
+      customApp.use(
+        createSecurityHeadersMiddleware({
+          contentSecurityPolicy: "default-src 'none'",
+          contentTypeOptions: 'nosniff',
+          referrerPolicy: 'no-referrer',
+        })
+      );
+      customApp.get('/test', (_req, res) => {
+        res.send('ok');
+      });
+
+      const res = await request(customApp).get('/test');
+      expect(res.headers['content-security-policy']).toBe("default-src 'none'");
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.headers['referrer-policy']).toBe('no-referrer');
+    });
+  });
+});

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -1,0 +1,66 @@
+import type { Request, Response, NextFunction } from 'express';
+import { getRequestId } from '../lib/envelope.js';
+import { logger } from '../logger.js';
+
+/**
+ * Options for configuring security headers middleware.
+ */
+export interface SecurityHeadersOptions {
+  /**
+   * Value for Content-Security-Policy header.
+   * Defaults to `"default-src 'self'; frame-ancestors 'none'; object-src 'none'"`.
+   */
+  contentSecurityPolicy?: string;
+  /**
+   * Value for X-Content-Type-Options header.
+   * Defaults to `"nosniff"`.
+   */
+  contentTypeOptions?: string;
+  /**
+   * Value for Referrer-Policy header.
+   * Defaults to `"strict-origin-when-cross-origin"`.
+   */
+  referrerPolicy?: string;
+}
+
+const DEFAULT_CSP = "default-src 'self'; frame-ancestors 'none'; object-src 'none'";
+const DEFAULT_CONTENT_TYPE_OPTIONS = 'nosniff';
+const DEFAULT_REFERRER_POLICY = 'strict-origin-when-cross-origin';
+
+/**
+ * Creates security header middleware enforcing CSP, X-Content-Type-Options,
+ * and Referrer-Policy on all HTTP responses.
+ *
+ * Ensures security headers are applied to both successful responses and
+ * error responses emitted downstream.
+ *
+ * @param options Optional custom security header values
+ * @returns Express middleware function
+ */
+export function createSecurityHeadersMiddleware(
+  options: SecurityHeadersOptions = {}
+): (req: Request, res: Response, next: NextFunction) => void {
+  const csp = options.contentSecurityPolicy ?? DEFAULT_CSP;
+  const contentTypeOptions = options.contentTypeOptions ?? DEFAULT_CONTENT_TYPE_OPTIONS;
+  const referrerPolicy = options.referrerPolicy ?? DEFAULT_REFERRER_POLICY;
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    res.setHeader('Content-Security-Policy', csp);
+    res.setHeader('X-Content-Type-Options', contentTypeOptions);
+    res.setHeader('Referrer-Policy', referrerPolicy);
+
+    const requestId = getRequestId(req as Request & { headers: Record<string, string | string[] | undefined> });
+    logger.info('[security-headers] applied headers to response', {
+      requestId,
+      path: req.path,
+      method: req.method,
+    });
+
+    next();
+  };
+}
+
+/**
+ * Standard security header middleware instance with default policy headers.
+ */
+export const securityHeadersMiddleware = createSecurityHeadersMiddleware();

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import webhookRoutes from '../webhooks/webhook.routes.js';
+import { securityHeadersMiddleware } from '../middleware/securityHeaders.js';
+
+const router = Router();
+
+// Apply security header sweep middleware to all webhook endpoints
+router.use(securityHeadersMiddleware);
+router.use(webhookRoutes);
+
+export default router;
+export { router as webhooksRouter };

--- a/src/webhooks/webhook.routes.ts
+++ b/src/webhooks/webhook.routes.ts
@@ -15,8 +15,12 @@ import { config } from '../config/index.js';
 import { logger } from '../logger.js';
 import { validateRetryPolicy } from '../services/webhookRetry.js';
 import { createWebhookHealthRouter } from '../routes/webhooks/health.js';
+import { securityHeadersMiddleware } from '../middleware/securityHeaders.js';
 
 const router = Router();
+
+// Apply security header sweep middleware to all webhook routes
+router.use(securityHeadersMiddleware);
 
 /**
  * Structured access log middleware scoped to webhook routes.


### PR DESCRIPTION
## Summary

Implements a security header sweep for `/api/webhooks` by ensuring webhook responses include the required security headers.

## Changes

- Added dedicated security headers middleware for webhook routes.
- Applied `Content-Security-Policy`, `X-Content-Type-Options`, and `Referrer-Policy` to webhook responses.
- Added focused tests covering webhook endpoints and middleware behavior.
- Included coverage for configurable middleware options and route integration.

## Testing

- Added unit and integration tests for webhook security headers.
- Verified all new tests pass with full coverage on the introduced middleware and route wrapper.

Closes #925