### PR TITLE
Add OpenAPI examples for /api/errors (#891)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3569,6 +3569,572 @@
           }
         }
       }
+    },
+    "/api/errors": {
+      "get": {
+        "summary": "List error definitions",
+        "description": "Returns all registered error definitions. Read-only; does not require authentication and is not audited.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Error definitions retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorsListResponse"
+                },
+                "examples": {
+                  "withRecords": {
+                    "summary": "Store contains registered error definitions",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "errors": [
+                          {
+                            "id": "1",
+                            "code": "ERR_INSUFFICIENT_CREDITS",
+                            "message": "Developer account has insufficient credits",
+                            "statusCode": 402,
+                            "description": "Returned when a billing deduction would take the balance below zero.",
+                            "createdAt": "2026-07-27T09:00:00.000Z",
+                            "updatedAt": "2026-07-27T09:00:00.000Z"
+                          }
+                        ]
+                      },
+                      "requestId": "req-errors-list-1",
+                      "timestamp": "2026-07-27T09:00:00.000Z"
+                    }
+                  },
+                  "empty": {
+                    "summary": "No error definitions registered yet",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "errors": []
+                      },
+                      "requestId": "req-errors-list-2",
+                      "timestamp": "2026-07-27T09:05:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an error definition",
+        "description": "Registers a new error definition. Requires authentication; the mutation is recorded in the audit log.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorCreateRequest"
+              },
+              "examples": {
+                "createErrorDefinition": {
+                  "summary": "Register a new billing error code",
+                  "value": {
+                    "code": "ERR_INSUFFICIENT_CREDITS",
+                    "message": "Developer account has insufficient credits",
+                    "statusCode": 402,
+                    "description": "Returned when a billing deduction would take the balance below zero."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Error definition created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorRecordResponse"
+                },
+                "examples": {
+                  "created": {
+                    "summary": "Newly created error definition",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "id": "1",
+                        "code": "ERR_INSUFFICIENT_CREDITS",
+                        "message": "Developer account has insufficient credits",
+                        "statusCode": 402,
+                        "description": "Returned when a billing deduction would take the balance below zero.",
+                        "createdAt": "2026-07-27T09:00:00.000Z",
+                        "updatedAt": "2026-07-27T09:00:00.000Z"
+                      },
+                      "requestId": "req-errors-create-1",
+                      "timestamp": "2026-07-27T09:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "validationFailed": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "BAD_REQUEST",
+                        "message": "Validation failed",
+                        "details": [
+                          {
+                            "field": "code",
+                            "message": "Required",
+                            "code": "invalid_type"
+                          }
+                        ]
+                      },
+                      "requestId": "req-errors-create-400",
+                      "timestamp": "2026-07-27T09:01:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication is required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "summary": "Missing or invalid authentication",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "UNAUTHORIZED",
+                        "message": "Unauthorized"
+                      },
+                      "requestId": "req-errors-create-401",
+                      "timestamp": "2026-07-27T09:02:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/errors/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Error definition ID",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get an error definition by ID",
+        "description": "Read-only; does not require authentication and is not audited.",
+        "responses": {
+          "200": {
+            "description": "Error definition retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorRecordResponse"
+                },
+                "examples": {
+                  "found": {
+                    "summary": "Existing error definition",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "id": "1",
+                        "code": "ERR_INSUFFICIENT_CREDITS",
+                        "message": "Developer account has insufficient credits",
+                        "statusCode": 402,
+                        "description": "Returned when a billing deduction would take the balance below zero.",
+                        "createdAt": "2026-07-27T09:00:00.000Z",
+                        "updatedAt": "2026-07-27T09:00:00.000Z"
+                      },
+                      "requestId": "req-errors-get-1",
+                      "timestamp": "2026-07-27T09:03:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error definition not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "notFound": {
+                    "summary": "No error definition with the given ID",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "NOT_FOUND",
+                        "message": "Error definition 999 not found"
+                      },
+                      "requestId": "req-errors-get-404",
+                      "timestamp": "2026-07-27T09:04:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Replace an error definition",
+        "description": "Full update of an existing error definition. Requires authentication; the mutation is recorded in the audit log.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorUpdateRequest"
+              },
+              "examples": {
+                "replaceErrorDefinition": {
+                  "summary": "Update the message and status code",
+                  "value": {
+                    "code": "ERR_INSUFFICIENT_CREDITS",
+                    "message": "Account balance is below the required minimum",
+                    "statusCode": 402,
+                    "description": "Returned when a billing deduction would take the balance below zero."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Error definition updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorRecordResponse"
+                },
+                "examples": {
+                  "updated": {
+                    "summary": "Updated error definition",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "id": "1",
+                        "code": "ERR_INSUFFICIENT_CREDITS",
+                        "message": "Account balance is below the required minimum",
+                        "statusCode": 402,
+                        "description": "Returned when a billing deduction would take the balance below zero.",
+                        "createdAt": "2026-07-27T09:00:00.000Z",
+                        "updatedAt": "2026-07-27T09:06:00.000Z"
+                      },
+                      "requestId": "req-errors-put-1",
+                      "timestamp": "2026-07-27T09:06:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "emptyUpdate": {
+                    "summary": "No fields provided",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "BAD_REQUEST",
+                        "message": "At least one field must be provided for update"
+                      },
+                      "requestId": "req-errors-put-400",
+                      "timestamp": "2026-07-27T09:07:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication is required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "summary": "Missing or invalid authentication",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "UNAUTHORIZED",
+                        "message": "Unauthorized"
+                      },
+                      "requestId": "req-errors-put-401",
+                      "timestamp": "2026-07-27T09:08:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error definition not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "notFound": {
+                    "summary": "No error definition with the given ID",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "NOT_FOUND",
+                        "message": "Error definition 999 not found"
+                      },
+                      "requestId": "req-errors-put-404",
+                      "timestamp": "2026-07-27T09:09:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Partially update an error definition",
+        "description": "Partial update of an existing error definition. Requires authentication; the mutation is recorded in the audit log.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorUpdateRequest"
+              },
+              "examples": {
+                "patchMessage": {
+                  "summary": "Update just the message",
+                  "value": {
+                    "message": "Account balance is below the required minimum"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Error definition updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorRecordResponse"
+                },
+                "examples": {
+                  "updated": {
+                    "summary": "Updated error definition",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "id": "1",
+                        "code": "ERR_INSUFFICIENT_CREDITS",
+                        "message": "Account balance is below the required minimum",
+                        "statusCode": 402,
+                        "description": "Returned when a billing deduction would take the balance below zero.",
+                        "createdAt": "2026-07-27T09:00:00.000Z",
+                        "updatedAt": "2026-07-27T09:10:00.000Z"
+                      },
+                      "requestId": "req-errors-patch-1",
+                      "timestamp": "2026-07-27T09:10:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "emptyUpdate": {
+                    "summary": "No fields provided",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "BAD_REQUEST",
+                        "message": "At least one field must be provided for update"
+                      },
+                      "requestId": "req-errors-patch-400",
+                      "timestamp": "2026-07-27T09:11:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication is required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "summary": "Missing or invalid authentication",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "UNAUTHORIZED",
+                        "message": "Unauthorized"
+                      },
+                      "requestId": "req-errors-patch-401",
+                      "timestamp": "2026-07-27T09:12:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error definition not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "notFound": {
+                    "summary": "No error definition with the given ID",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "NOT_FOUND",
+                        "message": "Error definition 999 not found"
+                      },
+                      "requestId": "req-errors-patch-404",
+                      "timestamp": "2026-07-27T09:13:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an error definition",
+        "description": "Requires authentication; the mutation is recorded in the audit log. Returns no content on success.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Error definition deleted"
+          },
+          "401": {
+            "description": "Authentication is required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "summary": "Missing or invalid authentication",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "UNAUTHORIZED",
+                        "message": "Unauthorized"
+                      },
+                      "requestId": "req-errors-delete-401",
+                      "timestamp": "2026-07-27T09:14:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error definition not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorEnvelope"
+                },
+                "examples": {
+                  "notFound": {
+                    "summary": "No error definition with the given ID",
+                    "value": {
+                      "success": false,
+                      "error": {
+                        "code": "NOT_FOUND",
+                        "message": "Error definition 999 not found"
+                      },
+                      "requestId": "req-errors-delete-404",
+                      "timestamp": "2026-07-27T09:15:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -5223,6 +5789,227 @@
           "notes": {
             "type": "string",
             "maxLength": 1000
+          }
+        }
+      },
+      "ErrorRecord": {
+        "type": "object",
+        "required": [
+          "id",
+          "code",
+          "message",
+          "statusCode",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "statusCode": {
+            "type": "integer"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ErrorRecordResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "data",
+          "requestId",
+          "timestamp"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "data": {
+            "$ref": "#/components/schemas/ErrorRecord"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ErrorsListResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "data",
+          "requestId",
+          "timestamp"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "data": {
+            "type": "object",
+            "required": [
+              "errors"
+            ],
+            "properties": {
+              "errors": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ErrorRecord"
+                }
+              }
+            }
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ErrorCreateRequest": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "statusCode"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "statusCode": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1000
+          }
+        }
+      },
+      "ErrorUpdateRequest": {
+        "type": "object",
+        "description": "At least one field must be provided.",
+        "minProperties": 1,
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "statusCode": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1000
+          }
+        }
+      },
+      "StandardErrorEnvelope": {
+        "type": "object",
+        "required": [
+          "success",
+          "error",
+          "requestId",
+          "timestamp"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              false
+            ]
+          },
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       }

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,16 +1,17 @@
-# OpenAPI fragment: /api/rate-limit examples
+# OpenAPI fragment: example request/response bodies
 #
 # Canonical full contract lives in docs/openapi.json (served at GET /api/openapi.json).
-# This YAML file documents request/response examples for the rate-limit surface
-# (GrantFox FWC26 #931). Keep examples in sync with docs/openapi.json — the
-# companion test src/routes/rate-limit/health.openapi.test.ts asserts both.
+# This YAML file documents request/response examples for individual API surfaces.
+# Keep examples in sync with docs/openapi.json — companion tests assert both:
+#   - rate-limit surface (GrantFox FWC26 #931): src/routes/rate-limit/health.openapi.test.ts
+#   - error-definitions surface (GrantFox FWC26 #891): src/routes/errors.openapi.test.ts
 openapi: 3.1.0
 info:
-  title: Callora rate-limit examples
+  title: Callora API examples
   version: "1.0.0"
   description: >
-    Example request/response bodies for the rate-limit health probe and the
-    authenticated budget peek. No request body is required for either GET.
+    Example request/response bodies for select Callora API surfaces: the
+    rate-limit health probe / budget peek, and the error-definitions CRUD API.
 paths:
   /api/rate-limit/health:
     get:
@@ -116,6 +117,408 @@ paths:
                     code: UNAUTHORIZED
                     message: Authentication required
                     requestId: req-rate-limit-check
+  /api/errors:
+    get:
+      summary: List error definitions
+      description: >
+        Returns all registered error definitions. Read-only; does not require
+        authentication and is not audited.
+      parameters: []
+      responses:
+        "200":
+          description: Error definitions retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorsListResponse"
+              examples:
+                withRecords:
+                  summary: Store contains registered error definitions
+                  value:
+                    success: true
+                    data:
+                      errors:
+                        - id: "1"
+                          code: ERR_INSUFFICIENT_CREDITS
+                          message: Developer account has insufficient credits
+                          statusCode: 402
+                          description: >-
+                            Returned when a billing deduction would take the
+                            balance below zero.
+                          createdAt: "2026-07-27T09:00:00.000Z"
+                          updatedAt: "2026-07-27T09:00:00.000Z"
+                    requestId: req-errors-list-1
+                    timestamp: "2026-07-27T09:00:00.000Z"
+                empty:
+                  summary: No error definitions registered yet
+                  value:
+                    success: true
+                    data:
+                      errors: []
+                    requestId: req-errors-list-2
+                    timestamp: "2026-07-27T09:05:00.000Z"
+    post:
+      summary: Create an error definition
+      description: >
+        Registers a new error definition. Requires authentication; the
+        mutation is recorded in the audit log.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorCreateRequest"
+            examples:
+              createErrorDefinition:
+                summary: Register a new billing error code
+                value:
+                  code: ERR_INSUFFICIENT_CREDITS
+                  message: Developer account has insufficient credits
+                  statusCode: 402
+                  description: >-
+                    Returned when a billing deduction would take the balance
+                    below zero.
+      responses:
+        "201":
+          description: Error definition created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorRecordResponse"
+              examples:
+                created:
+                  summary: Newly created error definition
+                  value:
+                    success: true
+                    data:
+                      id: "1"
+                      code: ERR_INSUFFICIENT_CREDITS
+                      message: Developer account has insufficient credits
+                      statusCode: 402
+                      description: >-
+                        Returned when a billing deduction would take the
+                        balance below zero.
+                      createdAt: "2026-07-27T09:00:00.000Z"
+                      updatedAt: "2026-07-27T09:00:00.000Z"
+                    requestId: req-errors-create-1
+                    timestamp: "2026-07-27T09:00:00.000Z"
+        "400":
+          description: Request body failed validation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                validationFailed:
+                  summary: Missing required field
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: Validation failed
+                      details:
+                        - field: code
+                          message: Required
+                          code: invalid_type
+                    requestId: req-errors-create-400
+                    timestamp: "2026-07-27T09:01:00.000Z"
+        "401":
+          description: Authentication is required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                unauthorized:
+                  summary: Missing or invalid authentication
+                  value:
+                    success: false
+                    error:
+                      code: UNAUTHORIZED
+                      message: Unauthorized
+                    requestId: req-errors-create-401
+                    timestamp: "2026-07-27T09:02:00.000Z"
+  /api/errors/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Error definition ID
+        schema:
+          type: string
+    get:
+      summary: Get an error definition by ID
+      description: >
+        Read-only; does not require authentication and is not audited.
+      responses:
+        "200":
+          description: Error definition retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorRecordResponse"
+              examples:
+                found:
+                  summary: Existing error definition
+                  value:
+                    success: true
+                    data:
+                      id: "1"
+                      code: ERR_INSUFFICIENT_CREDITS
+                      message: Developer account has insufficient credits
+                      statusCode: 402
+                      description: >-
+                        Returned when a billing deduction would take the
+                        balance below zero.
+                      createdAt: "2026-07-27T09:00:00.000Z"
+                      updatedAt: "2026-07-27T09:00:00.000Z"
+                    requestId: req-errors-get-1
+                    timestamp: "2026-07-27T09:03:00.000Z"
+        "404":
+          description: Error definition not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No error definition with the given ID
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: Error definition 999 not found
+                    requestId: req-errors-get-404
+                    timestamp: "2026-07-27T09:04:00.000Z"
+    put:
+      summary: Replace an error definition
+      description: >
+        Full update of an existing error definition. Requires authentication;
+        the mutation is recorded in the audit log.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorUpdateRequest"
+            examples:
+              replaceErrorDefinition:
+                summary: Update the message and status code
+                value:
+                  code: ERR_INSUFFICIENT_CREDITS
+                  message: Account balance is below the required minimum
+                  statusCode: 402
+                  description: >-
+                    Returned when a billing deduction would take the balance
+                    below zero.
+      responses:
+        "200":
+          description: Error definition updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorRecordResponse"
+              examples:
+                updated:
+                  summary: Updated error definition
+                  value:
+                    success: true
+                    data:
+                      id: "1"
+                      code: ERR_INSUFFICIENT_CREDITS
+                      message: Account balance is below the required minimum
+                      statusCode: 402
+                      description: >-
+                        Returned when a billing deduction would take the
+                        balance below zero.
+                      createdAt: "2026-07-27T09:00:00.000Z"
+                      updatedAt: "2026-07-27T09:06:00.000Z"
+                    requestId: req-errors-put-1
+                    timestamp: "2026-07-27T09:06:00.000Z"
+        "400":
+          description: Request body failed validation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                emptyUpdate:
+                  summary: No fields provided
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: At least one field must be provided for update
+                    requestId: req-errors-put-400
+                    timestamp: "2026-07-27T09:07:00.000Z"
+        "401":
+          description: Authentication is required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                unauthorized:
+                  summary: Missing or invalid authentication
+                  value:
+                    success: false
+                    error:
+                      code: UNAUTHORIZED
+                      message: Unauthorized
+                    requestId: req-errors-put-401
+                    timestamp: "2026-07-27T09:08:00.000Z"
+        "404":
+          description: Error definition not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No error definition with the given ID
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: Error definition 999 not found
+                    requestId: req-errors-put-404
+                    timestamp: "2026-07-27T09:09:00.000Z"
+    patch:
+      summary: Partially update an error definition
+      description: >
+        Partial update of an existing error definition. Requires
+        authentication; the mutation is recorded in the audit log.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorUpdateRequest"
+            examples:
+              patchMessage:
+                summary: Update just the message
+                value:
+                  message: Account balance is below the required minimum
+      responses:
+        "200":
+          description: Error definition updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorRecordResponse"
+              examples:
+                updated:
+                  summary: Updated error definition
+                  value:
+                    success: true
+                    data:
+                      id: "1"
+                      code: ERR_INSUFFICIENT_CREDITS
+                      message: Account balance is below the required minimum
+                      statusCode: 402
+                      description: >-
+                        Returned when a billing deduction would take the
+                        balance below zero.
+                      createdAt: "2026-07-27T09:00:00.000Z"
+                      updatedAt: "2026-07-27T09:10:00.000Z"
+                    requestId: req-errors-patch-1
+                    timestamp: "2026-07-27T09:10:00.000Z"
+        "400":
+          description: Request body failed validation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                emptyUpdate:
+                  summary: No fields provided
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: At least one field must be provided for update
+                    requestId: req-errors-patch-400
+                    timestamp: "2026-07-27T09:11:00.000Z"
+        "401":
+          description: Authentication is required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                unauthorized:
+                  summary: Missing or invalid authentication
+                  value:
+                    success: false
+                    error:
+                      code: UNAUTHORIZED
+                      message: Unauthorized
+                    requestId: req-errors-patch-401
+                    timestamp: "2026-07-27T09:12:00.000Z"
+        "404":
+          description: Error definition not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No error definition with the given ID
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: Error definition 999 not found
+                    requestId: req-errors-patch-404
+                    timestamp: "2026-07-27T09:13:00.000Z"
+    delete:
+      summary: Delete an error definition
+      description: >
+        Requires authentication; the mutation is recorded in the audit log.
+        Returns no content on success.
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: Error definition deleted
+        "401":
+          description: Authentication is required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                unauthorized:
+                  summary: Missing or invalid authentication
+                  value:
+                    success: false
+                    error:
+                      code: UNAUTHORIZED
+                      message: Unauthorized
+                    requestId: req-errors-delete-401
+                    timestamp: "2026-07-27T09:14:00.000Z"
+        "404":
+          description: Error definition not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No error definition with the given ID
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: Error definition 999 not found
+                    requestId: req-errors-delete-404
+                    timestamp: "2026-07-27T09:15:00.000Z"
 components:
   securitySchemes:
     bearerAuth:
@@ -180,3 +583,130 @@ components:
           type: string
         requestId:
           type: string
+    ErrorRecord:
+      type: object
+      required: [id, code, message, statusCode, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+        code:
+          type: string
+        message:
+          type: string
+        statusCode:
+          type: integer
+        description:
+          type: [string, "null"]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    ErrorRecordResponse:
+      type: object
+      required: [success, data, requestId, timestamp]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          $ref: "#/components/schemas/ErrorRecord"
+        requestId:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    ErrorsListResponse:
+      type: object
+      required: [success, data, requestId, timestamp]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          required: [errors]
+          properties:
+            errors:
+              type: array
+              items:
+                $ref: "#/components/schemas/ErrorRecord"
+        requestId:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    ErrorCreateRequest:
+      type: object
+      required: [code, message, statusCode]
+      properties:
+        code:
+          type: string
+          minLength: 1
+          maxLength: 100
+        message:
+          type: string
+          minLength: 1
+          maxLength: 500
+        statusCode:
+          type: integer
+          minimum: 100
+          maximum: 599
+        description:
+          type: [string, "null"]
+          maxLength: 1000
+    ErrorUpdateRequest:
+      type: object
+      description: At least one field must be provided.
+      minProperties: 1
+      properties:
+        code:
+          type: string
+          minLength: 1
+          maxLength: 100
+        message:
+          type: string
+          minLength: 1
+          maxLength: 500
+        statusCode:
+          type: integer
+          minimum: 100
+          maximum: 599
+        description:
+          type: [string, "null"]
+          maxLength: 1000
+    # Distinct from the pre-existing flat ErrorResponse — this matches the
+    # actual envelope produced by errorHandler.ts / buildErrorEnvelope():
+    # { success: false, error: { code, message, details? }, requestId, timestamp }
+    StandardErrorEnvelope:
+      type: object
+      required: [success, error, requestId, timestamp]
+      properties:
+        success:
+          type: boolean
+          enum: [false]
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+                  code:
+                    type: string
+        requestId:
+          type: string
+        timestamp:
+          type: string
+          format: date-time

--- a/src/routes/errors.openapi.test.ts
+++ b/src/routes/errors.openapi.test.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type JsonObject = Record<string, unknown>;
+
+describe('OpenAPI examples for /api/errors', () => {
+  const openApiPath = path.join(process.cwd(), 'docs', 'openapi.json');
+
+  function readSpec(): JsonObject {
+    return JSON.parse(fs.readFileSync(openApiPath, 'utf8')) as JsonObject;
+  }
+
+  function asObject(value: unknown): JsonObject {
+    return value as JsonObject;
+  }
+
+  test('documents populated and empty list examples for GET /api/errors', () => {
+    const spec = readSpec();
+    const operation = asObject(asObject(spec.paths)['/api/errors']).get as JsonObject;
+    const response200 = asObject(asObject(operation.responses)['200']);
+    const examples = asObject(
+      asObject(asObject(response200.content)['application/json']).examples,
+    );
+
+    expect(examples.withRecords).toBeDefined();
+    const withRecordsValue = asObject(asObject(examples.withRecords).value);
+    expect(withRecordsValue.success).toBe(true);
+    const errors = asObject(withRecordsValue.data).errors as unknown[];
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toEqual(
+      expect.objectContaining({ code: 'ERR_INSUFFICIENT_CREDITS', statusCode: 402 }),
+    );
+
+    expect(examples.empty).toBeDefined();
+    const emptyValue = asObject(asObject(examples.empty).value);
+    expect(asObject(emptyValue.data)).toEqual({ errors: [] });
+  });
+
+  test('documents create, validation-failure, and unauthorized examples for POST /api/errors', () => {
+    const spec = readSpec();
+    const operation = asObject(asObject(spec.paths)['/api/errors']).post as JsonObject;
+
+    const response201 = asObject(asObject(operation.responses)['201']);
+    const createdExamples = asObject(
+      asObject(asObject(response201.content)['application/json']).examples,
+    );
+    expect(asObject(asObject(createdExamples.created).value)).toEqual(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ code: 'ERR_INSUFFICIENT_CREDITS' }),
+      }),
+    );
+
+    const response400 = asObject(asObject(operation.responses)['400']);
+    const badRequestExamples = asObject(
+      asObject(asObject(response400.content)['application/json']).examples,
+    );
+    const validationFailed = asObject(asObject(badRequestExamples.validationFailed).value);
+    expect(asObject(validationFailed.error)).toEqual(
+      expect.objectContaining({ code: 'BAD_REQUEST' }),
+    );
+
+    const response401 = asObject(asObject(operation.responses)['401']);
+    const unauthorizedExamples = asObject(
+      asObject(asObject(response401.content)['application/json']).examples,
+    );
+    expect(asObject(asObject(unauthorizedExamples.unauthorized).value)).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({ code: 'UNAUTHORIZED' }),
+      }),
+    );
+  });
+
+  test('documents found and not-found examples for GET /api/errors/{id}', () => {
+    const spec = readSpec();
+    const operation = asObject(asObject(spec.paths)['/api/errors/{id}']).get as JsonObject;
+
+    const response200 = asObject(asObject(operation.responses)['200']);
+    const foundExamples = asObject(
+      asObject(asObject(response200.content)['application/json']).examples,
+    );
+    expect(asObject(asObject(foundExamples.found).value)).toEqual(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ id: '1', code: 'ERR_INSUFFICIENT_CREDITS' }),
+      }),
+    );
+
+    const response404 = asObject(asObject(operation.responses)['404']);
+    const notFoundExamples = asObject(
+      asObject(asObject(response404.content)['application/json']).examples,
+    );
+    expect(asObject(asObject(notFoundExamples.notFound).value)).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({ code: 'NOT_FOUND' }),
+      }),
+    );
+  });
+
+  test('documents update, empty-body, and not-found examples for PATCH /api/errors/{id}', () => {
+    const spec = readSpec();
+    const operation = asObject(asObject(spec.paths)['/api/errors/{id}']).patch as JsonObject;
+
+    const response200 = asObject(asObject(operation.responses)['200']);
+    const updatedExamples = asObject(
+      asObject(asObject(response200.content)['application/json']).examples,
+    );
+    expect(asObject(asObject(updatedExamples.updated).value)).toEqual(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          message: 'Account balance is below the required minimum',
+        }),
+      }),
+    );
+
+    const response400 = asObject(asObject(operation.responses)['400']);
+    const emptyUpdateExamples = asObject(
+      asObject(asObject(response400.content)['application/json']).examples,
+    );
+    expect(asObject(asObject(emptyUpdateExamples.emptyUpdate).value)).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({
+          message: 'At least one field must be provided for update',
+        }),
+      }),
+    );
+
+    const response404 = asObject(asObject(operation.responses)['404']);
+    const notFoundExamples = asObject(
+      asObject(asObject(response404.content)['application/json']).examples,
+    );
+    expect(asObject(asObject(notFoundExamples.notFound).value)).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({ code: 'NOT_FOUND' }),
+      }),
+    );
+  });
+
+  test('documents no-content deletion response for DELETE /api/errors/{id}', () => {
+    const spec = readSpec();
+    const operation = asObject(asObject(spec.paths)['/api/errors/{id}']).delete as JsonObject;
+    const response204 = asObject(asObject(operation.responses)['204']);
+    expect(response204.description).toBeDefined();
+
+    const response401 = asObject(asObject(operation.responses)['401']);
+    const unauthorizedExamples = asObject(
+      asObject(asObject(response401.content)['application/json']).examples,
+    );
+    expect(asObject(asObject(unauthorizedExamples.unauthorized).value)).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({ code: 'UNAUTHORIZED' }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds OpenAPI request/response examples for the `/api/errors` CRUD surface (GrantFox FWC26 #891). Documents all six operations across `GET /api/errors`, `GET /api/errors/{id}`, `POST /api/errors`, `PUT /api/errors/{id}`, `PATCH /api/errors/{id}`, and `DELETE /api/errors/{id}`, including success and error paths.

Closes #891

## Changes

- **`docs/openapi.json`** (canonical spec) — added `/api/errors` and `/api/errors/{id}` paths, plus six new component schemas: `ErrorRecord`, `ErrorRecordResponse`, `ErrorsListResponse`, `ErrorCreateRequest`, `ErrorUpdateRequest`, `StandardErrorEnvelope`.
- **`src/openapi.yaml`** (human-readable fragment) — mirrored the same paths/examples/schemas, following the existing rate-limit fragment's format. Updated the file header comment since it now documents two surfaces instead of one.
- **`src/routes/errors.openapi.test.ts`** — new companion test asserting the examples exist in `docs/openapi.json`, following the same pattern as `src/routes/rate-limit/health.openapi.test.ts`.

## Examples covered

| Operation | Success | Error cases |
|---|---|---|
| `GET /api/errors` | populated list, empty list | — |
| `GET /api/errors/{id}` | found | 404 not found |
| `POST /api/errors` | created (201) | 400 validation failure, 401 unauthorized |
| `PUT /api/errors/{id}` | updated | 400 empty body, 401 unauthorized, 404 not found |
| `PATCH /api/errors/{id}` | updated | 400 empty body, 401 unauthorized, 404 not found |
| `DELETE /api/errors/{id}` | 204 no content | 401 unauthorized, 404 not found |

## Notes for reviewers

- **New `StandardErrorEnvelope` schema**: the pre-existing `ErrorResponse` schema documents a flat `{code, message, requestId}` shape, but `errorHandler.ts` / `buildErrorEnvelope()` actually returns `{success: false, error: {code, message, details?}, requestId, timestamp}`. Rather than reuse the mismatched schema, I added `StandardErrorEnvelope` to reflect what `/api/errors` genuinely returns. Didn't touch `ErrorResponse` itself — that's used elsewhere and out of scope here.
- **400 example assumption**: the validation-failure `details` shape (`[{field, message, code}]`) is inferred from `errorEnvelopeSchema` in `src/middleware/envelope.ts`, since I didn't have `src/middleware/validate.ts` on hand. Please confirm this matches actual Zod validation output and I'll adjust if not.
- `docs/openapi.json` was patched via a one-off Node script (not committed) rather than hand-edited, to avoid JSON formatting errors — diff should be clean and additive only.

## Testing

- [x] `npx jest src/routes/errors.openapi.test.ts` passes
- [x] `npx jest src/routes/rate-limit/health.openapi.test.ts` passes (no regression)
- [ ] `npm run lint`