### PR TITLE
feat: security header sweep for /api/errors (#945)

### DIFF
--- a/docs/errors-security-headers.md
+++ b/docs/errors-security-headers.md
@@ -1,0 +1,71 @@
+# /api/errors Security Headers
+
+Every response from `/api/errors` — across all verbs, status codes, and both
+success and error paths — carries the following security headers as part of the
+GrantFox FWC26 security header sweep (#945).
+
+## Headers applied
+
+| Header | Value |
+|---|---|
+| `Content-Security-Policy` | `default-src 'self'; frame-ancestors 'none'; object-src 'none'` |
+| `X-Content-Type-Options` | `nosniff` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+
+### Why each header matters
+
+**Content-Security-Policy** — Restricts what resources the browser may load
+when an API response is rendered in a browser context. `frame-ancestors 'none'`
+prevents clickjacking; `object-src 'none'` blocks plugin-based attacks.
+
+**X-Content-Type-Options: nosniff** — Instructs browsers not to MIME-sniff the
+response away from the declared `Content-Type`, preventing content-confusion
+attacks where a JSON response is executed as a script.
+
+**Referrer-Policy: strict-origin-when-cross-origin** — Limits the `Referer`
+header to the origin only when making cross-origin requests, protecting
+potentially sensitive path information from leaking to third parties.
+
+## Implementation
+
+The middleware is applied as a router-level `use` at the top of
+`createErrorsRouter` so it fires before every route handler — including before
+`requireAuth`, meaning even `401 Unauthorized` and `400 Validation Error`
+responses carry the headers:
+
+```ts
+// src/routes/errors.ts
+router.use(securityHeadersMiddleware);
+```
+
+`securityHeadersMiddleware` is the shared default instance exported from
+`src/middleware/securityHeaders.ts`. The same instance is used on
+`/api/exports`, `/api/webhooks`, and `/api/admin/audit`.
+
+## Coverage
+
+`src/routes/errors.test.ts` contains a dedicated `describe` block
+(`/api/errors security headers (#945)`) that asserts all three headers on:
+
+| Verb | Path | Status codes covered |
+|---|---|---|
+| `GET` | `/api/errors` | 200 |
+| `GET` | `/api/errors/:id` | 404 |
+| `POST` | `/api/errors` | 201, 400, 401 |
+| `PATCH` | `/api/errors/:id` | 200, 404 |
+| `PUT` | `/api/errors/:id` | 200 |
+| `DELETE` | `/api/errors/:id` | 204, 404 |
+
+Run the focused tests with:
+
+```bash
+npx jest --forceExit --testPathPattern="src/routes/errors" --no-coverage
+```
+
+## Related
+
+- Middleware implementation: `src/middleware/securityHeaders.ts`
+- Middleware unit tests: `src/middleware/securityHeaders.test.ts`
+- Same pattern on exports: `src/routes/exports.ts`
+- Same pattern on webhooks: `src/webhooks/webhook.routes.ts`
+- Same pattern on admin audit: `src/routes/admin/audit.ts`

--- a/src/routes/errors.test.ts
+++ b/src/routes/errors.test.ts
@@ -299,3 +299,190 @@ describe('/api/errors audit logging (#918)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Security header sweep — GrantFox FWC26 (#945)
+// Verifies that every /api/errors response (success and error paths, across
+// all HTTP verbs) carries the required security headers.
+// ---------------------------------------------------------------------------
+
+const EXPECTED_CSP_FRAGMENT = "default-src 'self'";
+const EXPECTED_XCT = 'nosniff';
+const EXPECTED_RP = 'strict-origin-when-cross-origin';
+
+/** Shared no-op audit service for read-only and header-only tests. */
+const noopAudit: AuditService = { record: jest.fn().mockResolvedValue(undefined) };
+
+describe('/api/errors security headers (#945)', () => {
+  beforeEach(() => {
+    resetErrorStore();
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/errors — list (unauthenticated, public read)
+  // -----------------------------------------------------------------------
+  describe('GET /api/errors', () => {
+    it('includes Content-Security-Policy with default-src self', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app).get('/api/errors');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-security-policy']).toBeDefined();
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+    });
+
+    it('includes X-Content-Type-Options: nosniff', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app).get('/api/errors');
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+    });
+
+    it('includes Referrer-Policy: strict-origin-when-cross-origin', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app).get('/api/errors');
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/errors/:id — single record (404 error path)
+  // -----------------------------------------------------------------------
+  describe('GET /api/errors/:id — 404 error path', () => {
+    it('includes all three security headers on a 404 response', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app).get('/api/errors/nonexistent');
+      expect(res.status).toBe(404);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // POST /api/errors — create (201 success path)
+  // -----------------------------------------------------------------------
+  describe('POST /api/errors', () => {
+    it('includes all three security headers on a 201 Created response', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app)
+        .post('/api/errors')
+        .set('x-user-id', 'dev-sec-1')
+        .send({ code: 'ERR_SEC_001', message: 'Security test', statusCode: 400 });
+      expect(res.status).toBe(201);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+
+    it('includes security headers on 401 Unauthorized response', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app)
+        .post('/api/errors')
+        .send({ code: 'ERR_SEC_001', message: 'Security test', statusCode: 400 });
+      expect(res.status).toBe(401);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+
+    it('includes security headers on 400 validation-error response', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app)
+        .post('/api/errors')
+        .set('x-user-id', 'dev-sec-1')
+        .send({ message: 'Missing required fields' });
+      expect(res.status).toBe(400);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // PATCH /api/errors/:id — update (200 success path)
+  // -----------------------------------------------------------------------
+  describe('PATCH /api/errors/:id', () => {
+    it('includes all three security headers on a 200 OK response', async () => {
+      const app = buildApp(noopAudit);
+      // Seed a record first
+      await request(app)
+        .post('/api/errors')
+        .set('x-user-id', 'dev-sec-1')
+        .send({ code: 'ERR_PATCH_SEED', message: 'Seed record', statusCode: 422 });
+
+      const res = await request(app)
+        .patch('/api/errors/1')
+        .set('x-user-id', 'dev-sec-1')
+        .send({ message: 'Updated security test message' });
+      expect(res.status).toBe(200);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+
+    it('includes security headers on 404 response for unknown resource', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app)
+        .patch('/api/errors/9999')
+        .set('x-user-id', 'dev-sec-1')
+        .send({ message: 'Does not exist' });
+      expect(res.status).toBe(404);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // PUT /api/errors/:id — full update
+  // -----------------------------------------------------------------------
+  describe('PUT /api/errors/:id', () => {
+    it('includes all three security headers on a 200 OK response', async () => {
+      const app = buildApp(noopAudit);
+      await request(app)
+        .post('/api/errors')
+        .set('x-user-id', 'dev-sec-1')
+        .send({ code: 'ERR_PUT_SEED', message: 'Seed for PUT', statusCode: 503 });
+
+      const res = await request(app)
+        .put('/api/errors/1')
+        .set('x-user-id', 'dev-sec-1')
+        .send({ code: 'ERR_PUT_UPDATED' });
+      expect(res.status).toBe(200);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DELETE /api/errors/:id — deletion (204 No Content)
+  // -----------------------------------------------------------------------
+  describe('DELETE /api/errors/:id', () => {
+    it('includes all three security headers on a 204 No Content response', async () => {
+      const app = buildApp(noopAudit);
+      await request(app)
+        .post('/api/errors')
+        .set('x-user-id', 'dev-sec-1')
+        .send({ code: 'ERR_DEL_SEED', message: 'Seed for DELETE', statusCode: 500 });
+
+      const res = await request(app)
+        .delete('/api/errors/1')
+        .set('x-user-id', 'dev-sec-1');
+      expect(res.status).toBe(204);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+
+    it('includes security headers on 404 response for unknown resource', async () => {
+      const app = buildApp(noopAudit);
+      const res = await request(app)
+        .delete('/api/errors/9999')
+        .set('x-user-id', 'dev-sec-1');
+      expect(res.status).toBe(404);
+      expect(res.headers['content-security-policy']).toContain(EXPECTED_CSP_FRAGMENT);
+      expect(res.headers['x-content-type-options']).toBe(EXPECTED_XCT);
+      expect(res.headers['referrer-policy']).toBe(EXPECTED_RP);
+    });
+  });
+});

--- a/src/routes/errors.ts
+++ b/src/routes/errors.ts
@@ -6,6 +6,7 @@ import { BadRequestError, NotFoundError, UnauthorizedError } from '../errors/ind
 import { validate } from '../middleware/validate.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { successEnvelope } from '../lib/envelope.js';
+import { securityHeadersMiddleware } from '../middleware/securityHeaders.js';
 
 export interface ErrorRecord {
   id: string;
@@ -113,6 +114,10 @@ export function resetErrorStore(): void {
 export function createErrorsRouter(deps: ErrorsRouterDeps = {}): Router {
   const router = Router();
   const auditService = deps.auditService ?? defaultAuditService;
+
+  // Apply CSP, X-Content-Type-Options, and Referrer-Policy on every /api/errors
+  // response (success and error paths) — GrantFox FWC26 security header sweep.
+  router.use(securityHeadersMiddleware);
 
   /**
    * GET /api/errors — List error definitions (read-only, non-audited).


### PR DESCRIPTION
## Summary

Applies CSP, X-Content-Type-Options, and Referrer-Policy to every `/api/errors`
response as part of the GrantFox FWC26 security header sweep.

## Changes

### `src/routes/errors.ts`
Added `router.use(securityHeadersMiddleware)` at the top of `createErrorsRouter`,
matching the established pattern on `/api/exports`, `/api/webhooks`, and
`/api/admin/audit`. Mounting it before all route handlers means even `401` and
`400` error responses carry the headers — no path is unprotected.

### `src/routes/errors.test.ts`
Added a focused `/api/errors security headers (#945)` describe block asserting
all three headers across every verb and representative status codes:

| Verb | Status codes covered |
|---|---|
| `GET /` | 200 |
| `GET /:id` | 404 |
| `POST /` | 201, 401, 400 |
| `PATCH /:id` | 200, 404 |
| `PUT /:id` | 200 |
| `DELETE /:id` | 204, 404 |

### `docs/errors-security-headers.md`
New doc describing the headers applied, rationale for each, implementation
detail, and test coverage table.

## Testing


npx jest --forceExit --testPathPattern="src/routes/errors|src/middleware/securityHeaders" --no-coverage

33/33 tests pass across 3 suites.

Closes #945
