### PR TITLE
feat: security header sweep for /api/exports #885

### DIFF
--- a/docs/exports-security-headers.md
+++ b/docs/exports-security-headers.md
@@ -1,0 +1,22 @@
+# Security headers on `/api/exports`
+
+`GET /api/exports` (and every other response from that router) sets the following
+headers via `securityHeadersMiddleware` (`src/middleware/securityHeaders.ts`):
+
+| Header | Default value |
+| --- | --- |
+| `Content-Security-Policy` | `default-src 'self'; frame-ancestors 'none'; object-src 'none'` |
+| `X-Content-Type-Options` | `nosniff` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+
+Headers are applied at the router level (`router.use(...)`) so they appear on
+both successful `200` responses and error responses (`401` / `403` / `400`).
+
+The repo mounts this surface at **`/api/exports`** (plural). There is no
+singular `/api/export` route.
+
+## Related
+
+- Middleware: `src/middleware/securityHeaders.ts`
+- Route: `src/routes/exports.ts`
+- Tests: `src/routes/exports.test.ts` (`security headers` describe block)

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -28,6 +28,20 @@ const DEFAULT_CONTENT_TYPE_OPTIONS = 'nosniff';
 const DEFAULT_REFERRER_POLICY = 'strict-origin-when-cross-origin';
 
 /**
+ * Audit-route CSP (slightly stricter script/frame directives).
+ * Kept as named exports so admin audit routes and their unit tests remain stable.
+ */
+export const AUDIT_CSP_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "object-src 'none'",
+  "frame-src 'none'",
+].join('; ');
+
+export const AUDIT_X_CONTENT_TYPE_OPTIONS = DEFAULT_CONTENT_TYPE_OPTIONS;
+export const AUDIT_REFERRER_POLICY = DEFAULT_REFERRER_POLICY;
+
+/**
  * Creates security header middleware enforcing CSP, X-Content-Type-Options,
  * and Referrer-Policy on all HTTP responses.
  *
@@ -38,7 +52,7 @@ const DEFAULT_REFERRER_POLICY = 'strict-origin-when-cross-origin';
  * @returns Express middleware function
  */
 export function createSecurityHeadersMiddleware(
-  options: SecurityHeadersOptions = {}
+  options: SecurityHeadersOptions = {},
 ): (req: Request, res: Response, next: NextFunction) => void {
   const csp = options.contentSecurityPolicy ?? DEFAULT_CSP;
   const contentTypeOptions = options.contentTypeOptions ?? DEFAULT_CONTENT_TYPE_OPTIONS;
@@ -49,12 +63,18 @@ export function createSecurityHeadersMiddleware(
     res.setHeader('X-Content-Type-Options', contentTypeOptions);
     res.setHeader('Referrer-Policy', referrerPolicy);
 
-    const requestId = getRequestId(req as Request & { headers: Record<string, string | string[] | undefined> });
-    logger.info('[security-headers] applied headers to response', {
-      requestId,
-      path: req.path,
-      method: req.method,
-    });
+    try {
+      const requestId = getRequestId(
+        req as Request & { headers: Record<string, string | string[] | undefined> },
+      );
+      logger.info('[security-headers] applied headers to response', {
+        requestId,
+        path: req.path,
+        method: req.method,
+      });
+    } catch {
+      // Unit tests may pass a minimal req stub without headers — headers still apply.
+    }
 
     next();
   };
@@ -62,5 +82,15 @@ export function createSecurityHeadersMiddleware(
 
 /**
  * Standard security header middleware instance with default policy headers.
+ * Use on public API surfaces such as `/api/exports` and `/api/webhooks`.
  */
 export const securityHeadersMiddleware = createSecurityHeadersMiddleware();
+
+/**
+ * Alias used by admin audit routes — applies the audit CSP profile.
+ */
+export const securityHeaders = createSecurityHeadersMiddleware({
+  contentSecurityPolicy: AUDIT_CSP_POLICY,
+  contentTypeOptions: AUDIT_X_CONTENT_TYPE_OPTIONS,
+  referrerPolicy: AUDIT_REFERRER_POLICY,
+});

--- a/src/routes/exports.test.ts
+++ b/src/routes/exports.test.ts
@@ -200,4 +200,44 @@ describe('GET /api/exports', () => {
     expect(response.body).toHaveProperty('success');
     expect(response.body.success).toBe(false);
   });
+
+  describe('security headers', () => {
+    const expectedCsp = "default-src 'self'; frame-ancestors 'none'; object-src 'none'";
+
+    it('sets CSP, X-Content-Type-Options, and Referrer-Policy on 200 responses', async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .get('/api/exports')
+        .set('x-user-id', 'user-1');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-security-policy']).toBe(expectedCsp);
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+      expect(response.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    });
+
+    it('sets the same security headers on 401 error responses', async () => {
+      const app = createTestApp();
+      const response = await request(app).get('/api/exports');
+
+      expect(response.status).toBe(401);
+      expect(response.headers['content-security-policy']).toBe(expectedCsp);
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+      expect(response.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    });
+
+    it('sets the same security headers on 403 error responses', async () => {
+      const app = createTestApp();
+      mockDeveloperRepository.findByUserId.mockResolvedValueOnce(undefined);
+
+      const response = await request(app)
+        .get('/api/exports')
+        .set('x-user-id', 'user-no-profile');
+
+      expect(response.status).toBe(403);
+      expect(response.headers['content-security-policy']).toBe(expectedCsp);
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+      expect(response.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    });
+  });
 });

--- a/src/routes/exports.ts
+++ b/src/routes/exports.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
 import { validate } from '../middleware/validate.js';
+import { securityHeadersMiddleware } from '../middleware/securityHeaders.js';
 import { ForbiddenError, UnauthorizedError } from '../errors/index.js';
 import type { ReportExporterService } from '../services/reportExporter.js';
 import type { DeveloperRepository } from '../repositories/developerRepository.js';
@@ -38,6 +39,10 @@ export function createExportsRouter(deps: ExportsRouterDeps): Router {
   const router = Router();
   const { reportExporterService, developerRepository } = deps;
 
+  // Apply CSP, X-Content-Type-Options, and Referrer-Policy on every /api/exports response
+  // (success and error paths) — GrantFox FWC26 security header sweep.
+  router.use(securityHeadersMiddleware);
+
   /**
    * GET /api/exports
    *
@@ -51,6 +56,7 @@ export function createExportsRouter(deps: ExportsRouterDeps): Router {
    *   format     - Filter by format: 'csv' or 'json' (optional)
    *
    * Security: Requires authentication. Non-admin users can only access their own exports.
+   * Responses always include Content-Security-Policy, X-Content-Type-Options, and Referrer-Policy.
    *
    * @example Request
    * GET /api/exports?limit=10&offset=0


### PR DESCRIPTION
## Overview

This PR wires **Content-Security-Policy**, **X-Content-Type-Options**, and **Referrer-Policy** on every `/api/exports` response (both successful `200` and error paths), meeting the GrantFox FWC26 security header sweep requirement.

## Related Issue

Closes #885

## Changes

### Security headers on `/api/exports`

* **[MODIFY]** `src/middleware/securityHeaders.ts`
  * Restores the named-exports (`AUDIT_CSP_POLICY`, `securityHeaders`) needed by `src/routes/admin/audit.ts` while keeping the newer `createSecurityHeadersMiddleware` / `securityHeadersMiddleware` API.
  * Made `getRequestId` logging defensive so isolated unit tests pass.

* **[MODIFY]** `src/routes/exports.ts`
  * Added `router.use(securityHeadersMiddleware)` before any route handler so headers appear on all response paths.
  * Updated docstring to mention security headers.

* **[MODIFY]** `src/routes/exports.test.ts`
  * Added `security headers` describe block: asserts CSP, `nosniff`, `referrer-policy` on `200`, `401`, and `403` responses.

* **[ADD]** `docs/exports-security-headers.md`

## Verification Results

```
npx jest --runInBand --forceExit src/middleware/securityHeaders.test.ts src/routes/exports.test.ts -t "security headers|securityHeaders"
✅ 8/8 passed (2 suites)

npx eslint src/middleware/securityHeaders.ts src/routes/exports.ts src/routes/exports.test.ts
✅ 0 errors, 3 pre-existing warnings
```

| Acceptance Criteria | Status |
| --- | --- |
| Security headers set on `/api/export` (actually `/api/exports`) | ✅ CSP, X-Content-Type-Options, Referrer-Policy on all responses |
| Focused tests added | ✅ Headers asserted on 200, 401, 403 |
| Docs updated | ✅ `docs/exports-security-headers.md` |