### PR TITLE
fix: add security headers to audit route

### DIFF
--- a/src/routes/audit.test.ts
+++ b/src/routes/audit.test.ts
@@ -46,6 +46,16 @@ describe('/api/audit mutations', () => {
     expect(res.body.data).toBeInstanceOf(Array);
   });
 
+  it('sets the required security headers on audit responses', async () => {
+    const res = await request(app).get('/api/audit');
+
+    expect(res.headers['content-security-policy']).toBe(
+      "default-src 'self'; frame-ancestors 'none'; object-src 'none'",
+    );
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  });
+
   it('POST /api/audit creates a new config and logs AUDIT_CONFIG_CREATE', async () => {
     const res = await request(app).post('/api/audit').send({
       targetEndpoint: '/users',

--- a/src/routes/audit.ts
+++ b/src/routes/audit.ts
@@ -3,6 +3,7 @@ import { defaultAuditService, type AuditService } from '../services/auditService
 import { logger } from '../logger.js';
 import { NotFoundError, BadRequestError } from '../errors/index.js';
 import { requireAuth } from '../middleware/requireAuth.js';
+import { securityHeadersMiddleware } from '../middleware/securityHeaders.js';
 
 export interface AuditConfigRecord {
   id: string;
@@ -22,6 +23,8 @@ let nextId = 1;
 export function createAuditRouter(deps: AuditRouterDeps = {}): Router {
   const router = Router();
   const auditService = deps.auditService ?? defaultAuditService;
+
+  router.use(securityHeadersMiddleware);
 
   async function recordAudit(
     req: Request,


### PR DESCRIPTION
## Summary
- apply the standard CSP, X-Content-Type-Options, and Referrer-Policy middleware to `/api/audit`
- cover the required headers on the audit route

## Verification
- `npx jest src/routes/audit.test.ts --runInBand --forceExit` (10 tests passed)

Closes #1102