### PR TITLE
feat(openapi): add OpenAPI examples for /api/webhooks endpoints

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -871,6 +871,49 @@ paths:
                     events:
                       - "new_api_call"
                       - "low_balance_alert"
+        "400":
+          description: Bad request — invalid webhook registration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                missingFields:
+                  summary: Missing required fields
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: developerId, url, and a non-empty events array are required.
+                    requestId: req-webhook-post-400-missing
+                    timestamp: "2026-07-27T09:15:00.000Z"
+                invalidEventTypes:
+                  summary: Invalid event types
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: Invalid event types: invalid_event. Valid: new_api_call, settlement_completed, low_balance_alert
+                    requestId: req-webhook-post-400-events
+                    timestamp: "2026-07-27T09:16:00.000Z"
+                invalidUrl:
+                  summary: Invalid webhook URL
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: URL is not reachable or does not return 2xx
+                    requestId: req-webhook-post-400-url
+                    timestamp: "2026-07-27T09:17:00.000Z"
+                invalidRetryPolicy:
+                  summary: Invalid retry policy
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: retryPolicy.maxRetries must be between 0 and 10
+                    requestId: req-webhook-post-400-retry
+                    timestamp: "2026-07-27T09:18:00.000Z"
   /api/webhooks/{developerId}:
     get:
       summary: Get webhook config
@@ -906,6 +949,237 @@ paths:
                   summary: No webhook registered
                   value:
                     message: "No webhook registered for this developer."
+  /api/webhooks/{developerId}:
+    delete:
+      summary: Remove webhook
+      description: >
+        Removes the webhook configuration for the given developer. The webhook
+        will no longer receive events. This action is idempotent — calling
+        delete on a non-existent webhook still returns success.
+      responses:
+        "200":
+          description: Webhook removed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                removed:
+                  summary: Successfully removed
+                  value:
+                    message: Webhook removed.
+  /api/webhooks/{developerId}/rotate-secret:
+    post:
+      summary: Rotate webhook signing secret
+      description: >
+        Rotates the HMAC signing secret for the given developer's webhook. The
+        previous secret remains valid for a grace period (configurable via
+        WEBHOOK_SECRET_ROTATION_GRACE_MS) so consumers can transition without
+        delivery gaps.
+      responses:
+        "200":
+          description: Secret rotated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                rotated:
+                  summary: Successfully rotated
+                  value:
+                    message: Webhook secret rotated successfully.
+                    developerId: "dev-123"
+                    secret: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1
+                    previous_expires_at: "2026-07-27T10:15:00.000Z"
+        "404":
+          description: Webhook not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No webhook registered
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: No webhook registered for this developer.
+                    requestId: req-webhook-rotate-404
+                    timestamp: "2026-07-27T09:20:00.000Z"
+  /api/webhooks/{developerId}/retry-policy:
+    patch:
+      summary: Update webhook retry policy
+      description: >
+        Updates the per-subscription retry policy for the given developer's
+        webhook. Only the retryPolicy field is replaced; all other settings
+        remain unchanged.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+            examples:
+              updateRetryPolicy:
+                summary: Set custom retry policy
+                value:
+                  retryPolicy:
+                    maxRetries: 5
+                    baseDelayMs: 2000
+      responses:
+        "200":
+          description: Retry policy updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                updated:
+                  summary: Successfully updated
+                  value:
+                    message: Webhook retry policy updated successfully.
+                    developerId: "dev-123"
+                    url: "https://example.com/webhook"
+                    events:
+                      - "new_api_call"
+                      - "low_balance_alert"
+                    retryPolicy:
+                      maxRetries: 5
+                      baseDelayMs: 2000
+                    createdAt: "2026-07-27T09:00:00.000Z"
+        "400":
+          description: Bad request — invalid retry policy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                invalidRetryPolicy:
+                  summary: Invalid retry policy
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: retryPolicy.maxRetries must be between 0 and 10
+                    requestId: req-webhook-retry-patch-400
+                    timestamp: "2026-07-27T09:21:00.000Z"
+        "404":
+          description: Webhook not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No webhook registered
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: No webhook registered for this developer.
+                    requestId: req-webhook-retry-patch-404
+                    timestamp: "2026-07-27T09:22:00.000Z"
+  /api/webhooks/deliver/{developerId}:
+    post:
+      summary: Deliver a webhook event
+      description: >
+        Receives a signed webhook event from an external system. The request
+        body must include an HMAC-SHA256 signature in the
+        X-Callora-Signature-256 header and a timestamp in the
+        X-Callora-Timestamp header. The signature is verified before the
+        payload is processed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+            examples:
+              deliverEvent:
+                summary: Deliver a new_api_call event
+                value:
+                  event: new_api_call
+                  timestamp: "2026-07-27T09:30:00.000Z"
+                  developerId: "dev-123"
+                  data:
+                    apiId: "api-456"
+                    endpoint: /v1/checkout
+                    method: POST
+                    statusCode: 200
+                    latencyMs: 145
+                    creditsUsed: 10
+      responses:
+        "200":
+          description: Webhook delivery accepted
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                accepted:
+                  summary: Delivery accepted
+                  value:
+                    message: Webhook delivery accepted.
+                    body:
+                      event: new_api_call
+                      timestamp: "2026-07-27T09:30:00.000Z"
+                      developerId: "dev-123"
+                      data:
+                        apiId: "api-456"
+                        endpoint: /v1/checkout
+                        method: POST
+                        statusCode: 200
+                        latencyMs: 145
+                        creditsUsed: 10
+        "400":
+          description: Bad request — invalid payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                missingSignature:
+                  summary: Missing signature headers
+                  value:
+                    success: false
+                    error:
+                      code: BAD_REQUEST
+                      message: Missing required webhook signature headers
+                    requestId: req-webhook-deliver-400-sig
+                    timestamp: "2026-07-27T09:31:00.000Z"
+        "401":
+          description: Invalid webhook signature
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                invalidSignature:
+                  summary: Signature verification failed
+                  value:
+                    success: false
+                    error:
+                      code: UNAUTHORIZED
+                      message: Webhook signature verification failed
+                    requestId: req-webhook-deliver-401-invalid
+                    timestamp: "2026-07-27T09:32:00.000Z"
+        "404":
+          description: Webhook not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                notFound:
+                  summary: No webhook registered
+                  value:
+                    success: false
+                    error:
+                      code: NOT_FOUND
+                      message: No webhook registered for this developer.
+                    requestId: req-webhook-deliver-404
+                    timestamp: "2026-07-27T09:33:00.000Z"
 components:
   securitySchemes:
     bearerAuth:

--- a/src/routes/webhooks/openapi-yaml.test.ts
+++ b/src/routes/webhooks/openapi-yaml.test.ts
@@ -25,4 +25,49 @@ describe('src/openapi.yaml — webhooks examples', () => {
     expect(content).toContain('new_api_call');
     expect(content).toContain('low_balance_alert');
   });
+
+  test('documents POST /api/webhooks/{developerId}/rotate-secret endpoint', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/api/webhooks/{developerId}/rotate-secret');
+    expect(content).toContain('Rotate webhook signing secret');
+    expect(content).toContain('Webhook secret rotated successfully.');
+  });
+
+  test('documents DELETE /api/webhooks/{developerId} endpoint', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('Remove webhook');
+    expect(content).toContain('Webhook removed.');
+  });
+
+  test('documents PATCH /api/webhooks/{developerId}/retry-policy endpoint', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/api/webhooks/{developerId}/retry-policy');
+    expect(content).toContain('Update webhook retry policy');
+    expect(content).toContain('Webhook retry policy updated successfully.');
+  });
+
+  test('documents POST /api/webhooks/deliver/{developerId} endpoint', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toContain('/api/webhooks/deliver/{developerId}');
+    expect(content).toContain('Deliver a webhook event');
+    expect(content).toContain('Webhook delivery accepted.');
+  });
+
+  test('includes error response examples for webhook endpoints', () => {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    // POST /api/webhooks 400 errors
+    expect(content).toContain('Missing required fields');
+    expect(content).toContain('Invalid event types');
+    expect(content).toContain('Invalid webhook URL');
+    expect(content).toContain('Invalid retry policy');
+    // rotate-secret 404
+    expect(content).toContain('req-webhook-rotate-404');
+    // retry-policy 400 and 404
+    expect(content).toContain('req-webhook-retry-patch-400');
+    expect(content).toContain('req-webhook-retry-patch-404');
+    // deliver 400, 401, 404
+    expect(content).toContain('req-webhook-deliver-400-sig');
+    expect(content).toContain('req-webhook-deliver-401-invalid');
+    expect(content).toContain('req-webhook-deliver-404');
+  });
 });


### PR DESCRIPTION
## Overview

This PR adds OpenAPI request/response examples for the /api/webhooks endpoints in src/openapi.yaml. Previously only POST /api/webhooks (register) and GET /api/webhooks/{developerId} (get config) had examples documented. This change adds examples for all remaining webhook management endpoints, including error responses, to give API consumers a complete picture of the webhook surface.

## Related Issue

Closes #871

## Changes

### OpenAPI Examples

* **[ADD]** Error response examples for POST /api/webhooks -- 400 responses for missing fields, invalid event types, invalid URL, and invalid retry policy.
* **[ADD]** DELETE /api/webhooks/{developerId} -- 200 success response example.
* **[ADD]** POST /api/webhooks/{developerId}/rotate-secret -- 200 success and 404 not-found response examples.
* **[ADD]** PATCH /api/webhooks/{developerId}/retry-policy -- 200 success, 400 bad request, and 404 not-found response examples.
* **[ADD]** POST /api/webhooks/deliver/{developerId} -- 200 success, 400 bad request, 401 invalid signature, and 404 not-found response examples.

### Tests

* **[UPDATE]** src/routes/webhooks/openapi-yaml.test.ts -- Added assertions for all new endpoint examples and error responses.

## Verification Results

All 16 tests pass (2 suites) covering rate-limit and webhooks openapi-yaml tests.

| Acceptance Criteria | Status |
| --- | --- |
| OpenAPI examples added for all /api/webhooks endpoints | ✅ |
| Error response examples included (400, 401, 404) | ✅ |
| Companion tests assert new examples | ✅ |
| Tests pass without regressions | ✅ |
| Author and committer match assigned user | ✅ |