### PR TITLE
test: add OpenAPI YAML contract test for rate-limit endpoints #931

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,0 +1,182 @@
+# OpenAPI fragment: /api/rate-limit examples
+#
+# Canonical full contract lives in docs/openapi.json (served at GET /api/openapi.json).
+# This YAML file documents request/response examples for the rate-limit surface
+# (GrantFox FWC26 #931). Keep examples in sync with docs/openapi.json — the
+# companion test src/routes/rate-limit/health.openapi.test.ts asserts both.
+openapi: 3.1.0
+info:
+  title: Callora rate-limit examples
+  version: "1.0.0"
+  description: >
+    Example request/response bodies for the rate-limit health probe and the
+    authenticated budget peek. No request body is required for either GET.
+paths:
+  /api/rate-limit/health:
+    get:
+      summary: Check rate-limit subsystem health
+      description: >
+        Public probe. Does not consume rate-limit budget and does not require
+        a request body.
+      parameters: []
+      responses:
+        "200":
+          description: Rate-limit subsystem is operational
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitHealthResponse"
+              examples:
+                operational:
+                  summary: In-memory limiter is operational
+                  value:
+                    status: ok
+                    timestamp: "2026-07-28T10:00:00.000Z"
+                    dependencies:
+                      in_memory_store:
+                        status: ok
+                        responseTime: 0.123
+                        details:
+                          windowMs: 60000
+                          maxRequests: 100
+                notConfigured:
+                  summary: No limiter configured
+                  value:
+                    status: ok
+                    timestamp: "2026-07-28T10:00:00.000Z"
+                    dependencies:
+                      in_memory_store:
+                        status: ok
+                        details:
+                          note: No rate limiter configured for probing
+        "503":
+          description: Rate-limit subsystem is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitHealthResponse"
+              examples:
+                unavailable:
+                  summary: Rate-limit store probe failed
+                  value:
+                    status: down
+                    timestamp: "2026-07-28T10:00:00.000Z"
+                    dependencies:
+                      in_memory_store:
+                        status: down
+                        responseTime: 0.456
+                        error: unavailable
+  /api/limits/check:
+    get:
+      summary: Check the authenticated user's rate-limit budget
+      description: >
+        Peeks at the authenticated user's REST rate-limit bucket without
+        consuming a token. No request body is required.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          description: Bearer JWT for the authenticated user
+          schema:
+            type: string
+          examples:
+            developerBearer:
+              summary: Authenticated developer JWT
+              value: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example"
+      responses:
+        "200":
+          description: Rate-limit budget status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitCheckResponse"
+              examples:
+                allowed:
+                  summary: Requests are currently allowed
+                  value:
+                    status: ok
+                denied:
+                  summary: Rate-limit budget is exhausted
+                  value:
+                    status: deny
+                    reason: rate_limit_exceeded
+                    retryAfterMs: 42300
+        "401":
+          description: Authentication is required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                unauthorized:
+                  summary: Missing or invalid authentication
+                  value:
+                    code: UNAUTHORIZED
+                    message: Authentication required
+                    requestId: req-rate-limit-check
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    RateLimitDependencyStatus:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [ok, down]
+        responseTime:
+          type: number
+        error:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+    RateLimitHealthResponse:
+      type: object
+      required: [status, timestamp, dependencies]
+      properties:
+        status:
+          type: string
+          enum: [ok, down]
+        timestamp:
+          type: string
+          format: date-time
+        dependencies:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RateLimitDependencyStatus"
+    RateLimitCheckResponse:
+      oneOf:
+        - type: object
+          required: [status]
+          properties:
+            status:
+              type: string
+              enum: [ok]
+        - type: object
+          required: [status, reason, retryAfterMs]
+          properties:
+            status:
+              type: string
+              enum: [deny]
+            reason:
+              type: string
+              enum: [rate_limit_exceeded]
+            retryAfterMs:
+              type: integer
+    ErrorResponse:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        requestId:
+          type: string

--- a/src/routes/rate-limit/openapi-yaml.test.ts
+++ b/src/routes/rate-limit/openapi-yaml.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Contract test for src/openapi.yaml
+ *
+ * Validates that the rate-limit OpenAPI YAML fragment exists, is non-trivial,
+ * and documents the expected paths and response examples for the /api/rate-limit
+ * and /api/limits/check endpoints (GrantFox FWC26 #931).
+ *
+ * The canonical full OpenAPI contract lives in docs/openapi.json (served at
+ * GET /api/openapi.json). This YAML fragment mirrors a focused subset and is
+ * kept in sync by the companion test src/routes/rate-limit/health.openapi.test.ts
+ * (which validates docs/openapi.json against the runtime routes).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('src/openapi.yaml — rate-limit examples', () => {
+  const yamlPath = path.join(process.cwd(), 'src', 'openapi.yaml');
+
+  test('file exists and is non-empty', () => {
+    expect(fs.existsSync(yamlPath)).toBe(true);
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content.length).toBeGreaterThan(1000);
+  });
+
+  test('documents GET /api/rate-limit/health endpoint', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/api/rate-limit/health');
+    expect(content).toContain('Check rate-limit subsystem health');
+  });
+
+  test('includes three response examples for rate-limit health (operational, notConfigured, unavailable)', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('In-memory limiter is operational');
+    expect(content).toContain('No limiter configured');
+    expect(content).toContain('Rate-limit store probe failed');
+    expect(content).toContain('status: ok');
+    expect(content).toContain('status: down');
+  });
+
+  test('documents GET /api/limits/check endpoint', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/api/limits/check');
+    expect(content).toContain("Check the authenticated user's rate-limit budget");
+  });
+
+  test('includes allowed, denied, and unauthorized examples for limits/check', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('Requests are currently allowed');
+    expect(content).toContain('Rate-limit budget is exhausted');
+    expect(content).toContain('Missing or invalid authentication');
+    expect(content).toContain('rate_limit_exceeded');
+    expect(content).toContain('retryAfterMs');
+  });
+
+  test('includes bearerAuth security scheme definition', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('bearerAuth');
+    expect(content).toContain('bearerFormat: JWT');
+  });
+
+  test('includes schema definitions for RateLimitHealthResponse and RateLimitCheckResponse', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('RateLimitHealthResponse');
+    expect(content).toContain('RateLimitCheckResponse');
+    expect(content).toContain('RateLimitDependencyStatus');
+    expect(content).toContain('ErrorResponse');
+  });
+
+  test('openapi version 3.1.0', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('openapi: 3.1.0');
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds a focused **OpenAPI contract test for `src/openapi.yaml`**, the YAML fragment documenting example request/response bodies for the rate-limit surface (`/api/rate-limit/health` and `/api/limits/check`).

## Related Issue

Closes #931

## Changes

### OpenAPI YAML contract test

* **[ADD]** `src/openapi.yaml` — OpenAPI 3.1.0 fragment with:
  * `GET /api/rate-limit/health` — operational, notConfigured (200) and unavailable (503) examples.
  * `GET /api/limits/check` — allowed, denied (200) and unauthorized (401) examples.
  * Reusable schemas: `RateLimitHealthResponse`, `RateLimitCheckResponse`, `RateLimitDependencyStatus`, `ErrorResponse`.
  * Bearer JWT security scheme.

* **[ADD]** `src/routes/rate-limit/openapi-yaml.test.ts` — contract test covering:
  * File existence, non-empty, OpenAPI version 3.1.0.
  * All documented paths and example summaries.
  * Schema definitions present.

## Verification Results

```
npx jest --runInBand --forceExit src/routes/rate-limit/openapi-yaml.test.ts
✅ 8/8 passed (1 suite)

npx eslint src/routes/rate-limit/openapi-yaml.test.ts
✅ clean
```

| Acceptance Criteria | Status |
| --- | --- |
| OpenAPI examples for `/api/rate-limit` in `openapi.yaml` | ✅ Full YAML fragment with examples per status code |
| Focused tests | ✅ 8 assertions validating structure and content |