### PR TITLE
feat: input validation usage

### DIFF
--- a/src/routes/usage.ts
+++ b/src/routes/usage.ts
@@ -1,5 +1,4 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { z } from 'zod';
 import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
 import { type UsageEventsRepository, type GroupBy, type UsageEvent, type UsageStats, type UsageBucket } from '../repositories/usageEventsRepository.js';
 import { type UsageEventsPgRepository } from '../repositories/usageEventsRepository.pg.js';
@@ -9,6 +8,7 @@ import { parseCursor } from '../lib/cursorPagination.js';
 import { createRateLimitMiddleware } from '../middleware/rateLimit.js';
 import { etagMiddleware } from '../middleware/etag.js';
 import { logger } from '../logger.js';
+import { UsageQuerySchema } from '../validators/usage.js';
 
 export interface UsageRouterDeps {
   usageEventsRepository: UsageEventsRepository & Partial<UsageEventsPgRepository>;
@@ -46,29 +46,7 @@ interface UsageResponse {
   pagination?: Record<string, unknown>;
 }
 
-// ============================================================================
-// Boundary Validation Schema (Zod)
-// ============================================================================
-const UsageQuerySchema = z.object({
-  from: z.string().datetime().optional(),
-  to: z.string().datetime().optional(),
-  apiId: z.string().optional(),
-  groupBy: z.enum(['day', 'week', 'month']).optional(),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
-  cursor: z.string().optional(),
-  after: z.string().optional(),
-  before: z.string().optional(),
-  offset: z.coerce.number().int().min(0).optional(),
-}).refine(data => {
-  if (data.from && data.to) {
-    return new Date(data.from) <= new Date(data.to);
-  }
-  return true;
-}, { message: "'from' date must be before or equal to 'to' date", path: ["from"] });
 
-// ============================================================================
-// Router Implementation
-// ============================================================================
 export function createUsageRouter(deps: UsageRouterDeps): Router {
   const router = Router();
   const { usageEventsRepository } = deps;

--- a/src/validators/usage.test.ts
+++ b/src/validators/usage.test.ts
@@ -1,0 +1,260 @@
+import { UsageQuerySchema } from "./usage.js";
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+describe("UsageQuerySchema", () => {
+  // -----------------------------------------------------------------------
+  // Default values
+  // -----------------------------------------------------------------------
+  it("applies default limit of 20 when no limit is provided", () => {
+    const result = UsageQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+    }
+  });
+
+  it("applies default limit when undefined is passed explicitly", () => {
+    const result = UsageQuerySchema.safeParse({ limit: undefined });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // limit field validation
+  // -----------------------------------------------------------------------
+  it("accepts a valid limit within range", () => {
+    const result = UsageQuerySchema.safeParse({ limit: "50" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it("accepts limit at the lower boundary (1)", () => {
+    const result = UsageQuerySchema.safeParse({ limit: "1" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(1);
+    }
+  });
+
+  it("accepts limit at the upper boundary (100)", () => {
+    const result = UsageQuerySchema.safeParse({ limit: "100" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(100);
+    }
+  });
+
+  it("rejects limit exceeding 100", () => {
+    const result = UsageQuerySchema.safeParse({ limit: "101" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects limit below 1", () => {
+    const result = UsageQuerySchema.safeParse({ limit: "0" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative limit", () => {
+    const result = UsageQuerySchema.safeParse({ limit: "-5" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer limit string", () => {
+    const result = UsageQuerySchema.safeParse({ limit: "abc" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects decimal limit", () => {
+    const result = UsageQuerySchema.safeParse({ limit: "3.5" });
+    expect(result.success).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // offset field validation
+  // -----------------------------------------------------------------------
+  it("accepts a valid offset", () => {
+    const result = UsageQuerySchema.safeParse({ offset: "10" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.offset).toBe(10);
+    }
+  });
+
+  it("accepts zero offset", () => {
+    const result = UsageQuerySchema.safeParse({ offset: "0" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.offset).toBe(0);
+    }
+  });
+
+  it("rejects negative offset", () => {
+    const result = UsageQuerySchema.safeParse({ offset: "-1" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer offset", () => {
+    const result = UsageQuerySchema.safeParse({ offset: "abc" });
+    expect(result.success).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // from / to date validation
+  // -----------------------------------------------------------------------
+  it("accepts valid ISO datetime strings for from and to", () => {
+    const result = UsageQuerySchema.safeParse({
+      from: "2026-07-01T00:00:00Z",
+      to: "2026-07-10T00:00:00Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when from is after to", () => {
+    const result = UsageQuerySchema.safeParse({
+      from: "2026-07-10T00:00:00Z",
+      to: "2026-07-01T00:00:00Z",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain("from");
+    }
+  });
+
+  it("accepts when from equals to (single-day range)", () => {
+    const result = UsageQuerySchema.safeParse({
+      from: "2026-07-01T00:00:00Z",
+      to: "2026-07-01T00:00:00Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts from without to (partial date range)", () => {
+    const result = UsageQuerySchema.safeParse({
+      from: "2026-07-01T00:00:00Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts to without from (partial date range)", () => {
+    const result = UsageQuerySchema.safeParse({
+      to: "2026-07-10T00:00:00Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid date format for from", () => {
+    const result = UsageQuerySchema.safeParse({ from: "not-a-date" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid date format for to", () => {
+    const result = UsageQuerySchema.safeParse({ to: "2026/07/01" });
+    expect(result.success).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // groupBy validation
+  // -----------------------------------------------------------------------
+  it("accepts valid groupBy values", () => {
+    for (const groupBy of ["day", "week", "month"]) {
+      const result = UsageQuerySchema.safeParse({ groupBy });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid groupBy value", () => {
+    const result = UsageQuerySchema.safeParse({ groupBy: "invalid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty groupBy string", () => {
+    const result = UsageQuerySchema.safeParse({ groupBy: "" });
+    expect(result.success).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // apiId validation
+  // -----------------------------------------------------------------------
+  it("accepts a valid apiId string", () => {
+    const result = UsageQuerySchema.safeParse({ apiId: "api-123" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.apiId).toBe("api-123");
+    }
+  });
+
+  it("accepts optional apiId", () => {
+    const result = UsageQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // cursor / after / before validation
+  // -----------------------------------------------------------------------
+  it("accepts a cursor string", () => {
+    const result = UsageQuerySchema.safeParse({ cursor: "bmV4dC1jdXJzb3I=" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts after and before parameters", () => {
+    const result = UsageQuerySchema.safeParse({
+      after: "bmV4dC1jdXJzb3I=",
+      before: "cHJldi1jdXJzb3I=",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // All fields together
+  // -----------------------------------------------------------------------
+  it("accepts all valid fields together", () => {
+    const result = UsageQuerySchema.safeParse({
+      from: "2026-07-01T00:00:00Z",
+      to: "2026-07-10T00:00:00Z",
+      apiId: "api-1",
+      groupBy: "day",
+      limit: "50",
+      offset: "0",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+      expect(result.data.offset).toBe(0);
+      expect(result.data.groupBy).toBe("day");
+      expect(result.data.apiId).toBe("api-1");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Empty / undefined handling
+  // -----------------------------------------------------------------------
+  it("accepts an empty object with all defaults", () => {
+    const result = UsageQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+      expect(result.data.offset).toBeUndefined();
+      expect(result.data.from).toBeUndefined();
+      expect(result.data.to).toBeUndefined();
+      expect(result.data.apiId).toBeUndefined();
+      expect(result.data.groupBy).toBeUndefined();
+      expect(result.data.cursor).toBeUndefined();
+      expect(result.data.after).toBeUndefined();
+      expect(result.data.before).toBeUndefined();
+    }
+  });
+
+  it("rejects unexpected extra fields", () => {
+    // Zod's default object schema allows unknown keys unless .strict() is used
+    const result = UsageQuerySchema.safeParse({ unknownField: "value" });
+    // Should still succeed because we don't use .strict()
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/validators/usage.ts
+++ b/src/validators/usage.ts
@@ -1,0 +1,61 @@
+/**
+ * Zod validation schemas for /api/usage routes.
+ *
+ * Schemas are co-located here so that:
+ *  - The shapes served at the HTTP boundary are easy to audit in one place.
+ *  - Route handlers stay thin — they import a schema and call safeParse().
+ *  - TypeScript inferred types are available without duplicating interfaces.
+ *
+ * Naming convention:
+ *  - Query-parameter schemas end in `QuerySchema`
+ *  - Inferred TS types drop the "Schema" suffix.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// GET /api/usage  (query parameters)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validated query parameters for listing usage events.
+ *
+ * Supports both offset/limit and cursor-based pagination.
+ * Date range defaults to the last 30 days when neither from/to is provided.
+ */
+export const UsageQuerySchema = z
+  .object({
+    /** ISO-8601 start of the query window (optional, defaults to 30 days ago). */
+    from: z.string().datetime().optional(),
+    /** ISO-8601 end of the query window (optional, defaults to now). */
+    to: z.string().datetime().optional(),
+    /** Filter events to a specific API (optional). */
+    apiId: z.string().optional(),
+    /** Aggregation period for stats (optional). */
+    groupBy: z.enum(["day", "week", "month"]).optional(),
+    /** Maximum number of events to return (1–100, default 20). */
+    limit: z.coerce.number().int().min(1).max(100).default(20),
+    /** Legacy cursor token for cursor-based pagination (base64-encoded). */
+    cursor: z.string().optional(),
+    /** Forward cursor for stable cursor-based pagination (base64-encoded). */
+    after: z.string().optional(),
+    /** Backward cursor for stable cursor-based pagination (base64-encoded). */
+    before: z.string().optional(),
+    /** Zero-based offset for offset/limit pagination (optional). */
+    offset: z.coerce.number().int().min(0).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.from && data.to) {
+        return new Date(data.from) <= new Date(data.to);
+      }
+      return true;
+    },
+    {
+      message: "'from' date must be before or equal to 'to' date",
+      path: ["from"],
+    },
+  );
+
+/** Inferred type for a validated usage query. */
+export type UsageQueryInput = z.infer<typeof UsageQuerySchema>;


### PR DESCRIPTION
## Description

Implements **Zod-validated input schema for usage** (Issue #651 — GrantFox FWC26 campaign, buffer #14).

### Changes

- **`src/validators/usage.ts`** — New validator module with exported `UsageQuerySchema` (Zod schema) and inferred `UsageQueryInput` type. Schema validates:
  - `from` / `to`: ISO-8601 datetime strings (optional, with cross-field check that `from <= to`)
  - `apiId`: optional filter string
  - `groupBy`: `"day"` | `"week"` | `"month"` (optional)
  - `limit`: coerced integer, 1–100, default 20
  - `cursor` / `after` / `before`: cursor pagination tokens (optional)
  - `offset`: coerced non-negative integer (optional)

- **`src/routes/usage.ts`** — Removed inline `UsageQuerySchema`, now imports from `../validators/usage.js`. Removed unused `z` import.

- **`src/validators/usage.test.ts`** — 30 focused unit tests covering:
  - Default values (limit defaults to 20)
  - limit bounds (0 rejected, 1–100 accepted, decimals/non-integers rejected)
  - offset validation (zero accepted, negative rejected)
  - from/to date ordering (from after to rejected)
  - groupBy enum (valid values accepted, invalid rejected)
  - apiId handling
  - cursor/after/before acceptance
  - All-fields-together smoke test
  - Empty-object defaults

### Testing

- All existing usage route tests (`src/routes/__tests__/usage.test.ts`) pass
- New validator unit tests pass
- TypeScript compilation clean (no type errors)
- Follows project conventions: co-located validator, `safeParse` usage, standardized error envelope

Closes #651