### PR TITLE
feat: add per-developer concurrency stat endpoint at /api/admin/metrics

### DIFF
--- a/src/routes/admin/metrics.test.ts
+++ b/src/routes/admin/metrics.test.ts
@@ -36,6 +36,120 @@ function buildApp(developerSemaphore: DeveloperSemaphore) {
 }
 
 // ---------------------------------------------------------------------------
+// GET /api/admin/metrics — per-developer concurrency stats overview
+// ---------------------------------------------------------------------------
+
+describe('GET /api/admin/metrics', () => {
+  let developerSemaphore: DeveloperSemaphore;
+
+  beforeEach(() => {
+    developerSemaphore = new DeveloperSemaphore(5, 1000);
+  });
+
+  afterEach(() => {
+    developerSemaphore.clear();
+  });
+
+  it('returns empty stats when no developers are active', async () => {
+    const app = buildApp(developerSemaphore);
+
+    const res = await request(app)
+      .get('/api/admin/metrics')
+      .set('x-admin-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      totalActive: 0,
+      activeDeveloperCount: 0,
+      perDeveloper: [],
+      campaign: 'GrantFox FWC26',
+    });
+    expect(res.body.data.maxConcurrencyPerDeveloper).toBe(5);
+  });
+
+  it('returns per-developer stats with correct utilization', async () => {
+    const app = buildApp(developerSemaphore);
+
+    await developerSemaphore.withSlot('dev_abc', async () => {
+      await developerSemaphore.withSlot('dev_abc', async () => {
+        await developerSemaphore.withSlot('dev_def', async () => {
+          const res = await request(app)
+            .get('/api/admin/metrics')
+            .set('x-admin-api-key', ADMIN_KEY);
+
+          expect(res.status).toBe(200);
+          expect(res.body.data.totalActive).toBe(3);
+          expect(res.body.data.activeDeveloperCount).toBe(2);
+          expect(res.body.data.perDeveloper).toHaveLength(2);
+          expect(res.body.data.perDeveloper[0]).toMatchObject({
+            developerId: 'dev_abc',
+            activeCount: 2,
+            atLimit: false,
+            utilizationPercent: 40,
+          });
+          expect(res.body.data.perDeveloper[1]).toMatchObject({
+            developerId: 'dev_def',
+            activeCount: 1,
+            atLimit: false,
+            utilizationPercent: 20,
+          });
+        });
+      });
+    });
+  });
+
+  it('reports atLimit and 100% utilization when exactly at the ceiling', async () => {
+    const sem = new DeveloperSemaphore(1, 1000);
+    const app = buildApp(sem);
+
+    await sem.withSlot('dev_maxed', async () => {
+      const res = await request(app)
+        .get('/api/admin/metrics')
+        .set('x-admin-api-key', ADMIN_KEY);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.perDeveloper[0]).toMatchObject({
+        developerId: 'dev_maxed',
+        activeCount: 1,
+        atLimit: true,
+        utilizationPercent: 100,
+      });
+    });
+    sem.clear();
+  });
+
+  it('sorts per-developer results by active count descending', async () => {
+    const app = buildApp(developerSemaphore);
+
+    await developerSemaphore.withSlot('dev_light', async () => {
+      await developerSemaphore.withSlot('dev_heavy', async () => {
+        await developerSemaphore.withSlot('dev_heavy', async () => {
+          await developerSemaphore.withSlot('dev_heavy', async () => {
+            const res = await request(app)
+              .get('/api/admin/metrics')
+              .set('x-admin-api-key', ADMIN_KEY);
+
+            expect(res.status).toBe(200);
+            expect(res.body.data.perDeveloper[0].developerId).toBe('dev_heavy');
+            expect(res.body.data.perDeveloper[0].activeCount).toBe(3);
+            expect(res.body.data.perDeveloper[1].developerId).toBe('dev_light');
+            expect(res.body.data.perDeveloper[1].activeCount).toBe(1);
+          });
+        });
+      });
+    });
+  });
+
+  it('requires admin authentication — 401 without credentials', async () => {
+    const app = buildApp(developerSemaphore);
+
+    const res = await request(app).get('/api/admin/metrics');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // GET /api/admin/metrics/concurrency — collection endpoint
 // ---------------------------------------------------------------------------
 

--- a/src/routes/admin/metrics.ts
+++ b/src/routes/admin/metrics.ts
@@ -6,6 +6,7 @@ import { getClientIp } from '../../lib/clientIp.js';
 import { logger } from '../../logger.js';
 import { validate } from '../../middleware/validate.js';
 import { DeveloperSemaphore, sharedDeveloperSemaphore } from '../../utils/developerSemaphore.js';
+import { computeConcurrencyStats } from '../../services/concurrency.js';
 
 const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
 const GRANTFOX_FWC26_CAMPAIGN = 'GrantFox FWC26';
@@ -30,6 +31,10 @@ export interface AdminDevMetricsRouterDeps {
  * traffic.
  *
  * @example
+ * // Per-developer concurrency stats overview
+ * GET /api/admin/metrics
+ * // → { data: { totalActive: 3, activeDeveloperCount: 2, perDeveloper: [...], ... } }
+ *
  * // Active slot counts for all developers
  * GET /api/admin/metrics/concurrency
  * // → { data: { devCounts: { "dev_abc": 2 }, totalActive: 2 } }
@@ -43,6 +48,53 @@ export function createAdminDevMetricsRouter(
 ): Router {
   const router = Router();
   const developerSemaphore = deps.developerSemaphore ?? sharedDeveloperSemaphore;
+
+  /**
+   * GET /
+   *
+   * Returns a per-developer concurrency stats overview.  This is a
+   * dashboard-friendly summary that includes per-developer breakdown with
+   * utilisation percentages, total active slots, and system-level counts.
+   *
+   * Response shape:
+   * ```json
+   * {
+   *   "data": {
+   *     "totalActive": 3,
+   *     "maxConcurrencyPerDeveloper": 1,
+   *     "activeDeveloperCount": 2,
+   *     "perDeveloper": [
+   *       { "developerId": "dev_abc", "activeCount": 2, "atLimit": true, "utilizationPercent": 200 },
+   *       { "developerId": "dev_def", "activeCount": 1, "atLimit": false, "utilizationPercent": 100 }
+   *     ],
+   *     "campaign": "GrantFox FWC26"
+   *   }
+   * }
+   * ```
+   */
+  router.get('/', (req, res, next) => {
+    try {
+      const stats = computeConcurrencyStats(developerSemaphore);
+
+      logger.audit('READ_DEV_CONCURRENCY_STATS', res.locals.adminActor, {
+        campaign: GRANTFOX_FWC26_CAMPAIGN,
+        totalActive: stats.totalActive,
+        activeDeveloperCount: stats.activeDeveloperCount,
+        clientIp: getClientIp(req, TRUST_PROXY),
+        userAgent: req.get('User-Agent'),
+        correlationId: req.headers['x-request-id'] ?? req.headers['x-correlation-id'],
+      });
+
+      res.json({ data: stats });
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+        return;
+      }
+      logger.error('Failed to read developer concurrency stats', { error });
+      next(new InternalServerError());
+    }
+  });
 
   /**
    * GET /concurrency

--- a/src/services/concurrency.ts
+++ b/src/services/concurrency.ts
@@ -1,0 +1,58 @@
+import { DeveloperSemaphore } from '../utils/developerSemaphore.js';
+
+export interface PerDeveloperConcurrencyStat {
+  developerId: string;
+  activeCount: number;
+  atLimit: boolean;
+  utilizationPercent: number;
+}
+
+export interface ConcurrencyStats {
+  totalActive: number;
+  maxConcurrencyPerDeveloper: number;
+  activeDeveloperCount: number;
+  perDeveloper: PerDeveloperConcurrencyStat[];
+  campaign: string;
+}
+
+const GRANTFOX_FWC26_CAMPAIGN = 'GrantFox FWC26';
+
+/**
+ * Computes enriched per-developer concurrency statistics from the shared
+ * DeveloperSemaphore.
+ *
+ * This service exists as a single place to derive stats (utilization %, counts,
+ * summary fields) so that the admin metrics route stays thin and the logic can
+ * be unit-tested independently.
+ */
+export function computeConcurrencyStats(
+  semaphore: DeveloperSemaphore,
+): ConcurrencyStats {
+  const devCounts = semaphore.getCurrentActiveSlotCounts();
+  const totalActive = semaphore.getTotalActiveSlotCount();
+  const maxConcurrencyPerDeveloper = semaphore.maxConcurrency;
+  const developerIds = Object.keys(devCounts);
+
+  const perDeveloper: PerDeveloperConcurrencyStat[] = developerIds.map((developerId) => {
+    const activeCount = devCounts[developerId];
+    return {
+      developerId,
+      activeCount,
+      atLimit: activeCount >= maxConcurrencyPerDeveloper,
+      utilizationPercent:
+        maxConcurrencyPerDeveloper > 0
+          ? Math.round((activeCount / maxConcurrencyPerDeveloper) * 100)
+          : 0,
+    };
+  });
+
+  perDeveloper.sort((a, b) => b.activeCount - a.activeCount || a.developerId.localeCompare(b.developerId));
+
+  return {
+    totalActive,
+    maxConcurrencyPerDeveloper,
+    activeDeveloperCount: perDeveloper.length,
+    perDeveloper,
+    campaign: GRANTFOX_FWC26_CAMPAIGN,
+  };
+}


### PR DESCRIPTION
Closes: #525 

## Changes
- Added `src/services/concurrency.ts` — new service that computes enriched per-developer concurrency stats with utilization percentages
- Added `GET /api/admin/metrics` root endpoint — returns dashboard-friendly overview with per-developer breakdown, total active slots, and system-level counts
- Added comprehensive tests for the new endpoint

## New API
```
GET /api/admin/metrics
→ { data: { totalActive, maxConcurrencyPerDeveloper, activeDeveloperCount, perDeveloper: [{ developerId, activeCount, atLimit, utilizationPercent }], campaign } }
```

## Testing
- 5 new tests covering: empty state, utilization calculation, at-limit detection, sorting by active count descending, auth enforcement
- All 28 tests pass
- ESLint clean