### PR TITLE
docs: add openapi examples for spike route

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -11,8 +11,319 @@ info:
   version: "1.0.0"
   description: >
     Example request/response bodies for select Callora API surfaces: the
-    rate-limit health probe / budget peek, and the error-definitions CRUD API.
+    spike probe / record API, the rate-limit health probe / budget peek, and
+    the error-definitions CRUD API.
 paths:
+  /api/spike:
+    get:
+      summary: Run the spike timeout probe
+      description: >
+        Exercises timeout handling by delaying for the requested duration. No
+        request body is required.
+      parameters:
+        - name: delay
+          in: query
+          required: false
+          description: Delay in milliseconds before responding.
+          schema:
+            type: integer
+            minimum: 1
+            default: 2000
+          examples:
+            completesBeforeTimeout:
+              summary: Complete before the default timeout
+              value: 100
+            exceedsDefaultTimeout:
+              summary: Trigger the default timeout
+              value: 1200
+        - name: timeout
+          in: query
+          required: false
+          description: Optional request timeout override in milliseconds.
+          schema:
+            type: integer
+            minimum: 1
+          examples:
+            shortTimeout:
+              summary: Custom timeout shorter than the delay
+              value: 200
+        - name: x-timeout-ms
+          in: header
+          required: false
+          description: Optional request timeout override in milliseconds.
+          schema:
+            type: integer
+            minimum: 1
+          examples:
+            headerTimeout:
+              summary: Header-based timeout override
+              value: 200
+      responses:
+        "200":
+          description: Spike probe completed before the timeout.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpikeRunResponse"
+              examples:
+                completed:
+                  summary: Delay completed successfully
+                  value:
+                    success: true
+                    message: Spike completed successfully
+                    delay: 100
+                    elapsed: 100
+        "504":
+          description: Spike probe exceeded the configured timeout.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                timedOut:
+                  summary: Request timed out
+                  value:
+                    success: false
+                    error:
+                      code: GATEWAY_TIMEOUT
+                      message: Request timeout exceeded
+                    requestId: req-spike-timeout-1
+                    timestamp: "2026-07-29T10:00:00.000Z"
+    post:
+      summary: Create a spike record
+      description: >
+        Creates an in-memory spike record and records the mutation in the audit
+        trail.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpikeCreateRequest"
+            examples:
+              createHighSeverityRecord:
+                summary: Create a high severity spike record
+                value:
+                  label: Checkout latency spike
+                  severity: high
+      responses:
+        "201":
+          description: Spike record created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpikeRecord"
+              examples:
+                created:
+                  summary: Newly created spike record
+                  value:
+                    id: "1"
+                    label: Checkout latency spike
+                    severity: high
+                    createdAt: "2026-07-29T10:00:00.000Z"
+                    updatedAt: "2026-07-29T10:00:00.000Z"
+        "400":
+          description: Request body failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                missingLabel:
+                  summary: Missing required label
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: label is required and must be a non-empty string
+                    requestId: req-spike-create-400
+                    timestamp: "2026-07-29T10:01:00.000Z"
+        "503":
+          description: Audit service is temporarily unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                auditUnavailable:
+                  summary: Audit circuit breaker is open
+                  value:
+                    success: false
+                    error:
+                      code: SERVICE_UNAVAILABLE
+                      message: Audit service temporarily unavailable
+                    requestId: req-spike-create-503
+                    timestamp: "2026-07-29T10:02:00.000Z"
+  /api/spike/records:
+    get:
+      summary: List spike records
+      description: Returns the current in-memory spike records.
+      parameters: []
+      responses:
+        "200":
+          description: Spike records retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpikeRecordsResponse"
+              examples:
+                withRecords:
+                  summary: Store contains spike records
+                  value:
+                    records:
+                      - id: "1"
+                        label: Checkout latency spike
+                        severity: high
+                        createdAt: "2026-07-29T10:00:00.000Z"
+                        updatedAt: "2026-07-29T10:00:00.000Z"
+                empty:
+                  summary: No spike records exist yet
+                  value:
+                    records: []
+  /api/spike/{id}:
+    put:
+      summary: Update a spike record
+      description: >
+        Updates the label and/or severity for an existing spike record and
+        records the mutation in the audit trail.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Spike record identifier.
+          schema:
+            type: string
+          examples:
+            existingRecord:
+              summary: Existing spike record
+              value: "1"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpikeUpdateRequest"
+            examples:
+              updateSeverity:
+                summary: Escalate the spike severity
+                value:
+                  label: Checkout latency spike escalated
+                  severity: critical
+      responses:
+        "200":
+          description: Spike record updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpikeRecord"
+              examples:
+                updated:
+                  summary: Updated spike record
+                  value:
+                    id: "1"
+                    label: Checkout latency spike escalated
+                    severity: critical
+                    createdAt: "2026-07-29T10:00:00.000Z"
+                    updatedAt: "2026-07-29T10:05:00.000Z"
+        "400":
+          description: Request body failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                invalidSeverity:
+                  summary: Severity is outside the allowed set
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: Invalid option
+                    requestId: req-spike-update-400
+                    timestamp: "2026-07-29T10:06:00.000Z"
+        "404":
+          description: Spike record was not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No record exists for the supplied ID
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: Spike record 999 not found
+                    requestId: req-spike-update-404
+                    timestamp: "2026-07-29T10:07:00.000Z"
+        "503":
+          description: Audit service is temporarily unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                auditUnavailable:
+                  summary: Audit circuit breaker is open
+                  value:
+                    success: false
+                    error:
+                      code: SERVICE_UNAVAILABLE
+                      message: Audit service temporarily unavailable
+                    requestId: req-spike-update-503
+                    timestamp: "2026-07-29T10:08:00.000Z"
+    delete:
+      summary: Delete a spike record
+      description: >
+        Deletes an existing spike record and records the mutation in the audit
+        trail. Returns no content on success.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Spike record identifier.
+          schema:
+            type: string
+          examples:
+            existingRecord:
+              summary: Existing spike record
+              value: "1"
+      responses:
+        "204":
+          description: Spike record deleted.
+        "404":
+          description: Spike record was not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No record exists for the supplied ID
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: Spike record 999 not found
+                    requestId: req-spike-delete-404
+                    timestamp: "2026-07-29T10:09:00.000Z"
+        "503":
+          description: Audit service is temporarily unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                auditUnavailable:
+                  summary: Audit circuit breaker is open
+                  value:
+                    success: false
+                    error:
+                      code: SERVICE_UNAVAILABLE
+                      message: Audit service temporarily unavailable
+                    requestId: req-spike-delete-503
+                    timestamp: "2026-07-29T10:10:00.000Z"
   /api/rate-limit/health:
     get:
       summary: Check rate-limit subsystem health
@@ -526,6 +837,66 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
+    SpikeSeverity:
+      type: string
+      enum: [low, medium, high, critical]
+    SpikeRunResponse:
+      type: object
+      required: [success, message, delay, elapsed]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        message:
+          type: string
+        delay:
+          type: integer
+        elapsed:
+          type: integer
+    SpikeRecord:
+      type: object
+      required: [id, label, severity, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+          minLength: 1
+        severity:
+          $ref: "#/components/schemas/SpikeSeverity"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    SpikeRecordsResponse:
+      type: object
+      required: [records]
+      properties:
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/SpikeRecord"
+    SpikeCreateRequest:
+      type: object
+      required: [label, severity]
+      properties:
+        label:
+          type: string
+          minLength: 1
+        severity:
+          $ref: "#/components/schemas/SpikeSeverity"
+    SpikeUpdateRequest:
+      type: object
+      description: At least one field should be provided.
+      minProperties: 1
+      properties:
+        label:
+          type: string
+          minLength: 1
+        severity:
+          $ref: "#/components/schemas/SpikeSeverity"
     RateLimitDependencyStatus:
       type: object
       required: [status]

--- a/src/routes/spike.openapi.test.ts
+++ b/src/routes/spike.openapi.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Contract test for src/openapi.yaml.
+ *
+ * Validates that the /api/spike examples added for GrantFox FWC26 #911 cover
+ * the timeout probe and record mutation/listing response bodies.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('src/openapi.yaml - spike examples', () => {
+  const yamlPath = path.join(process.cwd(), 'src', 'openapi.yaml');
+
+  function readOpenApiYaml(): string {
+    return fs.readFileSync(yamlPath, 'utf8');
+  }
+
+  test('documents public spike paths', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('/api/spike:');
+    expect(content).toContain('/api/spike/records:');
+    expect(content).toContain('/api/spike/{id}:');
+  });
+
+  test('includes timeout probe request and response examples', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('Run the spike timeout probe');
+    expect(content).toContain('completesBeforeTimeout:');
+    expect(content).toContain('exceedsDefaultTimeout:');
+    expect(content).toContain('headerTimeout:');
+    expect(content).toContain('Spike completed successfully');
+    expect(content).toContain('GATEWAY_TIMEOUT');
+    expect(content).toContain('Request timeout exceeded');
+  });
+
+  test('includes create request, success, validation, and audit-unavailable examples', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('createHighSeverityRecord:');
+    expect(content).toContain('Checkout latency spike');
+    expect(content).toContain('missingLabel:');
+    expect(content).toContain('label is required and must be a non-empty string');
+    expect(content).toContain('auditUnavailable:');
+    expect(content).toContain('Audit service temporarily unavailable');
+  });
+
+  test('includes list, update, delete, and not-found examples', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('withRecords:');
+    expect(content).toContain('records: []');
+    expect(content).toContain('updateSeverity:');
+    expect(content).toContain('Checkout latency spike escalated');
+    expect(content).toContain('Spike record 999 not found');
+    expect(content).toContain('Spike record deleted');
+  });
+
+  test('defines spike schemas and severity enum', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('SpikeRunResponse');
+    expect(content).toContain('SpikeRecord');
+    expect(content).toContain('SpikeRecordsResponse');
+    expect(content).toContain('SpikeCreateRequest');
+    expect(content).toContain('SpikeUpdateRequest');
+    expect(content).toContain('enum: [low, medium, high, critical]');
+  });
+});


### PR DESCRIPTION
Closes #911

## Summary
- Add request/response examples for the public `/api/spike` timeout probe
- Document spike record create, list, update, and delete examples
- Add Spike OpenAPI component schemas and a focused YAML contract test

## Testing
- `git diff --check`
- `node -e "...OpenAPI spike examples smoke check..."`

## Notes
- `npm test -- --runInBand src/routes/spike.openapi.test.ts` was blocked by the existing `error-codes:check` failure before Jest started.
- Direct `npx jest`/`npx eslint` could not run because dependencies were not installed; `npm ci` timed out before local binaries were available.