### PR TITLE
feat: add per-user token-bucket rate limit on /api/gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,13 @@ BCRYPT_COST_FACTOR=12
 # -----------------------------------------------------------------------------
 UPSTREAM_URL=http://localhost:4000
 PROXY_TIMEOUT_MS=30000
+# REST API rate limiting (per-user with IP fallback for unauthenticated requests)
 REST_RATE_LIMIT_WINDOW_MS=60000
 REST_RATE_LIMIT_MAX_REQUESTS=100
+# Gateway/proxy rate limiting (per authenticated user only, runs after API key auth)
+# Enforces token-bucket rate limits on /api/gateway and /v1/call routes
+GATEWAY_RATE_LIMIT_WINDOW_MS=60000
+GATEWAY_RATE_LIMIT_MAX_REQUESTS=100
 WEBHOOK_SECRET_ROTATION_GRACE_MS=86400000
 
 # -----------------------------------------------------------------------------

--- a/docs/gateway-rate-limiting.md
+++ b/docs/gateway-rate-limiting.md
@@ -1,0 +1,236 @@
+# Gateway Rate Limiting
+
+This document describes the per-user token-bucket rate limiter applied to authenticated gateway and proxy routes (`/api/gateway` and `/v1/call`).
+
+## Overview
+
+Gateway rate limiting enforces per-user request quotas on authenticated API gateway traffic. Unlike the REST rate limiter (which limits REST API routes with IP-based fallback for unauthenticated requests), the gateway rate limiter **only operates on authenticated users** because gateway API key authentication middleware runs before rate limiting.
+
+**Affected routes:**
+- `ALL /api/gateway/:apiId` — legacy gateway proxy route
+- `ALL /v1/call/:apiSlugOrId/*` — modern proxy route
+
+**Not affected:**
+- `GET /api/gateway/health/:apiSlug` — public health endpoint (no auth)
+- REST API routes (`/api/billing`, `/api/usage`, `/api/developers`, etc.) — use separate REST rate limiter
+
+## Configuration
+
+Rate limits are configured via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `GATEWAY_RATE_LIMIT_WINDOW_MS` | `60000` | Time window in milliseconds (60 seconds) |
+| `GATEWAY_RATE_LIMIT_MAX_REQUESTS` | `100` | Maximum requests per user per window |
+
+### Example `.env` configuration
+
+```bash
+# Per-user gateway rate limiting (runs after API key auth)
+GATEWAY_RATE_LIMIT_WINDOW_MS=60000
+GATEWAY_RATE_LIMIT_MAX_REQUESTS=100
+```
+
+## Token Bucket Algorithm
+
+The gateway rate limiter uses a **token bucket** algorithm with continuous refill:
+
+- Each user starts with a full bucket of tokens (`GATEWAY_RATE_LIMIT_MAX_REQUESTS`)
+- Each request consumes 1 token
+- Tokens refill continuously at a steady rate: `maxRequests / windowMs` tokens per millisecond
+- When the bucket is empty, requests are rejected with `429 Too Many Requests`
+
+### Example behavior
+
+With `GATEWAY_RATE_LIMIT_WINDOW_MS=60000` and `GATEWAY_RATE_LIMIT_MAX_REQUESTS=100`:
+
+- **Refill rate:** 100 tokens / 60,000 ms = 0.00167 tokens/ms ≈ 1.67 tokens/second
+- **Burst traffic:** User can make 100 requests immediately (full bucket)
+- **Sustained traffic:** After exhausting the bucket, user is throttled to ~1.67 requests/second
+- **Recovery:** Tokens refill gradually — after 30 seconds of no requests, user regains ~50 tokens
+
+This allows for burst traffic up to the configured limit, then smooths to a steady-state rate.
+
+## Rate Limit Exceeded Response
+
+When a user exceeds their rate limit, the gateway returns:
+
+**HTTP Status:** `429 Too Many Requests`
+
+**Headers:**
+- `Retry-After: <seconds>` — whole seconds until next token is available (minimum 1)
+- `X-Request-Id: <requestId>` — correlation ID for the request
+
+**Body (JSON):**
+```json
+{
+  "code": "TOO_MANY_REQUESTS",
+  "message": "Too Many Requests",
+  "requestId": "req_abc123",
+  "retryAfterMs": 35420
+}
+```
+
+### Response fields
+
+| Field | Type | Description |
+|---|---|---|
+| `code` | string | Error code `TOO_MANY_REQUESTS` (matches standard error catalog) |
+| `message` | string | Human-readable error message |
+| `requestId` | string | Correlation ID for tracing (from `req.id` or `"unknown"`) |
+| `retryAfterMs` | number | Milliseconds until next token available (more precise than header) |
+
+### Example rejected request
+
+```bash
+curl -i -X POST https://api.example.com/v1/call/weather-api/forecast \
+  -H 'X-Api-Key: your-api-key-here'
+```
+
+```http
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json; charset=utf-8
+Retry-After: 36
+X-Request-Id: req_abc123
+
+{
+  "code": "TOO_MANY_REQUESTS",
+  "message": "Too Many Requests",
+  "requestId": "req_abc123",
+  "retryAfterMs": 35420
+}
+```
+
+The client should wait at least 36 seconds (per `Retry-After` header) before retrying.
+
+## Per-User Isolation
+
+Rate limits are tracked independently per authenticated user (derived from the API key's `userId` / `developerId`):
+
+- **User A** hitting the limit does **not** affect **User B**'s quota
+- Each user has their own token bucket
+- Tokens refill independently for each user
+
+**Example:**
+```bash
+# User 1 makes 100 requests (limit reached)
+for i in {1..100}; do
+  curl -H 'X-Api-Key: user1-key' https://api.example.com/v1/call/api/endpoint
+done
+
+# User 1's 101st request is rate-limited (429)
+curl -H 'X-Api-Key: user1-key' https://api.example.com/v1/call/api/endpoint
+# => 429 Too Many Requests
+
+# User 2 still has full quota (independent bucket)
+curl -H 'X-Api-Key: user2-key' https://api.example.com/v1/call/api/endpoint
+# => 200 OK
+```
+
+## Relationship to Other Rate Limiters
+
+The Callora backend has **three distinct rate limiters**:
+
+| Limiter | Routes | Scope | Authentication |
+|---|---|---|---|
+| **Gateway Rate Limiter** (this document) | `/api/gateway`, `/v1/call` | Per authenticated user | Required (API key) |
+| **REST Rate Limiter** | `/api/billing`, `/api/usage`, `/api/developers`, `/api/vault` | Per user (JWT/x-user-id), with IP fallback | Optional (fallback to IP) |
+| **Legacy Key Rate Limiter** | `/api/gateway`, `/v1/call` | Per API key (tier-aware) | Required (API key) |
+
+**Gateway routes use BOTH:**
+1. **Per-user token bucket** (this document) — limits individual users across all their API keys
+2. **Per-API-key tier limiter** (legacy) — additional limits tied to specific keys/tiers
+
+Both checks run in sequence. A request must pass **both** limiters to proceed.
+
+## Structured Logging
+
+When a request is rate-limited, the gateway logs a structured warning with the correlation ID:
+
+```json
+{
+  "level": "warn",
+  "msg": "[gatewayRateLimit] Rate limit exceeded",
+  "requestId": "req_abc123",
+  "userId": "user:dev_001",
+  "retryAfterMs": 35420,
+  "retryAfterSeconds": 36
+}
+```
+
+These logs can be correlated with application logs via the `requestId` field, which matches the `X-Request-Id` response header.
+
+## Implementation Details
+
+**Source files:**
+- `src/middleware/gatewayRateLimit.ts` — middleware implementation
+- `src/middleware/gatewayRateLimit.test.ts` — comprehensive test suite
+- `src/routes/gatewayRoutes.ts` — applied to `/api/gateway/:apiId`
+- `src/routes/proxyRoutes.ts` — applied to `/v1/call/:apiSlugOrId/*`
+
+**Key classes:**
+- `InMemoryGatewayRateLimiter` — token bucket implementation (in-memory store)
+- `createGatewayRateLimitMiddleware(options)` — factory for creating middleware
+- `createConfiguredGatewayRateLimitMiddleware()` — production factory reading from env vars
+
+**Dependencies:**
+- Reads `req.apiKeyRecord.userId` populated by gateway auth middleware
+- Returns standard error envelope matching `docs/error-codes.md`
+- Uses `logger` for structured logging with correlation IDs
+
+## Testing
+
+The gateway rate limiter includes comprehensive tests covering:
+- Per-user limiting (429 + Retry-After header)
+- User isolation (quotas are independent)
+- Token bucket refill behavior (continuous, not discrete)
+- Request ID propagation in error responses
+- Burst traffic handling
+- Pass-through when auth context is missing
+
+Run tests:
+```bash
+npm test src/middleware/gatewayRateLimit.test.ts
+```
+
+## Production Considerations
+
+### Scaling
+
+The current implementation uses **in-memory storage** for token buckets. This works for single-instance deployments but does not share state across multiple backend instances.
+
+For multi-instance deployments, consider:
+- Shared Redis store for token buckets (cross-instance quota enforcement)
+- Load balancer session affinity (sticky sessions per user)
+- Accept per-instance limits as a feature (distributes load)
+
+### Monitoring
+
+Monitor rate-limit rejections via:
+- **Structured logs:** Search for `[gatewayRateLimit] Rate limit exceeded`
+- **Metrics:** Track 429 response codes on gateway routes
+- **Client feedback:** Users experiencing frequent 429s may need quota increases
+
+### Tuning
+
+Adjust limits based on:
+- **User tier/plan:** Different users may have different quotas (future enhancement)
+- **API cost:** Expensive upstream APIs may warrant lower limits
+- **Infrastructure capacity:** Set limits that prevent backend overload
+
+**Example production values:**
+```bash
+# Generous limits for premium users
+GATEWAY_RATE_LIMIT_WINDOW_MS=60000
+GATEWAY_RATE_LIMIT_MAX_REQUESTS=500
+
+# Conservative limits for free tier
+GATEWAY_RATE_LIMIT_WINDOW_MS=60000
+GATEWAY_RATE_LIMIT_MAX_REQUESTS=50
+```
+
+## Related Documentation
+
+- [Error Codes](./error-codes.md) — Standard error envelope format
+- [Gateway API Key Auth](./gateway-api-key-auth.md) — Authentication middleware (runs before rate limiting)
+- REST Rate Limiter — `/api/*` routes rate limiting (separate system)

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -42,8 +42,12 @@ export const envSchema = z
     PROXY_BREAKER_FAILURE_THRESHOLD: z.coerce.number().int().positive().default(5),
     PROXY_BREAKER_COOLDOWN_MS: z.coerce.number().int().positive().default(30_000),
     PROXY_BREAKER_SUCCESS_THRESHOLD: z.coerce.number().int().positive().default(1),
+    // REST API rate limiting (per-user with IP fallback)
     REST_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
     REST_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(100),
+    // Gateway/proxy rate limiting (per authenticated user only)
+    GATEWAY_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
+    GATEWAY_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().default(100),
     WEBHOOK_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().optional(),
     WEBHOOK_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().int().positive().optional(),
     WEBHOOK_SECRET_ROTATION_GRACE_MS: z.coerce.number().int().positive().default(24 * 60 * 60 * 1000),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -133,6 +133,11 @@ export const config = {
     maxRequests: env.REST_RATE_LIMIT_MAX_REQUESTS,
   },
 
+  gatewayRateLimit: {
+    windowMs: env.GATEWAY_RATE_LIMIT_WINDOW_MS,
+    maxRequests: env.GATEWAY_RATE_LIMIT_MAX_REQUESTS,
+  },
+
   webhookRateLimit: {
     windowMs: env.WEBHOOK_RATE_LIMIT_WINDOW_MS ?? env.REST_RATE_LIMIT_WINDOW_MS,
     maxRequests: env.WEBHOOK_RATE_LIMIT_MAX_REQUESTS ?? env.REST_RATE_LIMIT_MAX_REQUESTS,

--- a/src/middleware/gatewayRateLimit.test.ts
+++ b/src/middleware/gatewayRateLimit.test.ts
@@ -1,0 +1,306 @@
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from './errorHandler.js';
+import { createGatewayRateLimitMiddleware, InMemoryGatewayRateLimiter } from './gatewayRateLimit.js';
+
+/**
+ * Build a test app with gateway rate limiting applied.
+ * 
+ * Simulates the gateway flow:
+ * 1. Auth middleware (mocked) attaches req.apiKeyRecord
+ * 2. Gateway rate limiter checks per-user limits
+ * 3. Protected handler executes if allowed
+ */
+function buildProtectedApp(
+  windowMs = 60_000,
+  maxRequests = 2,
+  rateLimiter?: InMemoryGatewayRateLimiter,
+) {
+  const app = express();
+  
+  // Mock gateway auth middleware - attaches apiKeyRecord to simulate
+  // what the real gateway auth middleware does
+  app.use((req, _res, next) => {
+    const userId = req.header('x-user-id');
+    if (userId) {
+      req.apiKeyRecord = { userId } as any;
+    }
+    next();
+  });
+
+  const gatewayRateLimit = createGatewayRateLimitMiddleware(
+    { windowMs, maxRequests },
+    rateLimiter,
+  );
+
+  app.get('/gateway/proxy', gatewayRateLimit, (req, res) => {
+    const apiKeyRecord = req.apiKeyRecord as { userId: string } | undefined;
+    res.json({ ok: true, userId: apiKeyRecord?.userId });
+  });
+
+  app.use(errorHandler);
+  return app;
+}
+
+describe('gatewayRateLimit middleware', () => {
+  describe('per-user rate limiting', () => {
+    test('returns 429 with Retry-After after the per-user limit is exceeded', async () => {
+      const app = buildProtectedApp();
+
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-1').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-1').expect(200);
+      const response = await request(app).get('/gateway/proxy').set('x-user-id', 'user-1');
+
+      expect(response.status).toBe(429);
+      expect(response.body.code).toBe('TOO_MANY_REQUESTS');
+      expect(response.body.message).toBe('Too Many Requests');
+      expect(response.headers['retry-after']).toBeDefined();
+      expect(Number(response.headers['retry-after'])).toBeGreaterThan(0);
+      expect(typeof response.body.retryAfterMs).toBe('number');
+      expect(response.body.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    test('tracks limits separately per authenticated user', async () => {
+      const app = buildProtectedApp();
+
+      // user-1 makes 2 requests (limit reached)
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-1').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-1').expect(200);
+
+      // user-2 makes 2 requests (limit reached)
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-2').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-2').expect(200);
+
+      // Both users are now rate-limited independently
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-1').expect(429);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-2').expect(429);
+    });
+
+    test('passes through requests when no apiKeyRecord is present', async () => {
+      const app = buildProtectedApp();
+
+      // Request without x-user-id header means no apiKeyRecord
+      // Middleware should pass through and let downstream handle it
+      const response = await request(app).get('/gateway/proxy');
+
+      // In this test setup, the protected handler returns 200 with no userId
+      expect(response.status).toBe(200);
+      expect(response.body.userId).toBeUndefined();
+    });
+  });
+
+  describe('token bucket refill behavior', () => {
+    test('allows requests after tokens have refilled', async () => {
+      const rateLimiter = new InMemoryGatewayRateLimiter(1000, 2); // 1 second window, 2 requests
+      const app = buildProtectedApp(1000, 2, rateLimiter);
+
+      // Consume both tokens
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-refill').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-refill').expect(200);
+
+      // Third request immediately is rate-limited
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-refill').expect(429);
+
+      // Wait for tokens to refill (1 second window + margin)
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      // Should now have tokens available again
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-refill').expect(200);
+    });
+
+    test('refills tokens gradually over time (continuous refill)', async () => {
+      // Set up: 2 tokens, 1000ms window = 0.002 tokens/ms = 1 token per 500ms
+      const rateLimiter = new InMemoryGatewayRateLimiter(1000, 2);
+      const app = buildProtectedApp(1000, 2, rateLimiter);
+
+      // Consume both tokens
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-gradual').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-gradual').expect(200);
+
+      // Immediately after, no tokens available
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-gradual').expect(429);
+
+      // Wait for ~half the window (should refill ~1 token)
+      await new Promise((resolve) => setTimeout(resolve, 550));
+
+      // Should have 1 token available now
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-gradual').expect(200);
+
+      // Immediately after, no tokens again
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-gradual').expect(429);
+    });
+  });
+
+  describe('Retry-After header', () => {
+    test('Retry-After header is set to whole seconds', async () => {
+      const app = buildProtectedApp(60_000, 2);
+
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-retry').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-retry').expect(200);
+      const response = await request(app).get('/gateway/proxy').set('x-user-id', 'user-retry');
+
+      expect(response.status).toBe(429);
+      const retryAfterHeader = Number(response.headers['retry-after']);
+      expect(retryAfterHeader).toBeGreaterThan(0);
+      expect(Number.isInteger(retryAfterHeader)).toBe(true);
+    });
+
+    test('retryAfterMs is consistent with Retry-After header (within same second)', async () => {
+      const app = buildProtectedApp(60_000, 2);
+
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-consistency').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-consistency').expect(200);
+      const response = await request(app).get('/gateway/proxy').set('x-user-id', 'user-consistency');
+
+      expect(response.status).toBe(429);
+      const retryAfterMs: number = response.body.retryAfterMs;
+      const retryAfterHeader = Number(response.headers['retry-after']) * 1000;
+      
+      // retryAfterMs must round up to the same second as the header
+      expect(Math.ceil(retryAfterMs / 1000) * 1000).toBeLessThanOrEqual(retryAfterHeader);
+      expect(retryAfterMs).toBeGreaterThan(0);
+    });
+  });
+
+  describe('request ID in error response', () => {
+    test('includes requestId in 429 response body', async () => {
+      const app = express();
+      
+      // Mock requestId middleware
+      app.use((req, _res, next) => {
+        (req as any).id = 'test-request-123';
+        next();
+      });
+
+      // Mock auth
+      app.use((req, _res, next) => {
+        req.apiKeyRecord = { userId: 'user-with-id' } as any;
+        next();
+      });
+
+      const gatewayRateLimit = createGatewayRateLimitMiddleware({
+        windowMs: 1000,
+        maxRequests: 1,
+      });
+
+      app.get('/gateway/proxy', gatewayRateLimit, (_req, res) => {
+        res.json({ ok: true });
+      });
+
+      app.use(errorHandler);
+
+      // First request succeeds
+      await request(app).get('/gateway/proxy').expect(200);
+
+      // Second request is rate-limited
+      const response = await request(app).get('/gateway/proxy');
+
+      expect(response.status).toBe(429);
+      expect(response.body.requestId).toBe('test-request-123');
+    });
+
+    test('uses "unknown" when requestId is not set', async () => {
+      const app = buildProtectedApp(1000, 1);
+
+      // First request succeeds
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-no-id').expect(200);
+
+      // Second request is rate-limited
+      const response = await request(app).get('/gateway/proxy').set('x-user-id', 'user-no-id');
+
+      expect(response.status).toBe(429);
+      expect(response.body.requestId).toBe('unknown');
+    });
+  });
+
+  describe('high-traffic scenarios', () => {
+    test('concurrent calls to check() on the same bucket all see consistent token accounting', async () => {
+      // Fix for original test which used supertest Promise.all — supertest without
+      // .listen() serializes requests through Node's http stack, so it does NOT
+      // exercise true concurrent bucket access.
+      //
+      // This test calls InMemoryGatewayRateLimiter.check() directly through
+      // Promise.all, which runs all calls within the same synchronous tick
+      // (check() is synchronous, Promise.all fires them before any await yield).
+      // Because check() is synchronous and Node is single-threaded, every call
+      // sees the bucket in the correct post-previous-call state — the bucket
+      // counter must decrement exactly once per call and never go negative.
+
+      const limiter = new InMemoryGatewayRateLimiter(60_000, 5);
+      const userId = 'user:burst-direct';
+
+      // Fire 5 concurrent check() calls
+      const results = await Promise.all([
+        Promise.resolve(limiter.check(userId)),
+        Promise.resolve(limiter.check(userId)),
+        Promise.resolve(limiter.check(userId)),
+        Promise.resolve(limiter.check(userId)),
+        Promise.resolve(limiter.check(userId)),
+      ]);
+
+      // All 5 must be allowed (bucket started with 5 tokens)
+      const allowedCount = results.filter((r) => r.allowed).length;
+      expect(allowedCount).toBe(5);
+
+      // 6th call must be rejected — bucket is now empty
+      const sixth = limiter.check(userId);
+      expect(sixth.allowed).toBe(false);
+      expect(sixth.retryAfterMs).toBeGreaterThan(0);
+
+      // Token count must be exactly 0 (not negative) after 5 allowed calls
+      expect(limiter.getTokens(userId)).toBeCloseTo(0, 0);
+    });
+
+    test('does not interfere with other users during rate limiting', async () => {
+      const app = buildProtectedApp(60_000, 2);
+
+      // User 1 exhausts their limit
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-isolated-1').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-isolated-1').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-isolated-1').expect(429);
+
+      // User 2 should still have full quota
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-isolated-2').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-isolated-2').expect(200);
+      await request(app).get('/gateway/proxy').set('x-user-id', 'user-isolated-2').expect(429);
+    });
+  });
+
+  describe('InMemoryGatewayRateLimiter direct tests', () => {
+    test('getTokens returns current token count after refill', () => {
+      const limiter = new InMemoryGatewayRateLimiter(1000, 10);
+      const now = 1000000;
+
+      // First check - consumes 1 token, 9 remain
+      limiter.check('user:test', now);
+      expect(limiter.getTokens('user:test', now)).toBe(9);
+
+      // After 500ms, should have ~5 more tokens (10 tokens / 1000ms * 500ms)
+      expect(limiter.getTokens('user:test', now + 500)).toBeCloseTo(14, 0);
+    });
+
+    test('reset clears all buckets', () => {
+      const limiter = new InMemoryGatewayRateLimiter(1000, 5);
+
+      limiter.check('user:a');
+      limiter.check('user:b');
+      expect(limiter.getTokens('user:a')).toBe(4);
+      expect(limiter.getTokens('user:b')).toBe(4);
+
+      limiter.reset();
+
+      expect(limiter.getTokens('user:a')).toBe(5);
+      expect(limiter.getTokens('user:b')).toBe(5);
+    });
+
+    test('tokens never exceed maxRequests after refill', () => {
+      const limiter = new InMemoryGatewayRateLimiter(1000, 10);
+      const now = 1000000;
+
+      limiter.check('user:test', now);
+      
+      // Wait a very long time - tokens should cap at maxRequests (10)
+      expect(limiter.getTokens('user:test', now + 1000000)).toBe(10);
+    });
+  });
+});

--- a/src/middleware/gatewayRateLimit.ts
+++ b/src/middleware/gatewayRateLimit.ts
@@ -1,0 +1,219 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import { logger } from '../logger.js';
+import { config } from '../config/index.js';
+
+/**
+ * Token bucket state for a single user.
+ * 
+ * Token bucket algorithm:
+ * - Each user has a bucket that can hold up to `maxTokens` tokens
+ * - Tokens are consumed when requests are made (1 token per request)
+ * - Tokens are refilled at a steady rate over time
+ * - When the bucket is empty, requests are rejected with 429
+ */
+interface TokenBucket {
+  tokens: number;
+  lastRefillAt: number;
+}
+
+interface RateLimitCheckResult {
+  allowed: boolean;
+  retryAfterMs?: number;
+}
+
+export interface GatewayRateLimitOptions {
+  windowMs: number;
+  maxRequests: number;
+}
+
+/**
+ * In-memory token-bucket rate limiter for gateway routes.
+ * 
+ * Unlike the REST rate limiter which falls back to IP-based limiting for
+ * unauthenticated requests, the gateway rate limiter ONLY operates on
+ * authenticated users because gateway API key auth middleware runs before
+ * this middleware.
+ * 
+ * Token bucket refill strategy:
+ * - Tokens refill continuously over time rather than in discrete windows
+ * - Refill rate = maxRequests / windowMs tokens per millisecond
+ * - This allows for burst traffic up to maxRequests, then throttles to the
+ *   steady-state rate
+ * 
+ * Example with maxRequests=100, windowMs=60000 (60 seconds):
+ * - User starts with 100 tokens
+ * - Each request consumes 1 token
+ * - Tokens refill at 100/60000 = 0.00167 tokens/ms = 1.67 tokens/second
+ * - After 30 seconds with no requests, user regains 50 tokens
+ */
+export class InMemoryGatewayRateLimiter {
+  private readonly buckets = new Map<string, TokenBucket>();
+  private readonly refillRate: number;
+
+  constructor(
+    private readonly windowMs: number,
+    private readonly maxRequests: number,
+  ) {
+    // Calculate tokens per millisecond
+    this.refillRate = maxRequests / windowMs;
+  }
+
+  /**
+   * Check if a request is allowed for the given user.
+   * 
+   * @param userId - The user identifier (from req.apiKeyRecord.userId)
+   * @param now - Current timestamp in milliseconds (injectable for testing)
+   * @returns { allowed: true } if the request should proceed,
+   *          { allowed: false, retryAfterMs } if rate-limited
+   */
+  check(userId: string, now = Date.now()): RateLimitCheckResult {
+    let bucket = this.buckets.get(userId);
+
+    if (!bucket) {
+      // First request from this user — initialize with full tokens minus one
+      this.buckets.set(userId, {
+        tokens: this.maxRequests - 1,
+        lastRefillAt: now,
+      });
+      return { allowed: true };
+    }
+
+    // Refill tokens based on elapsed time since last check
+    const elapsedMs = now - bucket.lastRefillAt;
+    const tokensToAdd = elapsedMs * this.refillRate;
+    bucket.tokens = Math.min(this.maxRequests, bucket.tokens + tokensToAdd);
+    bucket.lastRefillAt = now;
+
+    // Check if we have at least 1 token available
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return { allowed: true };
+    }
+
+    // Rate limited — calculate when the next token will be available
+    // We need 1 full token, so time = (1 - current_tokens) / refill_rate
+    const tokensNeeded = 1 - bucket.tokens;
+    const retryAfterMs = Math.ceil(tokensNeeded / this.refillRate);
+
+    return {
+      allowed: false,
+      retryAfterMs: Math.max(retryAfterMs, 1000), // Minimum 1 second
+    };
+  }
+
+  /**
+   * Reset all rate limit buckets.
+   * Exposed for testing only.
+   */
+  reset(): void {
+    this.buckets.clear();
+  }
+
+  /**
+   * Get the current token count for a user.
+   * Exposed for testing only.
+   */
+  getTokens(userId: string, now = Date.now()): number {
+    const bucket = this.buckets.get(userId);
+    if (!bucket) {
+      return this.maxRequests;
+    }
+
+    // Apply refill before returning current count
+    const elapsedMs = now - bucket.lastRefillAt;
+    const tokensToAdd = elapsedMs * this.refillRate;
+    return Math.min(this.maxRequests, bucket.tokens + tokensToAdd);
+  }
+}
+
+/**
+ * Extract user ID from the request after gateway auth middleware has run.
+ * 
+ * Gateway auth middleware (gatewayApiKeyAuth) attaches:
+ *   req.apiKeyRecord = { id, userId, apiId, ... }
+ * 
+ * This function extracts the userId from that record.
+ */
+export function getGatewayRateLimitKey(req: Request): string | null {
+  const apiKeyRecord = req.apiKeyRecord as { userId?: string } | undefined;
+  
+  if (!apiKeyRecord?.userId) {
+    return null;
+  }
+
+  return `user:${apiKeyRecord.userId}`;
+}
+
+/**
+ * Create a gateway rate limit middleware instance.
+ * 
+ * This middleware MUST be applied AFTER gateway API key authentication
+ * middleware, as it depends on req.apiKeyRecord being populated.
+ * 
+ * On rate limit exceeded:
+ * - Returns 429 with standard error envelope { code, message, requestId }
+ * - Sets Retry-After header (seconds until next token available)
+ * - Logs structured warning with correlation ID
+ * 
+ * @param options - Rate limit configuration
+ * @param rateLimiter - Rate limiter instance (injectable for testing)
+ */
+export function createGatewayRateLimitMiddleware(
+  options: GatewayRateLimitOptions,
+  rateLimiter = new InMemoryGatewayRateLimiter(options.windowMs, options.maxRequests),
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = getGatewayRateLimitKey(req);
+
+    // If no user key is available, the request hasn't been authenticated yet.
+    // This should never happen in production because gateway auth runs first,
+    // but we gracefully pass through and let downstream handlers catch it.
+    if (!key) {
+      next();
+      return;
+    }
+
+    const result = rateLimiter.check(key);
+
+    if (!result.allowed) {
+      const retryAfterMs = result.retryAfterMs ?? options.windowMs;
+      const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+      const requestId: string = (req as Request & { id?: string }).id ?? 'unknown';
+
+      // Set Retry-After header per RFC 6585
+      res.set('Retry-After', String(retryAfterSeconds));
+
+      // Structured logging with correlation ID
+      logger.warn('[gatewayRateLimit] Rate limit exceeded', {
+        requestId,
+        userId: key,
+        retryAfterMs,
+        retryAfterSeconds,
+      });
+
+      // Standard error envelope matching docs/error-codes.md
+      res.status(429).json({
+        code: 'TOO_MANY_REQUESTS',
+        message: 'Too Many Requests',
+        requestId,
+        retryAfterMs,
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Create a configured gateway rate limit middleware using values from config.
+ * 
+ * This is the production factory that reads from environment variables.
+ * Use this when wiring up routes in gatewayRoutes.ts and proxyRoutes.ts.
+ */
+export function createConfiguredGatewayRateLimitMiddleware(): RequestHandler {
+  return createGatewayRateLimitMiddleware({
+    windowMs: config.gatewayRateLimit.windowMs,
+    maxRequests: config.gatewayRateLimit.maxRequests,
+  });
+}

--- a/src/routes/gatewayRoutes.test.ts
+++ b/src/routes/gatewayRoutes.test.ts
@@ -353,3 +353,129 @@ describe("gateway route - API key prefix / hash mismatch (bug #421)", () => {
     expect(mismatchRes.body.message).toBe(unknownRes.body.message);
   });
 });
+
+// ---------------------------------------------------------------------------
+// gatewayRoutes.ts — per-user token-bucket inline invocation (issue #870)
+//
+// These tests exercise the inline gatewayRateLimit(req, res, () => {...})
+// call path inside the router.all('/:apiId', ...) handler in gatewayRoutes.ts.
+// They use createGatewayRouter directly with a gatewayRateLimitMiddleware stub
+// injected via GatewayDeps so the new code paths show up in coverage for that
+// file, not just gatewayRateLimit.ts.
+// ---------------------------------------------------------------------------
+describe("gateway route - per-user token-bucket rate limit (issue #870)", () => {
+  const API_ID = "my-api";
+  const VALID_KEY = "test-key-abcdefgh";
+
+  function buildGatewayApp(
+    gatewayRateLimitMiddleware: import("express").RequestHandler,
+    extra?: Partial<import("../types/gateway.js").GatewayDeps>,
+  ) {
+    const apiKeys = new Map<string, ApiKey>();
+    apiKeys.set(VALID_KEY, { key: "k1", apiId: API_ID, developerId: "dev1" });
+
+    const deps = {
+      billing: { deductCredit: async () => ({ success: false, balance: 0 }) }, // 402 fast
+      rateLimiter: { check: async () => ({ allowed: true }) },
+      usageStore: { record: () => true },
+      upstreamUrl: "http://example.invalid",
+      apiKeys,
+      gatewayRateLimitMiddleware,
+      ...extra,
+    } as any;
+
+    const app = express();
+    app.use(requestIdMiddleware);
+    app.use("/gateway", createGatewayRouter(deps));
+    app.use(errorHandler);
+    return app;
+  }
+
+  test("passes through to downstream handler when rate limiter calls next()", async () => {
+    // Middleware that always calls next() — exercises the gatewayRateLimitPassed=true path
+    const passThroughMiddleware: import("express").RequestHandler = (_req, _res, next) => {
+      next();
+    };
+
+    const app = buildGatewayApp(passThroughMiddleware);
+    const res = await request(app)
+      .get(`/gateway/${API_ID}`)
+      .set("x-api-key", VALID_KEY);
+
+    // Billing stub returns 402 — proves the inline check passed and execution continued
+    expect(res.status).toBe(402);
+  });
+
+  test("returns 429 and stops processing when rate limiter writes its own response (gatewayRateLimitPassed=false path)", async () => {
+    // Middleware that writes a 429 itself and does NOT call next() —
+    // exercises the gatewayRateLimitPassed=false early-return path in gatewayRoutes.ts
+    const blockingMiddleware: import("express").RequestHandler = (_req, res, _next) => {
+      res.status(429).json({
+        code: "TOO_MANY_REQUESTS",
+        message: "Too Many Requests",
+        requestId: "test-req-id",
+        retryAfterMs: 30_000,
+      });
+    };
+
+    const app = buildGatewayApp(blockingMiddleware);
+    const res = await request(app)
+      .get(`/gateway/${API_ID}`)
+      .set("x-api-key", VALID_KEY);
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe("TOO_MANY_REQUESTS");
+    // Billing must NOT have been called — the handler returned before reaching it
+    // (confirmed by absence of a 402 status)
+    expect(res.status).not.toBe(402);
+  });
+
+  test("rate limiter receives req.apiKeyRecord.userId = keyRecord.developerId", async () => {
+    // Verify that the inline req.apiKeyRecord assignment writes the correct userId
+    // so that the token-bucket key matches the developer, not the raw API key string.
+    let capturedUserId: string | undefined;
+
+    const inspectingMiddleware: import("express").RequestHandler = (req, _res, next) => {
+      const record = req.apiKeyRecord as { userId?: string } | undefined;
+      capturedUserId = record?.userId;
+      next();
+    };
+
+    const app = buildGatewayApp(inspectingMiddleware);
+    await request(app)
+      .get(`/gateway/${API_ID}`)
+      .set("x-api-key", VALID_KEY);
+
+    expect(capturedUserId).toBe("dev1"); // keyRecord.developerId from apiKeys map
+  });
+
+  test("returns 429 with Retry-After header via real InMemoryGatewayRateLimiter through createGatewayRouter", async () => {
+    // Wire a real (not stubbed) token-bucket limiter with limit=1 into the gateway router
+    // to exercise the full path: auth → req.apiKeyRecord assignment → limiter.check() →
+    // 429 written by middleware → gatewayRateLimitPassed=false → early return.
+    const { createGatewayRateLimitMiddleware, InMemoryGatewayRateLimiter } = await import(
+      "../middleware/gatewayRateLimit.js"
+    );
+
+    const limiter = new InMemoryGatewayRateLimiter(60_000, 1);
+    const rl = createGatewayRateLimitMiddleware({ windowMs: 60_000, maxRequests: 1 }, limiter);
+
+    const app = buildGatewayApp(rl);
+
+    // First request — token bucket not yet exhausted, billing stub returns 402
+    const first = await request(app)
+      .get(`/gateway/${API_ID}`)
+      .set("x-api-key", VALID_KEY);
+    expect(first.status).toBe(402); // auth + rate limit passed, billing fails fast
+
+    // Second request — bucket empty, rate limiter writes 429 directly
+    const second = await request(app)
+      .get(`/gateway/${API_ID}`)
+      .set("x-api-key", VALID_KEY);
+    expect(second.status).toBe(429);
+    expect(second.body.code).toBe("TOO_MANY_REQUESTS");
+    expect(second.headers["retry-after"]).toBeDefined();
+    expect(Number(second.headers["retry-after"])).toBeGreaterThan(0);
+    expect(second.body.retryAfterMs).toBeGreaterThan(0);
+  });
+});

--- a/src/routes/gatewayRoutes.ts
+++ b/src/routes/gatewayRoutes.ts
@@ -3,6 +3,7 @@ import express, { Router, type Request, type Response, type NextFunction } from 
 import { z } from 'zod';
 import { startUpstreamTimer, getUpstreamHealth, type UpstreamOutcome } from '../metrics.js';
 import { validate } from '../middleware/validate.js';
+import { createConfiguredGatewayRateLimitMiddleware } from '../middleware/gatewayRateLimit.js';
 import type { GatewayDeps, ApiKey } from '../types/gateway.js';
 import { buildHopByHopSet } from '../lib/hopByHop.js';
 import { getDefaultBreakerRegistry, CircuitBreakerState } from '../lib/circuitBreaker.js';
@@ -123,6 +124,12 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
   const maxBodySize = deps.maxBodySize ?? DEFAULT_MAX_BODY_SIZE;
   const router = Router();
 
+  // Per-user token-bucket rate limiter for authenticated gateway requests.
+  // A separate instance is created per router so tests can construct
+  // isolated routers without shared limiter state.  The configured instance
+  // reads limits from GATEWAY_RATE_LIMIT_WINDOW_MS / GATEWAY_RATE_LIMIT_MAX_REQUESTS.
+  const gatewayRateLimit = deps.gatewayRateLimitMiddleware ?? createConfiguredGatewayRateLimitMiddleware();
+
   // Enforce body size limits at the router level so the gateway is self-contained
   // regardless of whether a global body parser is present. Oversized bodies surface
   // as 413 via the app-level error handler.
@@ -222,6 +229,24 @@ export function createGatewayRouter(deps: GatewayDeps): Router {
 
         if (keyRecord.revoked) {
           next(new ForbiddenError('Forbidden: API key has been revoked'));
+          return;
+        }
+
+        // Per-user token-bucket rate limit (issue #870).
+        // Attach the resolved record to req so the shared middleware helper can
+        // read userId, then invoke it inline.  The middleware either calls next()
+        // to continue, or writes the 429 response itself and returns without
+        // calling next — in that case res.headersSent is true and we bail out.
+        req.apiKeyRecord = {
+          userId: keyRecord.developerId,
+          id: keyRecord.key,
+          apiId: keyRecord.apiId,
+        } as Record<string, unknown>;
+
+        let gatewayRateLimitPassed = false;
+        gatewayRateLimit(req, res, () => { gatewayRateLimitPassed = true; });
+        if (!gatewayRateLimitPassed) {
+          // Middleware wrote the 429 response; stop processing this request.
           return;
         }
 

--- a/src/routes/proxyRoutes.ts
+++ b/src/routes/proxyRoutes.ts
@@ -4,6 +4,7 @@ import { ProxyDeps, ProxyConfig, ApiRegistryEntry, EndpointPricing } from '../ty
 import { resolveEndpointPrice } from '../data/apiRegistry.js';
 import { startUpstreamTimer, recordProxyPrematureAbort, type UpstreamOutcome, setGatewayUpstreamBreakerState } from '../metrics.js';
 import { createMapBackedGatewayApiKeyAuthMiddleware } from '../middleware/gatewayApiKeyAuth.js';
+import { createConfiguredGatewayRateLimitMiddleware } from '../middleware/gatewayRateLimit.js';
 import { buildHopByHopSet } from '../lib/hopByHop.js';
 import {
   buildUpstreamTargetUrl,
@@ -101,10 +102,17 @@ export function createProxyRouter(deps: ProxyDeps): Router {
     },
   });
 
+  // Per-user token-bucket rate limiter (issue #870).
+  // Runs AFTER authMiddleware so req.apiKeyRecord.userId is guaranteed to be
+  // populated. Reads limits from GATEWAY_RATE_LIMIT_* env vars by default;
+  // can be overridden via deps for testing.
+  const gatewayRateLimitMiddleware = deps.gatewayRateLimitMiddleware
+    ?? createConfiguredGatewayRateLimitMiddleware();
+
   // Use a param of 0 to capture the wildcard path (everything after the slug)
-  router.all('/:apiSlugOrId/*', authMiddleware, handleProxy);
+  router.all('/:apiSlugOrId/*', authMiddleware, gatewayRateLimitMiddleware, handleProxy);
   // Also handle requests without a trailing path (e.g. /v1/call/my-api)
-  router.all('/:apiSlugOrId', authMiddleware, handleProxy);
+  router.all('/:apiSlugOrId', authMiddleware, gatewayRateLimitMiddleware, handleProxy);
 
   async function handleProxy(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
@@ -131,7 +139,8 @@ export function createProxyRouter(deps: ProxyDeps): Router {
       const stateValue = currentMetrics.state === 'CLOSED' ? 0 : currentMetrics.state === 'OPEN' ? 1 : 2;
       setGatewayUpstreamBreakerState(breakerKey, stateValue);
 
-      // 3. Rate-limit check
+      // 3. Per-API-key rate-limit check (tier-aware; complements the per-user
+      //    token-bucket check already applied by gatewayRateLimitMiddleware).
       const rateResult = await rateLimiter.check(apiKeyHeader, res.locals.apiKeyTier as string | undefined);
       if (!rateResult.allowed) {
         const retryAfterSec = Math.ceil((rateResult.retryAfterMs ?? 1000) / 1000);

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -118,6 +118,8 @@ export interface GatewayDeps {
   upstreamUrl: string;
   apiKeys?: Map<string, ApiKey>;
   authMiddleware?: RequestHandler;
+  /** Per-user token-bucket rate limiter middleware (issue #870). Defaults to configured instance. */
+  gatewayRateLimitMiddleware?: RequestHandler;
   /** Maximum allowed request body size (Express size string, e.g. '1mb', '512kb'). Default: '1mb'. */
   maxBodySize?: string;
   /**
@@ -142,6 +144,8 @@ export interface ProxyDeps {
   registry: ApiRegistry;
   apiKeys?: Map<string, ApiKey>;
   authMiddleware?: RequestHandler;
+  /** Per-user token-bucket rate limiter middleware (issue #870). Defaults to configured instance. */
+  gatewayRateLimitMiddleware?: RequestHandler;
   proxyConfig?: Partial<ProxyConfig>;
   circuitBreakerStore?: CircuitBreakerStore;
 }


### PR DESCRIPTION
## Summary
Adds a per-user token-bucket rate limiter to /api/gateway, returning 429 with a Retry-After header when the limit is exceeded.

## Changes

### `src/middleware/gatewayRateLimit.ts` (new)
- In-memory per-user token-bucket rate limiter with continuous refill

### `src/middleware/gatewayRateLimit.test.ts` (new)
- Unit tests covering allow/deny, refill over time, per-user isolation, and concurrent bucket access

### `docs/gateway-rate-limiting.md` (new)
- Documents the new env vars, 429 response shape, and Retry-After header

### `src/routes/proxyRoutes.ts`
- Wires the rate limiter into the proxy route chain after auth

### `src/routes/gatewayRoutes.ts`
- Wires the rate limiter into the legacy inline gateway route after key validation

### `src/routes/gatewayRoutes.test.ts`
- Adds coverage for the inline rate-limit invocation path (pass-through, 429, Retry-After)

### `.env.example`, `src/config/env.ts`, `src/config/index.ts`, `src/types/gateway.ts`
- Add `GATEWAY_RATE_LIMIT_WINDOW_MS` / `GATEWAY_RATE_LIMIT_MAX_REQUESTS` config, validated via Zod, and an optional `gatewayRateLimitMiddleware` injection point on `GatewayDeps` / `ProxyDeps` for testability


Closes #870