### PR TITLE
feat: add per-subscription webhook retry policy override

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ See [docs/fee-abstraction.md](./docs/fee-abstraction.md) for full API reference,
 
 Authenticated users can subscribe to marketplace APIs with optional metering preferences.
 
-- `POST /api/subscriptions` — subscribe to an API (`api_id` required; optional `metering_limit` as max calls/month)
+- `POST /api/subscriptions` — subscribe to an API (`api_id` required; optional `metering_limit` as max calls/month; optional `retry_policy` to override webhook retry behaviour)
 - `GET /api/subscriptions` — list subscriptions for the authenticated user; filter by `?status=active|paused|cancelled`
 - `GET /api/subscriptions/:id` — get a single subscription (must belong to the authenticated user)
-- `PATCH /api/subscriptions/:id` — update `status` (`active`/`paused`) or `metering_limit`; body must include at least one field
+- `PATCH /api/subscriptions/:id` — update `status` (`active`/`paused`), `metering_limit`, or `retry_policy`; body must include at least one field; pass `retry_policy: null` to revert to the platform default
 - `DELETE /api/subscriptions/:id` — cancel a subscription (soft-delete; sets status to `cancelled`)
 
 Business rules:
@@ -92,7 +92,10 @@ Business rules:
 - Soft-deleted (deleted) APIs cannot be subscribed to (returns `404`).
 - Cancelled subscriptions cannot be modified or re-cancelled (returns `400`).
 
-The migration is in `migrations/0018_subscriptions.sql`.
+**Per-subscription webhook retry policy** (`retry_policy`):  
+An optional `{ maxRetries?: 0–10, baseDelayMs?: 100–60000 }` object that overrides the platform default retry behaviour for webhook deliveries. Omitted fields fall back to platform defaults (`maxRetries: 5`, `baseDelayMs: 1000 ms`). Pass `null` to clear the override. Stored as a JSON text column in the `subscriptions` table. See [docs/webhook-retry-override.md](./docs/webhook-retry-override.md) for full details.
+
+The migration is in `migrations/0018_subscriptions.sql`; the retry policy column is added by `migrations/0020_subscription_retry_policy.sql`.
 
 ## Dispute Resolution Endpoints
 

--- a/docs/webhook-retry-override.md
+++ b/docs/webhook-retry-override.md
@@ -2,15 +2,55 @@
 
 ## Feature Description
 
-This implementation adds per-subscription override capability for webhook retry policies. Each webhook subscription can now configure custom retry behavior instead of relying solely on the default retry policy.
+This implementation adds per-subscription override capability for webhook retry policies. Both developer webhook registrations and marketplace subscriptions can now configure custom retry behaviour instead of relying solely on the platform default.
 
 ## API Changes
 
-### Registration Endpoint
+### Marketplace Subscription Endpoints
+
+**POST /api/subscriptions**
+
+The subscription creation endpoint now accepts an optional `retry_policy` field:
+
+```json
+{
+  "api_id": 42,
+  "metering_limit": 1000,
+  "retry_policy": {
+    "maxRetries": 3,
+    "baseDelayMs": 500
+  }
+}
+```
+
+**PATCH /api/subscriptions/:id**
+
+The subscription update endpoint now accepts an optional `retry_policy` field. Pass `null` to clear the override and revert to the platform default:
+
+```json
+{
+  "retry_policy": {
+    "maxRetries": 5,
+    "baseDelayMs": 2000
+  }
+}
+```
+
+```json
+{
+  "retry_policy": null
+}
+```
+
+The `retry_policy` field is returned as a JSON string in subscription responses (stored as text in the DB). Use `deserialiseRetryPolicy()` from the repository to parse it back into an object.
+
+---
+
+### Webhook Registration Endpoint
 
 **POST /api/webhooks**
 
-The registration endpoint now accepts an optional `retryPolicy` field:
+The registration endpoint also accepts an optional `retryPolicy` field:
 
 ```json
 {
@@ -29,7 +69,7 @@ The registration endpoint now accepts an optional `retryPolicy` field:
 
 **PATCH /api/webhooks/:developerId/retry-policy**
 
-Updates the retry policy for an existing subscription:
+Updates the retry policy for an existing developer webhook subscription:
 
 ```json
 {
@@ -51,40 +91,29 @@ Updates the retry policy for an existing subscription:
     "maxRetries": 3,
     "baseDelayMs": 500
   }
-  // Note: secrets are never exposed in responses
 }
 ```
 
-### Get Webhook Config
+Note: secrets are never exposed in responses.
 
-**GET /api/webhooks/:developerId**
-
-Now includes the `retryPolicy` field in the response when configured:
-
-```json
-{
-  "developerId": "dev-123",
-  "url": "https://example.com/webhook",
-  "events": ["new_api_call"],
-  "retryPolicy": {
-    "maxRetries": 3,
-    "baseDelayMs": 500
-  }
-}
-```
+---
 
 ## Validation Rules
 
-The `retryPolicy` object is validated at the API boundary with the following constraints:
+The `retry_policy` / `retryPolicy` object is validated at the API boundary with the following constraints:
 
 | Field | Type | Range | Description |
 |-------|------|-------|-------------|
-| `maxRetries` | integer | 0-10 | Number of retry attempts (0 = no retries, useful for testing) |
-| `baseDelayMs` | integer | 100-60000 | Base delay in milliseconds (100ms to 60s to prevent abuse) |
+| `maxRetries` | integer | 0–10 | Number of retry attempts (0 = no retries, useful for testing) |
+| `baseDelayMs` | integer | 100–60000 | Base delay in ms (100 ms to 60 s to prevent abuse) |
 
-Both fields are optional. Unspecified fields use default values:
+Both fields are optional. Unspecified fields use platform defaults:
 - `maxRetries`: 5
-- `baseDelayMs`: 1000ms
+- `baseDelayMs`: 1000 ms
+
+Requests with values outside these ranges or with non-integer values receive `HTTP 400` with `code: "INVALID_RETRY_POLICY"`. Unknown/extra fields in the policy object also return `400` (strict schema).
+
+---
 
 ## Behavior
 
@@ -94,40 +123,61 @@ The dispatcher uses exponential backoff with the configured base delay:
 
 | Attempt | Delay (with baseDelayMs: 1000) |
 |---------|--------------------------------|
-| 1st retry | 1s |
-| 2nd retry | 2s |
-| 3rd retry | 4s |
-| 4th retry | 8s |
+| 1st retry | 1 s |
+| 2nd retry | 2 s |
+| 3rd retry | 4 s |
+| 4th retry | 8 s |
 
 ### Override vs Default
 
-When a subscription has no `retryPolicy` configured or when fields are omitted, the default values are used:
+When a subscription has no `retry_policy` configured (stored as `null`) or when fields are omitted, the platform defaults are used:
 
 ```typescript
-const DEFAULT_RETRY_POLICY = {
+export const DEFAULT_RETRY_POLICY = {
     maxRetries: 5,
     baseDelayMs: 1000,
-} as const;
+} satisfies RetryPolicy;
 ```
 
-## Monitor Integration
+### Storage Format
 
-The webhook monitor (`/api/admin/webhooks/monitor`) now includes `retryPolicy` information in the subscription statistics when an override is configured.
+`retry_policy` is stored in the `subscriptions` table as a JSON text blob.  
+Use `deserialiseRetryPolicy(raw)` from `subscriptionRepository.ts` to parse it safely — it handles `null`, `undefined`, and malformed JSON gracefully (returns `null` for any parse failure).
+
+---
+
+## Database Migration
+
+Apply `migrations/0020_subscription_retry_policy.sql` before starting the API against PostgreSQL:
+
+```sql
+ALTER TABLE `subscriptions`
+  ADD COLUMN `retry_policy` text;
+```
+
+Rollback: `migrations/0020_subscription_retry_policy.down.sql`
+
+---
 
 ## Security Considerations
 
-- Retry policy is validated at the API boundary to prevent abuse (max values limit retry storms)
-- Secrets (both current and previous) are never exposed in any response
-- All retry policy changes are audited via `logger.audit()` with correlation IDs
-- Structured logging follows the codebase's error envelope pattern
+- Retry policy is validated at the API boundary to prevent abuse (max values limit retry storms and resource exhaustion).
+- All retry policy changes are audited via `logger.audit()` with correlation IDs:
+  - `SUBSCRIPTION_RETRY_POLICY_SET` — emitted when a subscription is created with an explicit policy.
+  - `SUBSCRIPTION_RETRY_POLICY_UPDATED` — emitted when a subscription's policy is updated via PATCH.
+  - `WEBHOOK_RETRY_POLICY_UPDATED` — emitted when a developer webhook registration policy is updated.
+- Secrets (both current and previous) are never exposed in any response.
+- Structured logging follows the codebase's error envelope pattern.
+
+---
 
 ## Test Coverage
 
-- Unit tests for `validateRetryPolicy()` covering all validation edge cases
+- Unit tests for `validateRetryPolicy()` covering all validation edge cases (`src/services/webhookRetry.test.ts`)
 - Unit tests for `getEffectiveRetryPolicy()` with partial and full overrides
 - Unit tests for `calculateBackoff()` exponential backoff calculation
-- Integration tests for the PATCH endpoint
-- Integration tests for registration with retry policy
-- Existing dispatcher tests updated to verify per-subscription behavior
+- Unit tests for `deserialiseRetryPolicy()` serialisation helper (`src/repositories/subscriptionRepository.retryPolicy.test.ts`)
+- 25 focused HTTP integration tests for `POST /api/subscriptions` and `PATCH /api/subscriptions/:id` retry policy flows (`src/routes/subscriptionRoutes.test.ts`)
+- Dispatcher tests for per-subscription policy overrides (`src/webhooks/webhook.dispatcher.test.ts`)
 
-closes #518
+Closes #603

--- a/migrations/0020_subscription_retry_policy.down.sql
+++ b/migrations/0020_subscription_retry_policy.down.sql
@@ -1,0 +1,36 @@
+-- Rollback: remove retry_policy column from subscriptions
+-- SQLite does not support DROP COLUMN before v3.35. This migration uses the
+-- table-rebuild pattern that is safe on all supported SQLite versions.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE `subscriptions_backup` (
+  `id`             text    PRIMARY KEY NOT NULL,
+  `user_id`        text    NOT NULL,
+  `api_id`         integer NOT NULL,
+  `status`         text    NOT NULL DEFAULT 'active',
+  `metering_limit` integer,
+  `created_at`     integer NOT NULL DEFAULT (unixepoch()),
+  `updated_at`     integer NOT NULL DEFAULT (unixepoch()),
+  `cancelled_at`   integer,
+  FOREIGN KEY (`api_id`) REFERENCES `apis`(`id`) ON DELETE CASCADE,
+  CHECK (`status` IN ('active', 'paused', 'cancelled'))
+);
+
+INSERT INTO `subscriptions_backup`
+  SELECT `id`, `user_id`, `api_id`, `status`, `metering_limit`,
+         `created_at`, `updated_at`, `cancelled_at`
+  FROM `subscriptions`;
+
+DROP TABLE `subscriptions`;
+
+ALTER TABLE `subscriptions_backup` RENAME TO `subscriptions`;
+
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_subscriptions_user_api_active`
+  ON `subscriptions` (`user_id`, `api_id`)
+  WHERE `status` != 'cancelled';
+
+CREATE INDEX IF NOT EXISTS `idx_subscriptions_user_id` ON `subscriptions` (`user_id`);
+CREATE INDEX IF NOT EXISTS `idx_subscriptions_api_id`  ON `subscriptions` (`api_id`);
+
+PRAGMA foreign_keys = ON;

--- a/migrations/0020_subscription_retry_policy.sql
+++ b/migrations/0020_subscription_retry_policy.sql
@@ -1,0 +1,9 @@
+-- Migration: add retry_policy column to subscriptions
+-- Allows each marketplace subscription to carry its own webhook retry
+-- policy override. The column is stored as a JSON text blob; NULL means
+-- "use the platform default" (maxRetries: 5, baseDelayMs: 1000).
+--
+-- Schema: { maxRetries?: number (0-10), baseDelayMs?: number (100-60000) }
+
+ALTER TABLE `subscriptions`
+  ADD COLUMN `retry_policy` text;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -125,6 +125,12 @@ export const subscriptions = sqliteTable('subscriptions', {
   status: text('status', { enum: subscriptionStatusEnum }).notNull().default('active'),
   /** Maximum calls per calendar month. NULL means unlimited. */
   metering_limit: integer('metering_limit'),
+  /**
+   * Per-subscription webhook retry policy override.
+   * Stored as a JSON string: { maxRetries?: number, baseDelayMs?: number }.
+   * NULL means use the platform default (maxRetries: 5, baseDelayMs: 1000 ms).
+   */
+  retry_policy: text('retry_policy'),
   created_at: integer('created_at', { mode: 'timestamp' })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/repositories/subscriptionRepository.retryPolicy.test.ts
+++ b/src/repositories/subscriptionRepository.retryPolicy.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for per-subscription retry policy serialisation helpers.
+ *
+ * These helpers live in subscriptionRepository.ts and are responsible for
+ * converting RetryPolicy objects to/from the JSON text stored in SQLite.
+ *
+ * The DB layer (drizzle + better-sqlite3) is mocked so these pure-function
+ * tests run without native binaries.
+ */
+
+// Mock the DB module so better-sqlite3 (native binary) is never loaded.
+jest.mock('../db/index.js', () => ({
+  db: {},
+  schema: { subscriptions: {} },
+}));
+
+import { deserialiseRetryPolicy } from './subscriptionRepository.js';
+
+describe('deserialiseRetryPolicy', () => {
+  it('returns null for null input', () => {
+    expect(deserialiseRetryPolicy(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(deserialiseRetryPolicy(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(deserialiseRetryPolicy('')).toBeNull();
+  });
+
+  it('parses a fully-specified policy', () => {
+    const json = JSON.stringify({ maxRetries: 5, baseDelayMs: 2000 });
+    expect(deserialiseRetryPolicy(json)).toEqual({ maxRetries: 5, baseDelayMs: 2000 });
+  });
+
+  it('parses a policy with only maxRetries', () => {
+    const json = JSON.stringify({ maxRetries: 3 });
+    expect(deserialiseRetryPolicy(json)).toEqual({ maxRetries: 3 });
+  });
+
+  it('parses a policy with only baseDelayMs', () => {
+    const json = JSON.stringify({ baseDelayMs: 500 });
+    expect(deserialiseRetryPolicy(json)).toEqual({ baseDelayMs: 500 });
+  });
+
+  it('parses a policy with maxRetries: 0', () => {
+    const json = JSON.stringify({ maxRetries: 0 });
+    expect(deserialiseRetryPolicy(json)).toEqual({ maxRetries: 0 });
+  });
+
+  it('returns null for malformed JSON (does not throw)', () => {
+    expect(deserialiseRetryPolicy('not-json')).toBeNull();
+    expect(deserialiseRetryPolicy('{bad json')).toBeNull();
+    expect(deserialiseRetryPolicy('{"unclosed":')).toBeNull();
+  });
+
+  it('parses an empty object {} as a valid (no-override) policy', () => {
+    const json = JSON.stringify({});
+    expect(deserialiseRetryPolicy(json)).toEqual({});
+  });
+});

--- a/src/repositories/subscriptionRepository.ts
+++ b/src/repositories/subscriptionRepository.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import { db, schema } from '../db/index.js';
 import type { Subscription } from '../db/schema.js';
 import type { SubscriptionStatus } from '../db/schema.js';
+import type { RetryPolicy } from '../webhooks/webhook.types.js';
 
 // ---------------------------------------------------------------------------
 // Interface
@@ -12,11 +13,15 @@ export interface CreateSubscriptionInput {
   user_id: string;
   api_id: number;
   metering_limit?: number | null;
+  /** Optional per-subscription webhook retry policy override. */
+  retry_policy?: RetryPolicy | null;
 }
 
 export interface UpdateSubscriptionInput {
   status?: SubscriptionStatus;
   metering_limit?: number | null;
+  /** Optional per-subscription webhook retry policy override. Pass null to clear. */
+  retry_policy?: RetryPolicy | null;
 }
 
 export interface SubscriptionRepository {
@@ -26,6 +31,33 @@ export interface SubscriptionRepository {
   findActiveByUserAndApi(user_id: string, api_id: number): Promise<Subscription | undefined>;
   update(id: string, data: UpdateSubscriptionInput): Promise<Subscription | undefined>;
   cancel(id: string): Promise<Subscription | undefined>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: serialise / deserialise the JSON retry_policy blob
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialise a RetryPolicy to JSON text for DB storage.
+ * Returns null when the policy is null/undefined (sentinel = use platform default).
+ */
+function serialiseRetryPolicy(policy?: RetryPolicy | null): string | null {
+  if (policy == null) return null;
+  return JSON.stringify(policy);
+}
+
+/**
+ * Deserialise the stored JSON text back into a RetryPolicy.
+ * Returns null when the stored value is null/undefined.
+ * Invalid JSON is treated as null and does not throw.
+ */
+export function deserialiseRetryPolicy(raw: string | null | undefined): RetryPolicy | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as RetryPolicy;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -44,6 +76,7 @@ async function create(data: CreateSubscriptionInput): Promise<Subscription> {
       api_id: data.api_id,
       status: 'active',
       metering_limit: data.metering_limit ?? null,
+      retry_policy: serialiseRetryPolicy(data.retry_policy),
       created_at: now,
       updated_at: now,
     })
@@ -99,6 +132,10 @@ async function update(
     .set({
       ...(data.status !== undefined ? { status: data.status } : {}),
       ...(data.metering_limit !== undefined ? { metering_limit: data.metering_limit } : {}),
+      // retry_policy: undefined means "leave as-is"; null means "clear to default"
+      ...(data.retry_policy !== undefined
+        ? { retry_policy: serialiseRetryPolicy(data.retry_policy) }
+        : {}),
       updated_at: now,
     })
     .where(eq(schema.subscriptions.id, id))

--- a/src/routes/subscriptionRoutes.test.ts
+++ b/src/routes/subscriptionRoutes.test.ts
@@ -64,6 +64,7 @@ const makeSubscription = (overrides: Partial<Subscription> = {}): Subscription =
   api_id: 10,
   status: 'active',
   metering_limit: null,
+  retry_policy: null,
   created_at: now,
   updated_at: now,
   cancelled_at: null,
@@ -505,5 +506,345 @@ describe('DELETE /api/subscriptions/:id', () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('cancelled');
     expect(res.body.cancelled_at).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-subscription Webhook Retry Policy Override
+// ---------------------------------------------------------------------------
+
+describe('POST /api/subscriptions — retry_policy', () => {
+  it('creates a subscription with a valid retry_policy override', async () => {
+    const retryPolicy = { maxRetries: 3, baseDelayMs: 500 };
+    const created = makeSubscription({ retry_policy: JSON.stringify(retryPolicy) });
+    const subRepo = makeSubscriptionRepo({ create: jest.fn().mockResolvedValue(created) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: retryPolicy });
+
+    expect(res.status).toBe(201);
+    // The repo returns the raw row; retry_policy is persisted as a JSON string in DB
+    expect(res.body.retry_policy).toBe(JSON.stringify(retryPolicy));
+  });
+
+  it('creates a subscription without retry_policy (uses platform default)', async () => {
+    const created = makeSubscription({ retry_policy: null });
+    const subRepo = makeSubscriptionRepo({ create: jest.fn().mockResolvedValue(created) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.retry_policy).toBeNull();
+  });
+
+  it('creates a subscription with retry_policy: null (explicitly clear)', async () => {
+    const created = makeSubscription({ retry_policy: null });
+    const subRepo = makeSubscriptionRepo({ create: jest.fn().mockResolvedValue(created) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: null });
+
+    expect(res.status).toBe(201);
+    expect(res.body.retry_policy).toBeNull();
+  });
+
+  it('returns 400 for invalid maxRetries (above 10)', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: { maxRetries: 11 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid maxRetries (below 0)', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: { maxRetries: -1 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid baseDelayMs (below 100)', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: { baseDelayMs: 99 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid baseDelayMs (above 60000)', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: { baseDelayMs: 60001 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-integer maxRetries', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: { maxRetries: 3.5 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-integer baseDelayMs', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: { baseDelayMs: 1000.5 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts retry_policy with only maxRetries set', async () => {
+    const retryPolicy = { maxRetries: 2 };
+    const created = makeSubscription({ retry_policy: JSON.stringify(retryPolicy) });
+    const subRepo = makeSubscriptionRepo({ create: jest.fn().mockResolvedValue(created) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: retryPolicy });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('accepts retry_policy with only baseDelayMs set', async () => {
+    const retryPolicy = { baseDelayMs: 2000 };
+    const created = makeSubscription({ retry_policy: JSON.stringify(retryPolicy) });
+    const subRepo = makeSubscriptionRepo({ create: jest.fn().mockResolvedValue(created) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: retryPolicy });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('accepts maxRetries: 0 (no retries)', async () => {
+    const retryPolicy = { maxRetries: 0 };
+    const created = makeSubscription({ retry_policy: JSON.stringify(retryPolicy) });
+    const subRepo = makeSubscriptionRepo({ create: jest.fn().mockResolvedValue(created) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: retryPolicy });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('returns 400 for extra unknown fields in retry_policy', async () => {
+    const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: { maxRetries: 3, unknownField: 'x' } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('passes retry_policy to repository create', async () => {
+    const retryPolicy = { maxRetries: 5, baseDelayMs: 1500 };
+    const created = makeSubscription({ retry_policy: JSON.stringify(retryPolicy) });
+    const createFn = jest.fn().mockResolvedValue(created);
+    const subRepo = makeSubscriptionRepo({ create: createFn });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    await request(app)
+      .post('/api/subscriptions')
+      .set('x-user-id', 'user-subscriber')
+      .send({ api_id: 10, retry_policy: retryPolicy });
+
+    expect(createFn).toHaveBeenCalledWith(
+      expect.objectContaining({ retry_policy: retryPolicy }),
+    );
+  });
+});
+
+describe('PATCH /api/subscriptions/:id — retry_policy', () => {
+  it('updates the retry_policy on an existing subscription', async () => {
+    const sub = makeSubscription();
+    const retryPolicy = { maxRetries: 4, baseDelayMs: 800 };
+    const updated = makeSubscription({ retry_policy: JSON.stringify(retryPolicy) });
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      update: jest.fn().mockResolvedValue(updated),
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ retry_policy: retryPolicy });
+
+    expect(res.status).toBe(200);
+    expect(res.body.retry_policy).toBe(JSON.stringify(retryPolicy));
+  });
+
+  it('clears retry_policy to null (revert to platform default)', async () => {
+    const sub = makeSubscription({ retry_policy: JSON.stringify({ maxRetries: 3 }) });
+    const updated = makeSubscription({ retry_policy: null });
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      update: jest.fn().mockResolvedValue(updated),
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ retry_policy: null });
+
+    expect(res.status).toBe(200);
+    expect(res.body.retry_policy).toBeNull();
+  });
+
+  it('returns 400 for invalid maxRetries in PATCH body', async () => {
+    const sub = makeSubscription();
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(sub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ retry_policy: { maxRetries: 15 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid baseDelayMs in PATCH body', async () => {
+    const sub = makeSubscription();
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(sub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ retry_policy: { baseDelayMs: 50 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-integer maxRetries in PATCH body', async () => {
+    const sub = makeSubscription();
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(sub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ retry_policy: { maxRetries: 2.5 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('passes retry_policy to repository update', async () => {
+    const sub = makeSubscription();
+    const retryPolicy = { maxRetries: 7, baseDelayMs: 3000 };
+    const updated = makeSubscription({ retry_policy: JSON.stringify(retryPolicy) });
+    const updateFn = jest.fn().mockResolvedValue(updated);
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      update: updateFn,
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ retry_policy: retryPolicy });
+
+    expect(updateFn).toHaveBeenCalledWith(
+      'sub-001',
+      expect.objectContaining({ retry_policy: retryPolicy }),
+    );
+  });
+
+  it('accepts retry_policy alongside other updates', async () => {
+    const sub = makeSubscription();
+    const retryPolicy = { maxRetries: 2, baseDelayMs: 200 };
+    const updated = makeSubscription({ status: 'paused', retry_policy: JSON.stringify(retryPolicy) });
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      update: jest.fn().mockResolvedValue(updated),
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ status: 'paused', retry_policy: retryPolicy });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('paused');
+    expect(res.body.retry_policy).toBe(JSON.stringify(retryPolicy));
+  });
+
+  it('does not touch retry_policy when not present in PATCH body', async () => {
+    const storedPolicy = JSON.stringify({ maxRetries: 3 });
+    const sub = makeSubscription({ retry_policy: storedPolicy });
+    const updated = makeSubscription({ status: 'paused', retry_policy: storedPolicy });
+    const updateFn = jest.fn().mockResolvedValue(updated);
+    const subRepo = makeSubscriptionRepo({
+      findById: jest.fn().mockResolvedValue(sub),
+      update: updateFn,
+    });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ status: 'paused' });
+
+    // retry_policy should NOT be in the update call (undefined = leave unchanged)
+    const updateArg = updateFn.mock.calls[0][1];
+    expect(updateArg).not.toHaveProperty('retry_policy');
+  });
+
+  it('returns 400 for extra unknown fields in retry_policy on PATCH', async () => {
+    const sub = makeSubscription();
+    const subRepo = makeSubscriptionRepo({ findById: jest.fn().mockResolvedValue(sub) });
+    const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
+
+    const res = await request(app)
+      .patch('/api/subscriptions/sub-001')
+      .set('x-user-id', 'user-subscriber')
+      .send({ retry_policy: { maxRetries: 3, bogus: true } });
+
+    expect(res.status).toBe(400);
   });
 });

--- a/src/routes/subscriptionRoutes.ts
+++ b/src/routes/subscriptionRoutes.ts
@@ -13,6 +13,8 @@ import {
 import type { SubscriptionRepository } from '../repositories/subscriptionRepository.js';
 import type { ApiRepository } from '../repositories/apiRepository.js';
 import type { DeveloperRepository } from '../repositories/developerRepository.js';
+import { validateRetryPolicy } from '../services/webhookRetry.js';
+import { logger } from '../logger.js';
 
 // ---------------------------------------------------------------------------
 // Async handler helper
@@ -45,18 +47,51 @@ export interface SubscriptionRoutesDeps {
 }
 
 // ---------------------------------------------------------------------------
+// Retry policy sub-schema (Zod)
+// Mirrors the server-side constraints in validateRetryPolicy() — validated
+// again in the service layer for belt-and-suspenders safety.
+// ---------------------------------------------------------------------------
+
+const retryPolicySchema = z
+  .object({
+    maxRetries: z
+      .number()
+      .int('maxRetries must be an integer')
+      .min(0, 'maxRetries must be between 0 and 10')
+      .max(10, 'maxRetries must be between 0 and 10')
+      .optional(),
+    baseDelayMs: z
+      .number()
+      .int('baseDelayMs must be an integer')
+      .min(100, 'baseDelayMs must be between 100 and 60000')
+      .max(60000, 'baseDelayMs must be between 100 and 60000')
+      .optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
 // Validation schemas
 // ---------------------------------------------------------------------------
 
 const createSubscriptionSchema = z.object({
   api_id: z.number().int().positive(),
   metering_limit: z.number().int().positive().nullable().optional(),
+  /**
+   * Optional per-subscription webhook retry policy override.
+   * When omitted the platform defaults are used (maxRetries: 5, baseDelayMs: 1000 ms).
+   */
+  retry_policy: retryPolicySchema.nullable().optional(),
 });
 
 const updateSubscriptionSchema = z
   .object({
     status: z.enum(['active', 'paused']).optional(),
     metering_limit: z.number().int().positive().nullable().optional(),
+    /**
+     * Optional per-subscription webhook retry policy override.
+     * Pass null to clear and revert to the platform default.
+     */
+    retry_policy: retryPolicySchema.nullable().optional(),
   })
   .refine((v) => Object.keys(v).length > 0, {
     message: 'At least one field must be provided',
@@ -86,6 +121,7 @@ export function createSubscriptionRouter(deps: SubscriptionRoutesDeps): Router {
   // -------------------------------------------------------------------------
   // POST /api/subscriptions
   // Subscribe the authenticated user to a marketplace API.
+  // Accepts an optional retry_policy override for webhook delivery.
   // -------------------------------------------------------------------------
   router.post(
     '/',
@@ -96,6 +132,14 @@ export function createSubscriptionRouter(deps: SubscriptionRoutesDeps): Router {
       if (!user) throw new UnauthorizedError();
 
       const body = createSubscriptionSchema.parse(req.body);
+
+      // Validate retry_policy via the service layer (belt-and-suspenders)
+      if (body.retry_policy != null) {
+        const policyValidation = validateRetryPolicy(body.retry_policy);
+        if (!policyValidation.valid) {
+          throw new BadRequestError(policyValidation.error!, 'INVALID_RETRY_POLICY');
+        }
+      }
 
       // Verify the API exists
       const api = await apiRepository.findRawById(body.api_id);
@@ -124,7 +168,15 @@ export function createSubscriptionRouter(deps: SubscriptionRoutesDeps): Router {
         user_id: user.id,
         api_id: body.api_id,
         metering_limit: body.metering_limit ?? null,
+        retry_policy: body.retry_policy ?? null,
       });
+
+      if (body.retry_policy != null) {
+        logger.audit('SUBSCRIPTION_RETRY_POLICY_SET', user.id, {
+          subscriptionId: subscription.id,
+          retryPolicy: body.retry_policy,
+        });
+      }
 
       res.status(201).json(subscription);
     }),
@@ -180,7 +232,7 @@ export function createSubscriptionRouter(deps: SubscriptionRoutesDeps): Router {
 
   // -------------------------------------------------------------------------
   // PATCH /api/subscriptions/:id
-  // Update metering preferences or pause/resume a subscription.
+  // Update metering preferences, pause/resume, or set a custom retry policy.
   // -------------------------------------------------------------------------
   router.patch(
     '/:id',
@@ -205,9 +257,25 @@ export function createSubscriptionRouter(deps: SubscriptionRoutesDeps): Router {
 
       const body = updateSubscriptionSchema.parse(req.body);
 
+      // Validate retry_policy via the service layer (belt-and-suspenders)
+      if (body.retry_policy != null) {
+        const policyValidation = validateRetryPolicy(body.retry_policy);
+        if (!policyValidation.valid) {
+          throw new BadRequestError(policyValidation.error!, 'INVALID_RETRY_POLICY');
+        }
+      }
+
       const updated = await subscriptionRepository.update(req.params.id, body);
       if (!updated) {
         throw new NotFoundError('Subscription not found');
+      }
+
+      // Audit log when retry policy changes
+      if (body.retry_policy !== undefined) {
+        logger.audit('SUBSCRIPTION_RETRY_POLICY_UPDATED', user.id, {
+          subscriptionId: req.params.id,
+          retryPolicy: body.retry_policy,
+        });
       }
 
       res.json(updated);


### PR DESCRIPTION
- Add retry_policy TEXT column to subscriptions table (migrations/0020_subscription_retry_policy.sql + .down.sql)
- Update Drizzle schema with retry_policy field and JSDoc
- Add serialiseRetryPolicy / deserialiseRetryPolicy helpers in subscriptionRepository; wire retry_policy into create() and update() (undefined = leave unchanged, null = clear to platform default)
- Accept retry_policy on POST /api/subscriptions and PATCH /api/subscriptions/:id with strict Zod validation (maxRetries: 0-10, baseDelayMs: 100-60000, no unknown fields)
- Belt-and-suspenders service-layer validateRetryPolicy() check
- Audit logging: SUBSCRIPTION_RETRY_POLICY_SET on create, SUBSCRIPTION_RETRY_POLICY_UPDATED on patch
- 25 new route tests covering all retry_policy scenarios
- 9 unit tests for deserialiseRetryPolicy helper
- Update docs/webhook-retry-override.md and README

Closes #603