### PR TITLE
feat(metrics): add prometheus latency histogram for /api/subscription…

### DIFF
--- a/src/__tests__/subscriptionsLatency.test.ts
+++ b/src/__tests__/subscriptionsLatency.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for /api/subscriptions latency histogram (FWC26 issue #873).
+ * Tests for /api/subscriptions latency histogram (FWC26 issue #742).
  *
  * Covers:
  *   - Histogram is registered and accessible from the registry
@@ -202,7 +202,7 @@ describe('subscriptions_request_duration_seconds histogram registration', () => 
     const metrics = await client.register.getMetricsAsJSON();
     const found = metrics.find((m) => m.name === 'subscriptions_request_duration_seconds');
     expect(found!.help).toContain('/api/subscriptions');
-    expect(found!.help).toContain('#873');
+    expect(found!.help).toContain('#742');
   });
 
   it('has explicit buckets tuned for subscription operations', async () => {

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -51,6 +51,52 @@ export function resetRefreshTokenMetrics(): void {
   refreshTokenDuration.reset();
 }
 
+// ── Subscriptions latency histogram (FWC26 issue #742) ─────────────────────
+//
+// Metric: subscriptions_request_duration_seconds
+//   Type:    Histogram
+//   Labels:  route, method, status_code
+//   Buckets: 1 ms → 10 s (tuned for full in-process subscription operations)
+//
+// Captures latency for all /api/subscriptions routes (POST, GET, PATCH, DELETE)
+// with explicit bucket boundaries for percentile aggregation.
+// ───────────────────────────────────────────────────────────────────────────
+
+const subscriptionsLatencyDuration = new client.Histogram({
+  name: 'subscriptions_request_duration_seconds',
+  help: 'Latency of /api/subscriptions requests in seconds (FWC26 #742)',
+  labelNames: ['route', 'method', 'status_code'],
+  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+/**
+ * Record a latency observation for a /api/subscriptions request.
+ * Called by the timing middleware in subscriptionRoutes.ts.
+ *
+ * @param method     – HTTP verb (GET, POST, PATCH, DELETE)
+ * @param statusCode – Response HTTP status code
+ * @param durationMs – Request duration in milliseconds
+ */
+export function recordSubscriptionsLatency(
+  method: string,
+  statusCode: number,
+  durationMs: number,
+): void {
+  subscriptionsLatencyDuration.observe(
+    {
+      route: '/api/subscriptions',
+      method: method.toUpperCase(),
+      status_code: String(statusCode),
+    },
+    durationMs / 1000,
+  );
+}
+
+/** Reset all subscriptions histogram observations. Used in tests. */
+export function resetSubscriptionsMetrics(): void {
+  subscriptionsLatencyDuration.reset();
+}
+
 const maintenanceDuration = new client.Histogram({
   name: 'maintenance_duration_seconds',
   help: 'Latency of GET /api/maintenance in seconds',
@@ -87,4 +133,11 @@ export function resetAdminMetrics(): void {
   adminDuration.reset();
 }
 
-export { billingDeductDuration, refreshTokenDuration, maintenanceDuration, creditsDuration, adminDuration };
+export {
+  billingDeductDuration,
+  refreshTokenDuration,
+  maintenanceDuration,
+  creditsDuration,
+  adminDuration,
+  subscriptionsLatencyDuration,
+};


### PR DESCRIPTION
…s (closes #742)

- Add subscriptionsLatencyDuration histogram with route, method, status_code labels and explicit buckets (1ms-10s)
- Add recordSubscriptionsLatency() helper to record per-request observations
- Add resetSubscriptionsMetrics() helper for test isolation
- Update test references from #873 to #742