### PR TITLE
test: Add integration tests for ETag caching on /api/apis

### DIFF
--- a/tests/integration/apis.test.ts
+++ b/tests/integration/apis.test.ts
@@ -133,4 +133,65 @@ describe('GET/POST /api/apis integration', () => {
       ['body.endpoints[0].method', 'body.endpoints[0].price_per_call_usdc'],
     );
   });
+
+  describe('ETag Caching', () => {
+    test('GET /api/apis returns a strong ETag and supports 304 Not Modified', async () => {
+      const app = buildApp();
+      
+      // Create an API to ensure the list is not empty
+      await request(app)
+        .post('/api/apis')
+        .set('x-user-id', 'dev-1')
+        .send(validBody);
+
+      // First request: Should return 200 and an ETag
+      const firstRes = await request(app).get('/api/apis');
+      assert.equal(firstRes.status, 200);
+      assert.ok(firstRes.headers.etag, 'Expected ETag header to be present');
+      assert.match(firstRes.headers.etag, /^"[a-f0-9]{64}"$/, 'Expected strong SHA-256 ETag format');
+      
+      const etag = firstRes.headers.etag;
+
+      // Second request: Send If-None-Match with the ETag
+      const secondRes = await request(app)
+        .get('/api/apis')
+        .set('If-None-Match', etag);
+      
+      // Should return 304 Not Modified with empty body
+      assert.equal(secondRes.status, 304);
+      assert.equal(secondRes.text, '');
+      
+      // Third request: Send mismatched ETag
+      const thirdRes = await request(app)
+        .get('/api/apis')
+        .set('If-None-Match', '"mismatchedetag"');
+        
+      assert.equal(thirdRes.status, 200);
+    });
+
+    test('GET /api/apis/:id returns a strong ETag and supports 304 Not Modified', async () => {
+      const app = buildApp();
+      
+      const createRes = await request(app)
+        .post('/api/apis')
+        .set('x-user-id', 'dev-1')
+        .send(validBody);
+      const apiId = createRes.body.id;
+
+      // First request: Should return 200 and an ETag
+      const firstRes = await request(app).get(`/api/apis/${apiId}`);
+      assert.equal(firstRes.status, 200);
+      assert.ok(firstRes.headers.etag, 'Expected ETag header to be present');
+      
+      const etag = firstRes.headers.etag;
+
+      // Second request: Send If-None-Match with the ETag
+      const secondRes = await request(app)
+        .get(`/api/apis/${apiId}`)
+        .set('If-None-Match', etag);
+      
+      assert.equal(secondRes.status, 304);
+      assert.equal(secondRes.text, '');
+    });
+  });
 });


### PR DESCRIPTION
**Description:**

Closes #735

### Description
This PR verifies the implementation of strong ETag and `304 Not Modified` caching mechanisms on the public API endpoints (`GET /api/apis` and `GET /api/apis/:id`), cutting down bandwidth overhead on repeat reads. 

The `etagMiddleware` logic is already integrated correctly into the route handlers; this PR finalizes the implementation by guaranteeing end-to-end coverage for the specified behaviors.

### Changes
*   **Added End-to-End ETag Coverage (`tests/integration/apis.test.ts`)**: 
    *   **GET `/api/apis`**: Asserts that an initial request generates a 200 OK along with a strong SHA-256 ETag. Submitting this same ETag in an `If-None-Match` header on subsequent requests now asserts that a `304 Not Modified` is correctly intercepted and returned without a body.
    *   **GET `/api/apis/:id`**: Adds equivalent assertions for the detailed view endpoint, confirming that specific API entity reads also support strong caching validations and appropriately bypass the body payload on cache hits.
    *   **Cache Miss Handling**: Asserts that sending a mismatched ETag gracefully falls back to generating a fresh `200 OK` response.

### Testing Instructions
1.  Run `npm run test -- tests/integration/apis.test.ts` to execute the integration suite.
2.  Verify that all `ETag Caching` sub-tests pass successfully.