### PR TITLE
feat(exports): register /api/exports/health dependency probe route

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -20,6 +20,7 @@ import { createUsageHealthRouter } from "./usage/health.js";
 import type { HealthCheckConfig } from "../services/healthCheck.js";
 import { createExportSchedulesRouter } from "./exports/schedules.js";
 import { createExportsRouter } from "./exports.js";
+import { createExportsHealthRouter } from "./exports/health.js";
 import { createUsageAccessLogMiddleware } from "../middleware/usageAccessLog.js";
 import { config } from "../config/index.js";
 import type { ScheduledExportsService } from "../services/scheduledExports.js";
@@ -137,6 +138,13 @@ export function createApiRouter(deps: ApiRouterDeps = {}): Router {
   );
 
 
+
+  // Exports subsystem external-dependency health probe (GrantFox FWC26 b#069).
+  // Mounted before the generic /exports handler to avoid path shadowing.
+  router.use(
+    "/exports/health",
+    createExportsHealthRouter(),
+  );
 
   if (deps.scheduledExportsService) {
     router.use(


### PR DESCRIPTION
Closes #934

## Summary

Registers the existing `createExportsHealthRouter` in the main API router (`src/routes/index.ts`) so `GET /api/exports/health` becomes accessible.

## Changes

- **src/routes/index.ts**: Added import of `createExportsHealthRouter` from `./exports/health.js` and mounted it at `/exports/health` before the generic `/exports` handler to avoid path shadowing — following the same pattern used by `/usage/health` and `/subscriptions/health`.

## Details

The health probe implementation (`src/routes/exports/health.ts`) and its comprehensive test suite (`src/routes/exports/health.test.ts`) already existed but the route was never mounted in the API router. This PR connects the dots by registering the route.

### Health probe features:
- Concurrently checks database, storage, queue, and notification API dependencies
- Each probe guarded by a 5-second timeout
- Returns 200 for ok/degraded, 503 for down
- Structured JSON logging with correlation ID propagation
- Injectable `ProbeRegistry` for testability