### PR TITLE
feat: ETag/304 caching on GET /api/tenants (#946)

### DIFF
--- a/docs/tenants-api.md
+++ b/docs/tenants-api.md
@@ -59,6 +59,70 @@ Request body accepts at least one of:
 
 Success response: `200` with `{ success: true, data, requestId, timestamp }`.
 
+## GET /api/tenants
+
+Returns the list of tenants for the authenticated actor. Supports **conditional
+GET** via strong ETags so dashboard clients can poll without re-downloading an
+unchanged payload.
+
+Required header:
+
+```http
+x-user-id: dev-1
+```
+
+### Caching behaviour (ETag / 304)
+
+Every successful `200` response includes a strong `ETag` header:
+
+```http
+ETag: "a1b2c3…64-char-sha256-hex…"
+```
+
+The digest is computed over the raw tenant list data only (not the volatile
+`timestamp` or `requestId` fields in the envelope), so the tag is stable
+across consecutive fetches that return the same tenant state.
+
+On a later request, send the ETag back in `If-None-Match`:
+
+```http
+GET /api/tenants
+If-None-Match: "a1b2c3…"
+```
+
+| Scenario | Response |
+|---|---|
+| Tenant list unchanged | `304 Not Modified` (empty body, `ETag` retained) |
+| Tenant list changed | `200 OK` with new body and updated `ETag` |
+| Mismatched / unrelated tag | `200 OK` with full body |
+| Weak tag (`W/"…"`) | `200 OK` — strong comparison; weak tags never match |
+| Wildcard (`*`) | `304 Not Modified` |
+
+Comparison follows **RFC 7232 §3.2 strong comparison**: weak client tags
+(`W/"…"`) never match the server's strong tag.
+
+### Example
+
+```bash
+# Initial fetch
+curl -i http://localhost:3000/api/tenants \
+  -H 'x-user-id: dev-1'
+# ← 200 OK
+# ← ETag: "e3b0c4…"
+# ← {"success":true,"data":[…],"requestId":"…","timestamp":"…"}
+
+# Conditional revalidation (unchanged list)
+curl -i http://localhost:3000/api/tenants \
+  -H 'x-user-id: dev-1' \
+  -H 'If-None-Match: "e3b0c4…"'
+# ← 304 Not Modified  (empty body)
+```
+
+### Related code
+
+- Middleware: `src/middleware/etag.ts` — `etagMiddleware` + `generateETag` + `etagMatches`
+- Route wiring: `src/routes/tenants.ts` (`GET /` handler)
+
 ## Validation Errors
 
 Invalid requests return `400` before route logic runs:

--- a/src/middleware/etag.ts
+++ b/src/middleware/etag.ts
@@ -81,19 +81,26 @@ export function etagMiddleware(req: Request, res: Response, next: NextFunction):
   const originalJson = res.json.bind(res);
 
   res.json = function (body?: unknown): Response {
-    // Only attach ETags to successful 200 responses that don't already have one
-    if (res.statusCode !== 200 || res.get('ETag')) {
+    // Only process successful 200 responses
+    if (res.statusCode !== 200) {
       return originalJson(body);
     }
 
-    // Serialise to the exact bytes that will form the response body
-    const serialised = JSON.stringify(body);
-    const etag = generateETag(serialised);
-
-    // Set our strong ETag before calling originalJson so Express won't
-    // overwrite it with its own weak variant (Express skips auto-ETag when one
-    // is already present on the response).
-    res.setHeader('ETag', etag);
+    // Determine the ETag to use.  A route may pre-set a strong ETag on the
+    // response (e.g. computed from stable payload fields to avoid hashing
+    // volatile envelope metadata like `timestamp`).  When one is already
+    // present we skip recomputing but still evaluate If-None-Match ourselves
+    // so that Express's built-in weak-comparison freshness logic never fires.
+    let etag = res.get('ETag') as string | undefined;
+    if (!etag) {
+      // No pre-set ETag — compute one from the full serialised body.
+      const serialised = JSON.stringify(body);
+      etag = generateETag(serialised);
+      // Set our strong ETag before calling originalJson so Express won't
+      // overwrite it with its own weak variant (Express skips auto-ETag when
+      // one is already present on the response).
+      res.setHeader('ETag', etag);
+    }
 
     const ifNoneMatch = req.header('if-none-match');
 

--- a/src/routes/tenants.test.ts
+++ b/src/routes/tenants.test.ts
@@ -11,6 +11,27 @@ import {
 import type { CreateTenantInput, UpdateTenantInput } from '../validators/tenants.js';
 
 class MockTenantRepository implements TenantRepository {
+  list = jest.fn(async (): Promise<TenantRecord[]> => ([
+    {
+      id: 'ten_test_123',
+      name: 'GrantFox Ops',
+      slug: 'grantfox-ops',
+      plan: 'growth',
+      createdBy: 'dev-1',
+      createdAt: '2026-07-28T00:00:00.000Z',
+      updatedAt: '2026-07-28T00:00:00.000Z',
+    },
+    {
+      id: 'ten_test_456',
+      name: 'GrantFox Stadium',
+      slug: 'grantfox-stadium',
+      plan: 'enterprise',
+      createdBy: 'dev-1',
+      createdAt: '2026-07-28T00:00:00.000Z',
+      updatedAt: '2026-07-28T00:00:00.000Z',
+    },
+  ]));
+
   create = jest.fn(async (input: CreateTenantInput, actorId: string): Promise<TenantRecord> => ({
     id: 'ten_test_123',
     name: input.name,
@@ -260,6 +281,111 @@ describe('createTenantsRouter', () => {
       .patch('/api/tenants/tenant_123')
       .set('x-user-id', 'dev-1')
       .send({ name: 'GrantFox Ops' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('INTERNAL_SERVER_ERROR');
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET / — list tenants with ETag / 304
+  // ---------------------------------------------------------------------------
+
+  it('returns 401 for GET when unauthenticated', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app).get('/api/tenants');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 200 with list of tenants in envelope', async () => {
+    const { app, repository } = buildApp();
+
+    const res = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0]).toMatchObject({ id: 'ten_test_123', name: 'GrantFox Ops' });
+    expect(res.body.data[1]).toMatchObject({ id: 'ten_test_456', name: 'GrantFox Stadium' });
+    expect(repository.list).toHaveBeenCalled();
+  });
+
+  it('sets a strong ETag header on GET response', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.etag).toBeDefined();
+    expect(res.headers.etag).toMatch(/^"[0-9a-f]{64}"$/);
+  });
+
+  it('returns 304 Not Modified when If-None-Match matches the ETag', async () => {
+    const { app } = buildApp();
+
+    const first = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1');
+
+    expect(first.status).toBe(200);
+    const etag = first.headers.etag as string;
+    expect(etag).toBeDefined();
+
+    const second = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('If-None-Match', etag);
+
+    expect(second.status).toBe(304);
+    expect(second.text).toBe('');
+  });
+
+  it('returns 200 when If-None-Match does not match the ETag', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('If-None-Match', '"different-hash-value"');
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('does not return 304 for a weak ETag (strong comparison)', async () => {
+    const { app } = buildApp();
+
+    const first = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1');
+
+    expect(first.status).toBe(200);
+    const etag = first.headers.etag as string;
+    const weakTag = `W/${etag}`;
+
+    const second = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('If-None-Match', weakTag);
+
+    expect(second.status).toBe(200);
+  });
+
+  it('routes list repository errors through the error handler', async () => {
+    const repository = new MockTenantRepository();
+    repository.list.mockRejectedValueOnce(new Error('tenant store unavailable'));
+    const { app } = buildApp(repository);
+
+    const res = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1');
 
     expect(res.status).toBe(500);
     expect(res.body.error.code).toBe('INTERNAL_SERVER_ERROR');

--- a/src/routes/tenants.ts
+++ b/src/routes/tenants.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import { requireAuth, type AuthenticatedLocals } from '../middleware/requireAuth.js';
 import { bodyValidator, validate } from '../middleware/validate.js';
 import { buildSuccessEnvelope } from '../middleware/envelope.js';
+import { etagMiddleware, generateETag } from '../middleware/etag.js';
 import { logger } from '../logger.js';
 import {
   createTenantSchema,
@@ -25,12 +26,17 @@ export interface TenantRecord {
 }
 
 export interface TenantRepository {
+  list(): Promise<TenantRecord[]>;
   create(input: CreateTenantInput, actorId: string): Promise<TenantRecord>;
   update(tenantId: string, input: UpdateTenantInput, actorId: string): Promise<TenantRecord>;
 }
 
 class InMemoryTenantRepository implements TenantRepository {
   private tenants = new Map<string, TenantRecord>();
+
+  async list(): Promise<TenantRecord[]> {
+    return Array.from(this.tenants.values());
+  }
 
   async create(input: CreateTenantInput, actorId: string): Promise<TenantRecord> {
     const now = new Date().toISOString();
@@ -141,6 +147,34 @@ export function createTenantsRouter(deps: TenantsRouterDeps = {}): Router {
         });
 
         res.json(buildSuccessEnvelope(tenant, requestId(req)));
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.get(
+    '/',
+    requireAuth,
+    etagMiddleware,
+    async (req: Request, res: Response<unknown, AuthenticatedLocals>, next) => {
+      try {
+        const tenants = await tenantRepository.list();
+
+        logger.info('[tenants] tenants listed', {
+          requestId: requestId(req),
+          correlationId: correlationId(req),
+          count: tenants.length,
+        });
+
+        // Pre-set a strong ETag derived from the tenant data alone, so that the
+        // ETag is stable across calls that return the same tenant list regardless
+        // of envelope fields that change per-request (timestamp, requestId).
+        // The etagMiddleware will honour the pre-set ETag and evaluate
+        // If-None-Match against it without recomputing a new hash.
+        res.setHeader('ETag', generateETag(JSON.stringify(tenants)));
+
+        res.json(buildSuccessEnvelope(tenants, requestId(req)));
       } catch (error) {
         next(error);
       }


### PR DESCRIPTION
## Summary

Implements strong ETag / 304 Not Modified caching on `GET /api/tenants` as specified in issue #946.

## Changes

### `src/middleware/etag.ts`
Extended `etagMiddleware` to honour a **pre-set** `ETag` response header while still evaluating `If-None-Match` through our own strong-comparison logic (RFC 7232 §3.2). Previously, a pre-set ETag caused the middleware to skip all freshness evaluation entirely, letting Express's built-in weak-comparison `fresh` module incorrectly return 304 for `W/"..."` tags.

### `src/routes/tenants.ts`
The `GET /` handler now pre-sets the strong ETag from the **tenant list data alone** before wrapping it in the response envelope:

ts
res.setHeader('ETag', generateETag(JSON.stringify(tenants)));

This makes the tag stable across consecutive fetches returning the same tenant state, regardless of volatile envelope fields (`timestamp`, `requestId`) that change per request.

### `src/routes/tenants.test.ts`
Added focused ETag/304 integration tests:
- 200 with a strong `ETag` header on first fetch
- 304 when `If-None-Match` matches exactly
- 200 when `If-None-Match` doesn't match
- 200 (not 304) for a weak tag — strong comparison only
- 401 for unauthenticated GET
- 500 propagation for repository errors

### `docs/tenants-api.md`
Added `GET /api/tenants` section documenting ETag format, `If-None-Match` semantics, comparison rules, and a curl example.

## Testing


npx jest --forceExit --testPathPattern="etag|tenants" --no-coverage

80/80 tests pass across all 4 suites.

Closes #946
