### PR TITLE
test: add schema snapshot test for feature-flags endpoint

### DIFF
--- a/tests/schema/__snapshots__/feature-flags.test.ts.snap
+++ b/tests/schema/__snapshots__/feature-flags.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/api/feature-flags — response schema stability GET /api/feature-flags matches the known success response shape 1`] = `
+{
+  "data": {
+    "flags": {
+      "beta-analytics": false,
+      "dark-mode": true,
+      "experimental-ui": false,
+      "new-billing-flow": false,
+      "sso-login": true,
+    },
+  },
+  "requestId": Any<String>,
+  "success": true,
+  "timestamp": Any<String>,
+}
+`;

--- a/tests/schema/feature-flags.test.ts
+++ b/tests/schema/feature-flags.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Response schema stability test for the `/api/feature-flags` surface.
+ *
+ * Snapshot test that asserts the feature-flags response shape doesn't drift accidentally.
+ */
+
+process.env.NODE_ENV = 'test';
+
+import express from 'express';
+import request from 'supertest';
+import { createFeatureFlagsRouter } from '../../src/routes/feature-flags.js';
+import { errorHandler } from '../../src/middleware/errorHandler.js';
+
+const FIXED_REQUEST_ID = '00000000-0000-4000-8000-000000000001';
+const SUCCESS_KEYS = ['success', 'data', 'requestId', 'timestamp'].sort();
+
+describe('/api/feature-flags — response schema stability', () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/feature-flags', createFeatureFlagsRouter());
+    app.use(errorHandler);
+  });
+
+  describe('GET /api/feature-flags', () => {
+    it('matches the known success response shape', async () => {
+      const res = await request(app)
+        .get('/api/feature-flags')
+        .set('x-request-id', FIXED_REQUEST_ID);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchSnapshot({
+        timestamp: expect.any(String),
+        requestId: expect.any(String),
+      });
+    });
+
+    it('always returns the same top-level and nested key sets on success', async () => {
+      const res = await request(app)
+        .get('/api/feature-flags')
+        .set('x-request-id', FIXED_REQUEST_ID);
+
+      expect(res.status).toBe(200);
+      expect(Object.keys(res.body).sort()).toEqual(SUCCESS_KEYS);
+      expect(Object.keys(res.body.data).sort()).toEqual(['flags']);
+    });
+  });
+});


### PR DESCRIPTION
Closes #879 

# Description

This is a backend issue for the GrantFox FWC26 campaign. Added a snapshot test that asserts the `/api/feature-flags` response shape doesn't drift accidentally.

Closes #[Insert Issue Number]

## Requirements and Context
- Implemented the snapshot tests to assert the response shape of `/api/feature-flags`.
- Locked the full JSON shape of the feature-flags endpoint so any additive or renaming drift will fail CI.
- Adhered to the repository's linting and testing conventions.

## Changes
- **New Test File**: Created `tests/schema/feature-flags.test.ts`.
- **Snapshot File**: Generated `tests/schema/__snapshots__/feature-flags.test.ts.snap` to lock in the expected response schema.
- **Coverage**: The tests focus entirely on ensuring the schema returned from `src/routes/feature-flags.ts` remains consistent and stable.

## Verification
- Verified the test covers both the shape (top-level and nested key sets) and the exact JSON snapshot of the success response envelope.