### PR TITLE
feat: add correlation-id propagation on /api/refresh-token

### DIFF
--- a/src/routes/refresh-token.test.ts
+++ b/src/routes/refresh-token.test.ts
@@ -467,6 +467,63 @@ describe('GET /api/refresh-token', () => {
     );
   });
 
+  describe('X-Correlation-Id propagation (issue #957)', () => {
+    it('always sets X-Correlation-Id response header', async () => {
+      const repo = new MockRefreshTokenRepository([makeToken()]);
+      const app = buildApp(repo);
+
+      const res = await request(app).get('/api/refresh-token').set(authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['x-correlation-id']).toBeDefined();
+      expect(typeof res.headers['x-correlation-id']).toBe('string');
+      expect(res.headers['x-correlation-id'].length).toBeGreaterThan(0);
+    });
+
+    it('propagates client-supplied x-correlation-id in response header', async () => {
+      const repo = new MockRefreshTokenRepository([makeToken()]);
+      const app = buildApp(repo);
+      const clientCorrelationId = 'client-corr-test-abc-123';
+
+      const res = await request(app)
+        .get('/api/refresh-token')
+        .set(authHeader)
+        .set('x-correlation-id', clientCorrelationId);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['x-correlation-id']).toBe(clientCorrelationId);
+    });
+
+    it('includes correlation ID in structured log output', async () => {
+      const repo = new MockRefreshTokenRepository([makeToken()]);
+      const app = buildApp(repo);
+
+      await request(app).get('/api/refresh-token').set(authHeader);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        'LIST_REFRESH_TOKENS',
+        expect.objectContaining({
+          correlationId: expect.any(String),
+        }),
+      );
+    });
+
+    it('includes correlation ID in error log when repository fails', async () => {
+      const repo = new MockRefreshTokenRepository([]);
+      jest.spyOn(repo, 'listRefreshTokens').mockRejectedValue(new Error('DB error'));
+      const app = buildApp(repo);
+
+      await request(app).get('/api/refresh-token').set(authHeader);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to list refresh tokens',
+        expect.objectContaining({
+          correlationId: expect.any(String),
+        }),
+      );
+    });
+  });
+
   describe('Token-Bucket Rate Limiting (issue #930)', () => {
     it('allows requests within capacity and rejects with HTTP 429 when capacity is exceeded', async () => {
       const repo = new MockRefreshTokenRepository([makeToken()]);

--- a/src/routes/refresh-token.ts
+++ b/src/routes/refresh-token.ts
@@ -16,6 +16,7 @@
 
 import { Router } from 'express';
 import { requireAuth } from '../middleware/requireAuth.js';
+import { correlationMiddleware } from '../middleware/correlation.js';
 import { getClientIp, DEFAULT_PROXY_HEADERS } from '../lib/clientIp.js';
 import { encodeCursor, parseCursor } from '../lib/cursorPagination.js';
 import {
@@ -29,7 +30,6 @@ import {
 } from '../errors/index.js';
 import { ValidationError } from '../middleware/validate.js';
 import { logger } from '../logger.js';
-import { getRequestId } from '../utils/asyncContext.js';
 import type { RefreshTokenRepository } from '../repositories/refreshTokenRepository.js';
 import { DatabaseRefreshTokenRepository } from '../repositories/refreshTokenRepository.js';
 
@@ -49,6 +49,7 @@ export interface RefreshTokenRouterDeps {
 
 export function createRefreshTokenRouter(deps: RefreshTokenRouterDeps = {}): Router {
   const router = Router();
+  router.use(correlationMiddleware);
   const refreshTokenRepository = deps.refreshTokenRepository ?? new DatabaseRefreshTokenRepository();
   const rateLimitMiddleware =
     deps.rateLimitMiddleware ??
@@ -89,7 +90,7 @@ export function createRefreshTokenRouter(deps: RefreshTokenRouterDeps = {}): Rou
    *   }
    */
   router.get('/', rateLimitMiddleware, requireAuth, async (req, res, next) => {
-    const requestId = getRequestId();
+    const correlationId = (req as Request & { correlationId?: string }).correlationId;
     const userId = req.developerId || res.locals.authenticatedUser?.id;
 
     if (!userId) {
@@ -144,7 +145,7 @@ export function createRefreshTokenRouter(deps: RefreshTokenRouterDeps = {}): Rou
         userId,
         clientIp: getClientIp(req, TRUST_PROXY, DEFAULT_PROXY_HEADERS),
         userAgent: req.get('User-Agent'),
-        correlationId: requestId,
+        correlationId,
         limit,
         cursorProvided: rawCursor !== undefined,
         count: data.length,
@@ -166,7 +167,7 @@ export function createRefreshTokenRouter(deps: RefreshTokenRouterDeps = {}): Rou
       logger.error('Failed to list refresh tokens', {
         error,
         userId,
-        correlationId: requestId,
+        correlationId,
       });
       next(new InternalServerError('Failed to list refresh tokens'));
     }


### PR DESCRIPTION
## Summary

Adds X-Correlation-Id propagation to the GET /api/refresh-token endpoint by mounting the existing correlationMiddleware on the refresh-token router.

## Changes

- **src/routes/refresh-token.ts**: 
  - Imported and mounted correlationMiddleware at router level
  - Replaced getRequestId() from AsyncLocalStorage with eq.correlationId from the middleware
  - Structured logs now use the properly resolved correlation ID

- **src/routes/refresh-token.test.ts**:
  - Added test: always sets X-Correlation-Id response header
  - Added test: propagates client-supplied x-correlation-id header
  - Added test: includes correlation ID in structured log output
  - Added test: includes correlation ID in error log on repository failure

## Behaviour

The middleware resolves the correlation ID with the following priority:
1. Incoming x-correlation-id header (sanitised)
2. eq.id (set by global equestIdMiddleware)
3. Fresh UUID v4 (fallback)

The resolved value is set as the X-Correlation-Id response header and attached to eq.correlationId for structured logging.

Closes #957