### PR TITLE
Persist audit rows for state-changing calls on /api/webhooks

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { createUsageAnomaliesRouter } from './routes/admin/usage/anomalies.js';
 import { createAdminUsageByEndpointRouter } from './routes/admin/usage/byEndpoint.js';
 import { createApiRouter } from './routes/index.js';
 import { createApisRouter } from './routes/apis.js';
+import { createWebhooksRouter } from './routes/webhooks.js';
 import { createPluginsRouter } from './routes/marketplace/plugins.js';
 import { pool } from './db.js';
 import {
@@ -305,6 +306,9 @@ export const createApp = (dependencies?: Partial<AppDependencies>) => {
 
   // Plugin marketplace — community-developed billing rule plugins
   app.use('/api/marketplace/plugins', createPluginsRouter());
+
+  // Webhook management routes
+  app.use('/api/webhooks', createWebhooksRouter());
 
   // Mount all routes including billing and limits
   app.use('/api', createApiRouter({

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -174,6 +174,9 @@ export const ErrorCode = {
   /** Webhook URL validation failed */
   WEBHOOK_URL_VALIDATION_FAILED: "WEBHOOK_URL_VALIDATION_FAILED",
 
+  /** Retry policy configuration is invalid */
+  INVALID_RETRY_POLICY: "INVALID_RETRY_POLICY",
+
   /** Webhook signature headers are missing */
   MISSING_WEBHOOK_SIGNATURE_HEADERS: "MISSING_WEBHOOK_SIGNATURE_HEADERS",
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import type { Server } from 'http';
 import { createDeveloperRouter } from './routes/developerRoutes.js';
 import { createGatewayRouter } from './routes/gatewayRoutes.js';
 import { createProxyRouter } from './routes/proxyRoutes.js';
+import { createWebhooksRouter } from './routes/webhooks.js';
 import adminRouter from './routes/admin.js';
 import { createUsageAnomaliesRouter } from './routes/admin/usage/anomalies.js';
 import { defaultDeveloperRepository } from './repositories/developerRepository.js';
@@ -171,6 +172,10 @@ if (isDirectExecution) {
   // Mounted before the generic admin router so it is not shadowed by
   // adminRouter's `/usage/:developerId` route.
   app.use('/api/admin/usage/anomalies', createUsageAnomaliesRouter({ pool }));
+
+  // Webhook management routes
+  app.use('/api/webhooks', createWebhooksRouter());
+
   app.use('/api/admin', adminRouter);
 
   // Legacy gateway route (existing)

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import request from 'supertest';
+
+jest.mock('../db.js', () => ({
+  writeQuery: jest.fn(),
+}));
+
+jest.mock('../logger.js', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    audit: jest.fn(),
+  },
+}));
+
+import { writeQuery } from '../db.js';
+import app from '../index.js';
+import { WebhookStore } from '../webhooks/webhook.store.js';
+
+const mockWriteQuery = writeQuery as jest.MockedFunction<typeof writeQuery>;
+
+describe('Webhook routes — audit persistence', () => {
+  beforeEach(() => {
+    mockWriteQuery.mockResolvedValue({ rows: [] });
+    WebhookStore.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/webhooks — register', () => {
+    it('persists an audit row for webhook registration', async () => {
+      const response = await request(app)
+        .post('/api/webhooks')
+        .send({
+          developerId: 'dev-test-1',
+          url: 'https://example.com/webhook',
+          events: ['new_api_call'],
+        });
+
+      assert.equal(response.status, 201);
+      assert.equal(mockWriteQuery.mock.calls.length, 1);
+
+      const call = mockWriteQuery.mock.calls[0]!;
+      const sql = call[0] as string;
+      const params = call[1] as unknown[];
+      assert.ok(sql.includes('INSERT INTO audit_logs'));
+      assert.equal(params[1], 'WEBHOOK_REGISTERED');
+      assert.equal(params[2], 'dev-test-1');
+
+      const details = JSON.parse(params[8] as string);
+      assert.ok(details.after);
+      assert.equal(details.after.developerId, 'dev-test-1');
+      assert.equal(details.after.url, 'https://example.com/webhook');
+    });
+
+    it('persists before as undefined when no existing webhook', async () => {
+      await request(app)
+        .post('/api/webhooks')
+        .send({
+          developerId: 'dev-test-2',
+          url: 'https://example.com/webhook',
+          events: ['new_api_call'],
+        });
+
+      const call = mockWriteQuery.mock.calls[0]!;
+      const params = call[1] as unknown[];
+      const details = JSON.parse(params[8] as string);
+      assert.equal(details.before, undefined);
+    });
+  });
+
+  describe('POST /api/webhooks/:developerId/rotate-secret', () => {
+    it('persists an audit row for secret rotation', async () => {
+      WebhookStore.register({
+        developerId: 'dev-rotate-1',
+        url: 'https://example.com/webhook',
+        events: ['new_api_call'],
+        secret_current: 'old-secret-key-at-least-32-chars',
+        createdAt: new Date(),
+      });
+
+      const response = await request(app)
+        .post('/api/webhooks/dev-rotate-1/rotate-secret')
+        .send({});
+
+      assert.equal(response.status, 200);
+      assert.equal(mockWriteQuery.mock.calls.length, 1);
+
+      const call = mockWriteQuery.mock.calls[0]!;
+      const params = call[1] as unknown[];
+      assert.equal(params[1], 'WEBHOOK_SECRET_ROTATED');
+      assert.equal(params[2], 'dev-rotate-1');
+
+      const details = JSON.parse(params[8] as string);
+      assert.ok(details.before);
+      assert.ok(details.after);
+    });
+  });
+
+  describe('PATCH /api/webhooks/:developerId/retry-policy', () => {
+    it('persists an audit row for retry policy update', async () => {
+      WebhookStore.register({
+        developerId: 'dev-retry-1',
+        url: 'https://example.com/webhook',
+        events: ['new_api_call'],
+        createdAt: new Date(),
+      });
+
+      const response = await request(app)
+        .patch('/api/webhooks/dev-retry-1/retry-policy')
+        .send({
+          retryPolicy: { maxRetries: 3, baseDelayMs: 1000 },
+        });
+
+      assert.equal(response.status, 200);
+      assert.equal(mockWriteQuery.mock.calls.length, 1);
+
+      const call = mockWriteQuery.mock.calls[0]!;
+      const params = call[1] as unknown[];
+      assert.equal(params[1], 'WEBHOOK_RETRY_POLICY_UPDATED');
+      assert.equal(params[2], 'dev-retry-1');
+
+      const details = JSON.parse(params[8] as string);
+      assert.ok(details.before);
+      assert.ok(details.after);
+    });
+  });
+
+  describe('DELETE /api/webhooks/:developerId', () => {
+    it('persists an audit row for webhook deletion with before state', async () => {
+      WebhookStore.register({
+        developerId: 'dev-delete-1',
+        url: 'https://example.com/webhook',
+        events: ['new_api_call'],
+        secret_current: 'secret-key-at-least-32-chars-long',
+        createdAt: new Date(),
+      });
+
+      const response = await request(app)
+        .delete('/api/webhooks/dev-delete-1');
+
+      assert.equal(response.status, 200);
+      assert.equal(mockWriteQuery.mock.calls.length, 1);
+
+      const call = mockWriteQuery.mock.calls[0]!;
+      const params = call[1] as unknown[];
+      assert.equal(params[1], 'WEBHOOK_DELETED');
+      assert.equal(params[2], 'dev-delete-1');
+
+      const details = JSON.parse(params[8] as string);
+      assert.ok(details.before);
+      assert.equal(details.before.developerId, 'dev-delete-1');
+      assert.equal(details.after, undefined);
+    });
+
+    it('persists an audit row with null before when webhook does not exist', async () => {
+      const response = await request(app)
+        .delete('/api/webhooks/dev-delete-nonexistent');
+
+      assert.equal(response.status, 200);
+      assert.equal(mockWriteQuery.mock.calls.length, 1);
+
+      const call = mockWriteQuery.mock.calls[0]!;
+      const params = call[1] as unknown[];
+      assert.equal(params[1], 'WEBHOOK_DELETED');
+      assert.equal(params[2], 'dev-delete-nonexistent');
+    });
+  });
+
+  describe('GET /api/webhooks/:developerId — non-state-changing', () => {
+    it('does NOT persist an audit row for GET requests', async () => {
+      WebhookStore.register({
+        developerId: 'dev-get-1',
+        url: 'https://example.com/webhook',
+        events: ['new_api_call'],
+        createdAt: new Date(),
+      });
+
+      const response = await request(app)
+        .get('/api/webhooks/dev-get-1');
+
+      assert.equal(response.status, 200);
+      assert.equal(mockWriteQuery.mock.calls.length, 0);
+    });
+  });
+});

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,0 +1,297 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import express from 'express';
+import crypto from 'crypto';
+import { validateWebhookUrl, WebhookValidationError } from '../webhooks/webhook.validator.js';
+import { WebhookStore } from '../webhooks/webhook.store.js';
+import { WebhookEventType, type RetryPolicy } from '../webhooks/webhook.types.js';
+import {
+  captureRawBody,
+  verifyWebhookSignature,
+} from '../webhooks/webhook.signature.js';
+import { AppError, BadRequestError, NotFoundError } from '../errors/index.js';
+import { createRestRateLimitMiddleware } from '../middleware/restRateLimit.js';
+import { config } from '../config/index.js';
+import { logger } from '../logger.js';
+import { validateRetryPolicy } from '../services/webhookRetry.js';
+import { appendAuditRow } from '../services/auditService.js';
+
+const router = Router();
+
+const webhookMgmtRateLimit = createRestRateLimitMiddleware(config.webhookRateLimit);
+
+const VALID_EVENTS: WebhookEventType[] = [
+  'new_api_call',
+  'settlement_completed',
+  'low_balance_alert',
+];
+
+function generateWebhookSecret(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+function sanitizeConfig(
+  config: Record<string, unknown> | undefined,
+): Record<string, unknown> | null {
+  if (!config) return null;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (key === 'secret' || key === 'secret_current' || key === 'secret_previous') {
+      sanitized[key] = maskSecret(typeof value === 'string' ? value : undefined);
+    } else if (key === 'previous_expires_at' && value instanceof Date) {
+      sanitized[key] = value.toISOString();
+    } else if (typeof value === 'function') {
+      sanitized[key] = '[Function]';
+    } else {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+function maskSecret(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.length <= 8) return '****';
+  return value.slice(0, 4) + '****' + value.slice(-4);
+}
+
+async function auditStateChange(
+  req: Request,
+  action: string,
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown> | null,
+): Promise<void> {
+  const actor = req.params.developerId ?? req.body.developerId;
+  const auditContext = (req as Request & { auditContext?: unknown }).auditContext as
+    | { clientIp?: string; userAgent?: string; correlationId?: string; bodyHash?: string; tenantId?: string | null }
+    | undefined;
+
+  try {
+    await appendAuditRow({
+      actor,
+      action,
+      before,
+      after,
+      tenantId: auditContext?.tenantId ?? null,
+      correlationId: auditContext?.correlationId ?? null,
+      clientIp: auditContext?.clientIp ?? null,
+      userAgent: auditContext?.userAgent ?? null,
+      bodyHash: auditContext?.bodyHash ?? null,
+    });
+  } catch (err) {
+    logger.error('Failed to persist audit row', { error: err, action, actor });
+  }
+}
+
+// POST /api/webhooks — Register a webhook
+router.post('/', webhookMgmtRateLimit, express.json(), async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { developerId, url, events, secret, retryPolicy } = req.body;
+
+    if (!developerId || !url || !Array.isArray(events) || events.length === 0) {
+      throw new BadRequestError(
+        'developerId, url, and a non-empty events array are required.',
+        'INVALID_WEBHOOK_REGISTRATION'
+      );
+    }
+
+    const invalidEvents = events.filter(
+      (e: string) => !VALID_EVENTS.includes(e as WebhookEventType)
+    );
+    if (invalidEvents.length > 0) {
+      throw new BadRequestError(
+        `Invalid event types: ${invalidEvents.join(', ')}. Valid: ${VALID_EVENTS.join(', ')}`,
+        'INVALID_WEBHOOK_EVENT_TYPES'
+      );
+    }
+
+    const validation = validateRetryPolicy(retryPolicy);
+    if (!validation.valid) {
+      throw new BadRequestError(
+        validation.error!,
+        'INVALID_RETRY_POLICY'
+      );
+    }
+
+    try {
+      await validateWebhookUrl(url);
+    } catch (err: unknown) {
+      if (err instanceof WebhookValidationError) {
+        throw new BadRequestError(err.message, 'INVALID_WEBHOOK_URL');
+      }
+
+      throw new AppError('URL validation failed.', 500, 'WEBHOOK_URL_VALIDATION_FAILED');
+    }
+
+    const before = WebhookStore.get(developerId) ? sanitizeConfig(WebhookStore.get(developerId) as unknown as Record<string, unknown>) : null;
+
+    WebhookStore.register({
+      developerId,
+      url,
+      events: events as WebhookEventType[],
+      secret_current: secret ?? undefined,
+      retryPolicy: retryPolicy as RetryPolicy | undefined,
+      createdAt: new Date(),
+    });
+
+    const after = sanitizeConfig(WebhookStore.get(developerId) as unknown as Record<string, unknown>);
+
+    await auditStateChange(req, 'WEBHOOK_REGISTERED', before, after);
+
+    res.status(201).json({
+      message: 'Webhook registered successfully.',
+      developerId,
+      url,
+      events,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/webhooks/:developerId — Get webhook config
+router.get('/:developerId', webhookMgmtRateLimit, (req: Request, res: Response) => {
+  const config = WebhookStore.get(req.params.developerId);
+  if (!config) {
+    throw new NotFoundError(
+      'No webhook registered for this developer.',
+      'WEBHOOK_NOT_FOUND'
+    );
+  }
+  const {
+    secret: _s,
+    secret_current: _sc,
+    secret_previous: _sp,
+    ...safeConfig
+  } = config;
+  return res.json(safeConfig);
+});
+
+// POST /api/webhooks/:developerId/rotate-secret — Rotate webhook signing secret
+router.post('/:developerId/rotate-secret', webhookMgmtRateLimit, (req: Request, res: Response) => {
+  const existing = WebhookStore.get(req.params.developerId);
+  if (!existing) {
+    throw new NotFoundError(
+      'No webhook registered for this developer.',
+      'WEBHOOK_NOT_FOUND'
+    );
+  }
+
+  const before = sanitizeConfig(existing as unknown as Record<string, unknown>);
+
+  const newSecret = generateWebhookSecret();
+  const previousExpiresAt = new Date(Date.now() + config.webhooks.secretRotationGraceMs);
+  const rotated = WebhookStore.rotateSecret(req.params.developerId, newSecret, previousExpiresAt);
+
+  if (!rotated) {
+    throw new NotFoundError(
+      'No webhook registered for this developer.',
+      'WEBHOOK_NOT_FOUND'
+    );
+  }
+
+  const after = sanitizeConfig(rotated as unknown as Record<string, unknown>);
+
+  logger.audit('WEBHOOK_SECRET_ROTATED', req.params.developerId, {
+    developerId: req.params.developerId,
+    previousExpiresAt: rotated.previous_expires_at?.toISOString(),
+    hadPreviousSecret: Boolean(existing.secret_current ?? existing.secret),
+  });
+
+  void auditStateChange(req, 'WEBHOOK_SECRET_ROTATED', before, after);
+
+  return res.status(200).json({
+    message: 'Webhook secret rotated successfully.',
+    developerId: req.params.developerId,
+    secret: newSecret,
+    previous_expires_at: rotated.previous_expires_at?.toISOString(),
+  });
+});
+
+// DELETE /api/webhooks/:developerId — Remove webhook
+router.delete('/:developerId', webhookMgmtRateLimit, async (req: Request, res: Response) => {
+const existing = WebhookStore.get(req.params.developerId);
+  const before = existing ? sanitizeConfig(existing as unknown as Record<string, unknown>) : null;
+
+  WebhookStore.delete(req.params.developerId);
+
+  await auditStateChange(req, 'WEBHOOK_DELETED', before, null);
+
+  return res.json({ message: 'Webhook removed.' });
+});
+
+// PATCH /api/webhooks/:developerId/retry-policy — Update retry policy for subscription
+router.patch('/:developerId/retry-policy', webhookMgmtRateLimit, (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { retryPolicy } = req.body;
+
+    const validation = validateRetryPolicy(retryPolicy);
+    if (!validation.valid) {
+      throw new BadRequestError(
+        validation.error!,
+        'INVALID_RETRY_POLICY'
+      );
+    }
+
+    const existing = WebhookStore.get(req.params.developerId);
+    const before = existing ? { retryPolicy: (existing as unknown as Record<string, unknown>).retryPolicy } : null;
+
+    const updated = WebhookStore.updateRetryPolicy(
+      req.params.developerId,
+      retryPolicy as RetryPolicy | undefined
+    );
+
+    if (!updated) {
+      throw new NotFoundError(
+        'No webhook registered for this developer.',
+        'WEBHOOK_NOT_FOUND'
+      );
+    }
+
+    const after = { retryPolicy: updated.retryPolicy };
+
+    logger.audit('WEBHOOK_RETRY_POLICY_UPDATED', req.params.developerId, {
+      developerId: req.params.developerId,
+      retryPolicy: updated.retryPolicy,
+    });
+
+    void auditStateChange(req, 'WEBHOOK_RETRY_POLICY_UPDATED', before, after);
+
+    const {
+      secret: _s,
+      secret_current: _sc,
+      secret_previous: _sp,
+      ...safeConfig
+    } = updated;
+
+    return res.status(200).json({
+      message: 'Webhook retry policy updated successfully.',
+      ...safeConfig,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post(
+  '/deliver/:developerId',
+  captureRawBody,
+  (req: Request & { webhookSecrets?: string[] }, res: Response, next) => {
+    const config = WebhookStore.get(req.params.developerId);
+    if (!config) {
+      next(new NotFoundError(
+        'No webhook registered for this developer.',
+        'WEBHOOK_NOT_FOUND'
+      ));
+      return;
+    }
+    req.webhookSecrets = WebhookStore.getActiveSecrets(config);
+    next();
+  },
+  verifyWebhookSignature,
+  express.json(),
+  (req: Request, res: Response) => {
+    return res.status(200).json({ message: 'Webhook delivery accepted.', body: req.body });
+  }
+);
+
+export default router;

--- a/src/services/auditService.test.ts
+++ b/src/services/auditService.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+
+jest.mock('../db.js', () => ({
+  writeQuery: jest.fn(),
+}));
+
+import { writeQuery } from '../db.js';
+import { appendAuditRow, type AuditRowInput } from './auditService.js';
+
+const mockWriteQuery = writeQuery as jest.MockedFunction<typeof writeQuery>;
+
+beforeEach(() => {
+  mockWriteQuery.mockResolvedValue({ rows: [] });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('appendAuditRow', () => {
+  const baseInput: AuditRowInput = {
+    actor: 'dev-123',
+    action: 'WEBHOOK_REGISTERED',
+    before: null,
+    after: { developerId: 'dev-123', url: 'https://example.com', events: ['new_api_call'] },
+  };
+
+  it('inserts a row with all required fields', async () => {
+    const result = await appendAuditRow(baseInput);
+
+    assert.ok(result.id);
+    assert.equal(result.actor, 'dev-123');
+    assert.equal(result.action, 'WEBHOOK_REGISTERED');
+    assert.ok(result.createdAt);
+  });
+
+  it('calls writeQuery with correct SQL and params', async () => {
+    await appendAuditRow(baseInput);
+
+    assert.equal(mockWriteQuery.mock.calls.length, 1);
+    const call = mockWriteQuery.mock.calls[0]!;
+    const sql = call[0] as string;
+    const params = call![1];
+    assert.ok(sql.includes('INSERT INTO audit_logs'));
+    assert.equal(params[1]!, 'WEBHOOK_REGISTERED');
+    assert.equal(params[2]!, 'dev-123');
+  });
+
+  it('includes tenantId when provided', async () => {
+    await appendAuditRow({ ...baseInput, tenantId: 'tenant-abc' });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    assert.equal(params[3], 'tenant-abc');
+  });
+
+  it('passes null for tenantId when not provided', async () => {
+    await appendAuditRow(baseInput);
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    assert.equal(params[3], null);
+  });
+
+  it('includes correlationId when provided', async () => {
+    await appendAuditRow({ ...baseInput, correlationId: 'req-xyz' });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    assert.equal(params[6], 'req-xyz');
+  });
+
+  it('includes clientIp when provided', async () => {
+    await appendAuditRow({ ...baseInput, clientIp: '192.168.1.1' });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    assert.equal(params[4], '192.168.1.1');
+  });
+
+  it('includes userAgent when provided', async () => {
+    await appendAuditRow({ ...baseInput, userAgent: 'Mozilla/5.0' });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    assert.equal(params[5], 'Mozilla/5.0');
+  });
+
+  it('includes bodyHash when provided', async () => {
+    await appendAuditRow({ ...baseInput, bodyHash: 'abc123' });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    assert.equal(params[7], 'abc123');
+  });
+
+  it('serializes details JSON with before and after', async () => {
+    await appendAuditRow(baseInput);
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    const details = JSON.parse(params[8] as string);
+    assert.ok(details.before);
+    assert.ok(details.after);
+    assert.equal(details.after.developerId, 'dev-123');
+  });
+
+  it('masks secret_current in before/after details', async () => {
+    await appendAuditRow({
+      ...baseInput,
+      before: { secret_current: 'sk_live_abc123def456', url: 'https://example.com' },
+      after: { secret_current: 'sk_live_xyz789abc012', url: 'https://example.com' },
+    });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    const details = JSON.parse(params[8] as string);
+    assert.equal(details.before.secret_current, 'sk_l****c012');
+    assert.equal(details.after.secret_current, 'sk_l****c012');
+  });
+
+  it('masks secret in before/after details', async () => {
+    await appendAuditRow({
+      ...baseInput,
+      before: { secret: 'sk_live_abc123def456' },
+      after: { secret: 'sk_live_xyz789abc012' },
+    });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    const details = JSON.parse(params[8] as string);
+    assert.equal(details.before.secret, 'sk_l****f456');
+    assert.equal(details.after.secret, 'sk_l****c012');
+  });
+
+  it('handles short secrets by masking entirely', async () => {
+    await appendAuditRow({
+      ...baseInput,
+      before: { secret_current: 'short' },
+      after: { secret_current: 'short' },
+    });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    const details = JSON.parse(params[8] as string);
+    assert.equal(details.before.secret_current, '****');
+    assert.equal(details.after.secret_current, '****');
+  });
+
+  it('returns the row with id, createdAt, and all input fields', async () => {
+    const result = await appendAuditRow(baseInput);
+
+    assert.ok(result.id);
+    assert.ok(result.createdAt);
+    assert.equal(result.actor, 'dev-123');
+    assert.equal(result.action, 'WEBHOOK_REGISTERED');
+    assert.equal(result.before, null);
+    assert.deepEqual(result.after, { developerId: 'dev-123', url: 'https://example.com', events: ['new_api_call'] });
+  });
+
+  it('includes null fields when before and after are both null', async () => {
+    await appendAuditRow({
+      actor: 'dev-123',
+      action: 'WEBHOOK_DELETED',
+      before: null,
+      after: null,
+    });
+
+    const call = mockWriteQuery.mock.calls[0]!;
+    const params = call[1]!;
+    const details = JSON.parse(params[8] as string);
+    assert.equal(details.before, undefined);
+    assert.equal(details.after, undefined);
+  });
+});

--- a/src/services/auditService.ts
+++ b/src/services/auditService.ts
@@ -1,0 +1,109 @@
+import { v4 as uuidv4 } from 'uuid';
+import { writeQuery } from '../db.js';
+
+export interface AuditRowInput {
+  actor: string;
+  action: string;
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  tenantId?: string | null;
+  correlationId?: string | null;
+  clientIp?: string | null;
+  userAgent?: string | null;
+  bodyHash?: string | null;
+}
+
+export interface AuditRow extends AuditRowInput {
+  id: string;
+  createdAt: string;
+}
+
+function maskSecret(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.length <= 8) return '****';
+  return value.slice(0, 4) + '****' + value.slice(-4);
+}
+
+function sanitizeWebhookConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (key === 'secret' || key === 'secret_current' || key === 'secret_previous') {
+      sanitized[key] = maskSecret(typeof value === 'string' ? value : undefined);
+    } else if (key === 'previous_expires_at' && value instanceof Date) {
+      sanitized[key] = value.toISOString();
+    } else if (typeof value === 'function') {
+      sanitized[key] = '[Function]';
+    } else {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+export async function appendAuditRow(input: AuditRowInput): Promise<AuditRow> {
+  const id = uuidv4();
+  const now = new Date().toISOString();
+
+  const details: Record<string, unknown> = {};
+
+  if (input.before !== null && input.before !== undefined) {
+    details.before = sanitizeWebhookConfig(input.before);
+  }
+
+  if (input.after !== null && input.after !== undefined) {
+    details.after = sanitizeWebhookConfig(input.after);
+  }
+
+  if (input.tenantId) {
+    details.tenantId = input.tenantId;
+  }
+
+  if (input.clientIp) {
+    details.clientIp = input.clientIp;
+  }
+
+  if (input.userAgent) {
+    details.userAgent = input.userAgent;
+  }
+
+  if (input.bodyHash) {
+    details.bodyHash = input.bodyHash;
+  }
+
+  if (input.correlationId) {
+    details.correlationId = input.correlationId;
+  }
+
+  await writeQuery(
+    `
+      INSERT INTO audit_logs (id, event, actor, tenant_id, client_ip, user_agent, correlation_id, body_hash, details, created_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    `,
+    [
+      id,
+      input.action,
+      input.actor,
+      input.tenantId ?? null,
+      input.clientIp ?? null,
+      input.userAgent ?? null,
+      input.correlationId ?? null,
+      input.bodyHash ?? null,
+      JSON.stringify(details),
+      now,
+    ],
+  );
+
+  return {
+    id,
+    createdAt: now,
+    actor: input.actor,
+    action: input.action,
+    before: input.before,
+    after: input.after,
+    tenantId: input.tenantId ?? null,
+    correlationId: input.correlationId ?? null,
+    clientIp: input.clientIp ?? null,
+    userAgent: input.userAgent ?? null,
+    bodyHash: input.bodyHash ?? null,
+  };
+}

--- a/src/webhooks/webhook.types.ts
+++ b/src/webhooks/webhook.types.ts
@@ -5,6 +5,16 @@ export type WebhookEventType =
     | 'quota.threshold.reached'
     | 'invoice_created';
 
+export interface RetryPolicy {
+  maxRetries?: number;
+  baseDelayMs?: number;
+}
+
+export const DEFAULT_RETRY_POLICY: RetryPolicy = {
+  maxRetries: 3,
+  baseDelayMs: 1000,
+};
+
 export interface WebhookConfig {
     developerId: string;
     url: string;


### PR DESCRIPTION
- Add src/services/auditService.ts with appendAuditRow() that persists audit rows (actor, action, before/after) to the audit_logs table
- Add src/routes/webhooks.ts with audit logging integrated for all state-changing webhook operations: registration, secret rotation, retry policy update, and deletion
- Mount webhooks router in src/app.ts and src/index.ts
- Add INVALID_RETRY_POLICY error code to src/errors/codes.ts
- Add RetryPolicy type and DEFAULT_RETRY_POLICY to webhook.types.ts
- Add focused tests for audit service and webhook route audit persistence

Closes #898