### PR TITLE
enforce CORS allowlist on /api/subscriptions (b#035)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,28 @@ CORS_ALLOWED_ORIGINS=http://localhost:5173
 MAINTENANCE_CORS_ALLOWED_ORIGINS=
 
 # -----------------------------------------------------------------------------
+# Subscription route CORS allowlist (issue #b035)
+#
+# Comma-separated list of origins permitted to call the /api/subscriptions
+# endpoints (deny by default; preflight cached for 10 minutes via
+# Access-Control-Max-Age).
+#
+# Set to an empty string (the default) to deny ALL cross-origin requests
+# to /api/subscriptions. In production you MUST set this to the origins
+# of the dashboards that are allowed to manage subscriptions.
+#
+# Example:
+#   SUBSCRIPTION_CORS_ALLOWED_ORIGINS=https://app.callora.com,https://admin.callora.com
+#
+# Notes:
+#   • Whitespace around entries is trimmed; duplicates are removed.
+#   • Origins are matched exactly (no wildcards / no scheme-less matches).
+#   • The middleware is mounted lazily so changing this variable requires
+#     a process restart to take effect.
+# -----------------------------------------------------------------------------
+SUBSCRIPTION_CORS_ALLOWED_ORIGINS=
+
+# -----------------------------------------------------------------------------
 # Soroban RPC (optional — set SOROBAN_RPC_ENABLED=true to activate)
 # -----------------------------------------------------------------------------
 SOROBAN_RPC_ENABLED=false

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -166,6 +166,17 @@ export const envSchema = z
     // CORS
     CORS_ALLOWED_ORIGINS: z.string().default("http://localhost:5173"),
 
+    // Subscription CORS allowlist (comma-separated origins; deny by default when empty).
+    //
+    // This entry mirrors the pattern used by MAINTENANCE_CORS_ALLOWED_ORIGINS:
+    // the runtime parser lives in
+    // {@link createSubscriptionCorsMiddleware} (src/middleware/cors.ts), which
+    // reads `process.env` lazily so tests that mutate the env after module
+    // load still work. If this entry is transformed into an array here, the
+    // middleware will continue to read the raw string and the two sources of
+    // truth will silently diverge.
+    SUBSCRIPTION_CORS_ALLOWED_ORIGINS: z.string().default(""),
+
     // Maintenance CORS allowlist (comma-separated origins; deny by default when empty).
     //
     // This entry is intentionally left as a raw string — it exists in the

--- a/src/middleware/cors.test.ts
+++ b/src/middleware/cors.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import {
   createCorsAllowlistMiddleware,
   createMaintenanceCorsMiddleware,
+  createSubscriptionCorsMiddleware,
   parseAllowedOrigins,
   CORS_ERROR_CODE,
 } from './cors.js';
@@ -322,5 +323,93 @@ describe('createMaintenanceCorsMiddleware', () => {
       .get('/m')
       .set('Origin', 'https://allowed.example.com');
     expect(res.headers['access-control-allow-credentials']).toBe('true');
+  });
+});
+
+describe('createSubscriptionCorsMiddleware', () => {
+  const originalEnv = process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS = originalEnv;
+    }
+  });
+
+  it('denies by default when SUBSCRIPTION_CORS_ALLOWED_ORIGINS is unset', async () => {
+    delete process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS;
+    const app = express();
+    app.use(
+      '/s',
+      createSubscriptionCorsMiddleware(),
+      (_req, res) => res.json({ ok: true }),
+    );
+    const res = await request(app)
+      .get('/s')
+      .set('Origin', 'https://app.example.com');
+    expect(res.status).toBe(403);
+  });
+
+  it('denies an origin not on the allowlist', async () => {
+    process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS =
+      'https://trusted.example.com';
+    const app = express();
+    app.use(
+      '/s',
+      createSubscriptionCorsMiddleware(),
+      (_req, res) => res.json({ ok: true }),
+    );
+    const res = await request(app)
+      .get('/s')
+      .set('Origin', 'https://evil.example.com');
+    expect(res.status).toBe(403);
+  });
+
+  it('allows an origin that is on the allowlist', async () => {
+    process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS =
+      'https://trusted.example.com,https://also-ok.example.com';
+    const app = express();
+    app.use(
+      '/s',
+      createSubscriptionCorsMiddleware(),
+      (_req, res) => res.json({ ok: true }),
+    );
+    const res = await request(app)
+      .get('/s')
+      .set('Origin', 'https://also-ok.example.com');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('caches the preflight result (Access-Control-Max-Age header set)', async () => {
+    process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS =
+      'https://trusted.example.com';
+    const app = express();
+    app.use(
+      '/s',
+      createSubscriptionCorsMiddleware(),
+      (_req, res) => res.json({ ok: true }),
+    );
+    const res = await request(app)
+      .options('/s')
+      .set('Origin', 'https://trusted.example.com');
+    expect(res.status).toBe(204);
+    expect(res.headers['access-control-max-age']).toBe('600');
+  });
+
+  it('does NOT set Access-Control-Allow-Credentials for subscription route', async () => {
+    process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS =
+      'https://trusted.example.com';
+    const app = express();
+    app.use(
+      '/s',
+      createSubscriptionCorsMiddleware(),
+      (_req, res) => res.json({ ok: true }),
+    );
+    const res = await request(app)
+      .get('/s')
+      .set('Origin', 'https://trusted.example.com');
+    expect(res.headers['access-control-allow-credentials']).toBeUndefined();
   });
 });

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -206,6 +206,55 @@ export function createCorsAllowlistMiddleware(
 }
 
 /**
+ * Subscription-route CORS middleware factory.
+ *
+ * Reads the `SUBSCRIPTION_CORS_ALLOWED_ORIGINS` environment variable on first
+ * use (lazy) so unit tests that mutate `process.env` after module load
+ * continue to work. The factory returns the same middleware instance on
+ * every subsequent request to avoid re-parsing the allowlist per request;
+ * to pick up runtime changes the operator must restart the process.
+ *
+ * NOTE: the matching schema entry in `src/config/env.ts` is intentionally
+ * left as a `z.string()` (no transform) — it is documentation-only. If a
+ * future maintainer attempts to transform it to `z.array(z.string())` in
+ * the schema, the runtime env read below will silently use the raw string
+ * and callers will see the old un-parsed value. Coordinate any schema
+ * changes with this middleware.
+ *
+ * Defaults to:
+ *  - `allowCredentials: false` — subscriptions authenticate via JWT in headers.
+ *  - `maxAgeSeconds: 600`      — 10 minute preflight cache.
+ *
+ * If `SUBSCRIPTION_CORS_ALLOWED_ORIGINS` is unset/empty every cross-origin
+ * request to the subscription route is denied (deny by default).
+ */
+export function createSubscriptionCorsMiddleware(): (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => void {
+  let middleware: ReturnType<typeof createCorsAllowlistMiddleware> | null =
+    null;
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!middleware) {
+      const allowedOrigins = parseAllowedOrigins(
+        process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS,
+      );
+      logger.info('[cors] subscription allowlist loaded', {
+        originCount: allowedOrigins.length,
+      });
+      middleware = createCorsAllowlistMiddleware({
+        allowedOrigins,
+        allowCredentials: false,
+        maxAgeSeconds: DEFAULT_MAX_AGE_SECONDS,
+      });
+    }
+    middleware(req, res, next);
+  };
+}
+
+/**
  * Maintenance-route CORS middleware factory.
  *
  * Reads the `MAINTENANCE_CORS_ALLOWED_ORIGINS` environment variable on first

--- a/src/routes/subscriptionRoutes.test.ts
+++ b/src/routes/subscriptionRoutes.test.ts
@@ -1,3 +1,5 @@
+process.env.SUBSCRIPTION_CORS_ALLOWED_ORIGINS = 'https://app.callora.com';
+
 import request from 'supertest';
 import express from 'express';
 import { createSubscriptionRouter } from './subscriptionRoutes.js';
@@ -7,6 +9,8 @@ import type { SubscriptionRepository } from '../repositories/subscriptionReposit
 import type { ApiRepository } from '../repositories/apiRepository.js';
 import type { DeveloperRepository } from '../repositories/developerRepository.js';
 import type { Api, Developer, Subscription } from '../db/schema.js';
+
+const TEST_ORIGIN = 'https://app.callora.com';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -144,7 +148,7 @@ function buildApp(
 describe('POST /api/subscriptions', () => {
   it('returns 401 when unauthenticated', async () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
-    const res = await request(app).post('/api/subscriptions').send({ api_id: 10 });
+    const res = await request(app).post('/api/subscriptions').set('Origin', TEST_ORIGIN).send({ api_id: 10 });
     expect(res.status).toBe(401);
   });
 
@@ -152,6 +156,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({});
     expect(res.status).toBe(400);
@@ -161,6 +166,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 'bad' });
     expect(res.status).toBe(400);
@@ -170,6 +176,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, metering_limit: 0 });
     expect(res.status).toBe(400);
@@ -180,6 +187,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), apiRepo, makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 99 });
     expect(res.status).toBe(404);
@@ -190,6 +198,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), apiRepo, makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 11 });
     expect(res.status).toBe(404);
@@ -200,6 +209,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-owner') // this user is the owner
       .send({ api_id: 10 });
     expect(res.status).toBe(403);
@@ -212,6 +222,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10 });
     expect(res.status).toBe(409);
@@ -223,6 +234,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, metering_limit: 500 });
     expect(res.status).toBe(201);
@@ -234,6 +246,7 @@ describe('POST /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, metering_limit: null });
     expect(res.status).toBe(201);
@@ -247,7 +260,7 @@ describe('POST /api/subscriptions', () => {
 describe('GET /api/subscriptions', () => {
   it('returns 401 when unauthenticated', async () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
-    const res = await request(app).get('/api/subscriptions');
+    const res = await request(app).get('/api/subscriptions').set('Origin', TEST_ORIGIN);
     expect(res.status).toBe(401);
   });
 
@@ -255,6 +268,7 @@ describe('GET /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .get('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual([]);
@@ -267,6 +281,7 @@ describe('GET /api/subscriptions', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .get('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(200);
     expect(res.body.total).toBe(2);
@@ -282,6 +297,7 @@ describe('GET /api/subscriptions', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .get('/api/subscriptions?status=active')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(200);
     expect(res.body.total).toBe(1);
@@ -292,6 +308,7 @@ describe('GET /api/subscriptions', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .get('/api/subscriptions?status=invalid')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(400);
   });
@@ -304,7 +321,7 @@ describe('GET /api/subscriptions', () => {
 describe('GET /api/subscriptions/:id', () => {
   it('returns 401 when unauthenticated', async () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
-    const res = await request(app).get('/api/subscriptions/sub-001');
+    const res = await request(app).get('/api/subscriptions/sub-001').set('Origin', TEST_ORIGIN);
     expect(res.status).toBe(401);
   });
 
@@ -312,6 +329,7 @@ describe('GET /api/subscriptions/:id', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .get('/api/subscriptions/does-not-exist')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(404);
   });
@@ -322,6 +340,7 @@ describe('GET /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .get('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(403);
   });
@@ -332,6 +351,7 @@ describe('GET /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .get('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(200);
     expect(res.body.id).toBe('sub-001');
@@ -347,7 +367,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
-      .send({ status: 'paused' });
+      .set('Origin', TEST_ORIGIN).send({ status: 'paused' });
     expect(res.status).toBe(401);
   });
 
@@ -355,6 +375,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/does-not-exist')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ status: 'paused' });
     expect(res.status).toBe(404);
@@ -366,6 +387,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ status: 'paused' });
     expect(res.status).toBe(403);
@@ -377,6 +399,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ status: 'active' });
     expect(res.status).toBe(400);
@@ -388,6 +411,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({});
     expect(res.status).toBe(400);
@@ -399,6 +423,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ metering_limit: -1 });
     expect(res.status).toBe(400);
@@ -414,6 +439,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ status: 'paused' });
     expect(res.status).toBe(200);
@@ -430,6 +456,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ metering_limit: 1000 });
     expect(res.status).toBe(200);
@@ -446,6 +473,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ metering_limit: null });
     expect(res.status).toBe(200);
@@ -460,7 +488,7 @@ describe('PATCH /api/subscriptions/:id', () => {
 describe('DELETE /api/subscriptions/:id', () => {
   it('returns 401 when unauthenticated', async () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
-    const res = await request(app).delete('/api/subscriptions/sub-001');
+    const res = await request(app).delete('/api/subscriptions/sub-001').set('Origin', TEST_ORIGIN);
     expect(res.status).toBe(401);
   });
 
@@ -468,6 +496,7 @@ describe('DELETE /api/subscriptions/:id', () => {
     const app = buildApp(makeSubscriptionRepo(), makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .delete('/api/subscriptions/does-not-exist')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(404);
   });
@@ -478,6 +507,7 @@ describe('DELETE /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .delete('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(403);
   });
@@ -488,6 +518,7 @@ describe('DELETE /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .delete('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(400);
   });
@@ -502,6 +533,7 @@ describe('DELETE /api/subscriptions/:id', () => {
     const app = buildApp(subRepo, makeApiRepo(), makeDeveloperRepo());
     const res = await request(app)
       .delete('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber');
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('cancelled');
@@ -522,6 +554,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: retryPolicy });
 
@@ -537,6 +570,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10 });
 
@@ -551,6 +585,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: null });
 
@@ -563,6 +598,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: { maxRetries: 11 } });
 
@@ -574,6 +610,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: { maxRetries: -1 } });
 
@@ -585,6 +622,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: { baseDelayMs: 99 } });
 
@@ -596,6 +634,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: { baseDelayMs: 60001 } });
 
@@ -607,6 +646,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: { maxRetries: 3.5 } });
 
@@ -618,6 +658,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: { baseDelayMs: 1000.5 } });
 
@@ -632,6 +673,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: retryPolicy });
 
@@ -646,6 +688,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: retryPolicy });
 
@@ -660,6 +703,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: retryPolicy });
 
@@ -671,6 +715,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     const res = await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: { maxRetries: 3, unknownField: 'x' } });
 
@@ -686,6 +731,7 @@ describe('POST /api/subscriptions — retry_policy', () => {
 
     await request(app)
       .post('/api/subscriptions')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ api_id: 10, retry_policy: retryPolicy });
 
@@ -708,6 +754,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ retry_policy: retryPolicy });
 
@@ -726,6 +773,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ retry_policy: null });
 
@@ -740,6 +788,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ retry_policy: { maxRetries: 15 } });
 
@@ -753,6 +802,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ retry_policy: { baseDelayMs: 50 } });
 
@@ -766,6 +816,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ retry_policy: { maxRetries: 2.5 } });
 
@@ -785,6 +836,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ retry_policy: retryPolicy });
 
@@ -806,6 +858,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ status: 'paused', retry_policy: retryPolicy });
 
@@ -827,6 +880,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ status: 'paused' });
 
@@ -842,6 +896,7 @@ describe('PATCH /api/subscriptions/:id — retry_policy', () => {
 
     const res = await request(app)
       .patch('/api/subscriptions/sub-001')
+      .set('Origin', TEST_ORIGIN)
       .set('x-user-id', 'user-subscriber')
       .send({ retry_policy: { maxRetries: 3, bogus: true } });
 

--- a/src/routes/subscriptionRoutes.ts
+++ b/src/routes/subscriptionRoutes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
 import { validate } from '../middleware/validate.js';
 import { createRateLimitMiddleware } from '../middleware/rateLimit.js';
+import { createSubscriptionCorsMiddleware } from '../middleware/cors.js';
 import {
   BadRequestError,
   ConflictError,
@@ -108,6 +109,11 @@ const listQuerySchema = z.object({
 export function createSubscriptionRouter(deps: SubscriptionRoutesDeps): Router {
   const router = Router();
   const { subscriptionRepository, apiRepository, developerRepository } = deps;
+
+  // Env-driven CORS allowlist (deny by default; preflight cached).
+  // Applied before auth so the preflight OPTIONS request can succeed
+  // without requiring credentials.
+  router.use(createSubscriptionCorsMiddleware());
 
   // Per-user token-bucket rate limit. Configurable via deps for testing.
   const subscriptionRateLimit = createRateLimitMiddleware({


### PR DESCRIPTION
Closes #900

---

Add SUBSCRIPTION_CORS_ALLOWED_ORIGINS env-driven CORS middleware to /api/subscriptions, matching the pattern established by the maintenance route CORS (MAINTENANCE_CORS_ALLOWED_ORIGINS).

- createSubscriptionCorsMiddleware() in src/middleware/cors.ts — exact-match allowlist, deny by default, 10-min preflight cache
- Applied as first middleware in createSubscriptionRouter()
- SUBSCRIPTION_CORS_ALLOWED_ORIGINS added to env schema & .env.example
- 5 new unit tests in cors.test.ts + Origin headers on all 56 existing subscription route tests

closes#900