### PR TITLE
feat: standardise refresh-token rate limit error envelope

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -96,10 +96,14 @@ export function createTokenBucketRateLimitMiddleware(
 
       res.set("Retry-After", String(retryAfterSeconds));
       res.status(429).json({
-        code: "TOO_MANY_REQUESTS",
-        message: "Too Many Requests",
+        success: false,
+        error: {
+          code: "TOO_MANY_REQUESTS",
+          message: "Too Many Requests",
+          retryAfterMs,
+        },
         requestId,
-        retryAfterMs,
+        timestamp: new Date().toISOString(),
       });
       return;
     }

--- a/src/routes/refresh-token.test.ts
+++ b/src/routes/refresh-token.test.ts
@@ -543,12 +543,15 @@ describe('GET /api/refresh-token', () => {
       expect(res3.status).toBe(429);
       expect(res3.body).toEqual(
         expect.objectContaining({
-          code: 'TOO_MANY_REQUESTS',
-          message: 'Too Many Requests',
+          success: false,
+          error: expect.objectContaining({
+            code: 'TOO_MANY_REQUESTS',
+            message: 'Too Many Requests',
+            retryAfterMs: expect.any(Number),
+          }),
         }),
       );
       expect(res3.body).toHaveProperty('requestId');
-      expect(res3.body).toHaveProperty('retryAfterMs');
     });
 
     it('returns Retry-After header in whole seconds reflecting refill time', async () => {


### PR DESCRIPTION
# Description
This PR standardizes the token-bucket rate limit error payload returned on the `/api/refresh-token` endpoint. 

The `createTokenBucketRateLimitMiddleware` response was refactored to align with the canonical project error envelope, resolving inconsistencies with input validation boundaries. The accompanying integration tests have been focused and updated to verify the nested structure format along with `Retry-After`.

Closes #724

### Requirements Fulfilled:
- [x] Per-user token-bucket rate limit with 429 + Retry-After (via existing `getRateLimitKey` identifying the user from auth headers).
- [x] Input validation at the boundary utilizing the standardized error envelope.
- [x] Updated focused tests reflecting the structural schema change.
- [x] Structured logs with correlation IDs are preserved untouched during `429` enforcement.
