### PR TITLE
feat: add Zod-validated /api/tenants schema with structured 400 error…

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -830,6 +830,367 @@ paths:
                       message: Error definition 999 not found
                     requestId: req-errors-delete-404
                     timestamp: "2026-07-27T09:15:00.000Z"
+  /api/tenants:
+    get:
+      summary: List tenants
+      description: >
+        Returns all tenants visible to the authenticated user. Responses are
+        ETag-stamped so clients can use conditional GET (If-None-Match) to avoid
+        redundant transfers.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: x-user-id
+          in: header
+          required: true
+          description: Authenticated user identifier (set by auth middleware).
+          schema:
+            type: string
+          examples:
+            developer:
+              summary: Authenticated developer
+              value: dev-1
+        - name: If-None-Match
+          in: header
+          required: false
+          description: >
+            Strong ETag from a prior response. Returns 304 if the tenant list
+            has not changed.
+          schema:
+            type: string
+          examples:
+            etag:
+              summary: Strong ETag from prior response
+              value: '"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"'
+      responses:
+        "200":
+          description: Tenant list retrieved successfully.
+          headers:
+            ETag:
+              description: Strong ETag of the current tenant list payload.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantListResponse"
+              examples:
+                withTenants:
+                  summary: Two tenants returned
+                  value:
+                    success: true
+                    data:
+                      - id: ten_a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                        name: GrantFox Ops
+                        slug: grantfox-ops
+                        contactEmail: ops@grantfox.test
+                        plan: growth
+                        metadata:
+                          campaign: fwc26
+                        createdBy: dev-1
+                        createdAt: "2026-07-28T00:00:00.000Z"
+                        updatedAt: "2026-07-28T00:00:00.000Z"
+                      - id: ten_b2c3d4e5-f6a7-8901-bcde-f12345678901
+                        name: GrantFox Stadium
+                        slug: grantfox-stadium
+                        plan: enterprise
+                        createdBy: dev-1
+                        createdAt: "2026-07-28T00:00:00.000Z"
+                        updatedAt: "2026-07-28T00:00:00.000Z"
+                    requestId: req-tenants-list-1
+                    timestamp: "2026-07-28T10:00:00.000Z"
+                empty:
+                  summary: No tenants exist yet
+                  value:
+                    success: true
+                    data: []
+                    requestId: req-tenants-list-2
+                    timestamp: "2026-07-28T10:01:00.000Z"
+        "304":
+          description: >
+            Tenant list has not changed since the ETag supplied in
+            If-None-Match.
+        "401":
+          description: Authentication is required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                unauthorized:
+                  summary: Missing or invalid authentication
+                  value:
+                    success: false
+                    error:
+                      code: UNAUTHORIZED
+                      message: Unauthorized
+                    requestId: req-tenants-list-401
+                    timestamp: "2026-07-28T10:02:00.000Z"
+    post:
+      summary: Create a tenant
+      description: >
+        Creates a new tenant. The request body is Zod-validated at the route
+        boundary; unrecognised keys are rejected with a structured 400 error
+        envelope so clients receive per-field details without any internal
+        information leaking.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TenantCreateRequest"
+            examples:
+              createFull:
+                summary: Full tenant payload with optional fields
+                value:
+                  name: GrantFox Ops
+                  slug: grantfox-ops
+                  contactEmail: ops@grantfox.test
+                  plan: growth
+                  metadata:
+                    campaign: fwc26
+                    priority: 1
+                    active: true
+              createMinimal:
+                summary: Minimal tenant — only name is required
+                value:
+                  name: GrantFox Stadium
+      responses:
+        "201":
+          description: Tenant created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantResponse"
+              examples:
+                created:
+                  summary: Newly created tenant
+                  value:
+                    success: true
+                    data:
+                      id: ten_a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                      name: GrantFox Ops
+                      slug: grantfox-ops
+                      contactEmail: ops@grantfox.test
+                      plan: growth
+                      metadata:
+                        campaign: fwc26
+                        priority: 1
+                        active: true
+                      createdBy: dev-1
+                      createdAt: "2026-07-28T10:00:00.000Z"
+                      updatedAt: "2026-07-28T10:00:00.000Z"
+                    requestId: req-tenants-create-1
+                    timestamp: "2026-07-28T10:00:00.000Z"
+        "400":
+          description: >
+            Request body failed Zod validation. The error envelope includes a
+            per-field `details` array so clients can surface precise messages
+            without any server internals leaking.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                missingName:
+                  summary: Required field missing
+                  value:
+                    success: false
+                    error:
+                      code: VALIDATION_ERROR
+                      message: Request validation failed
+                      details:
+                        - field: body.name
+                          message: name is required
+                          code: INVALID_TYPE
+                    requestId: req-tenants-create-400-name
+                    timestamp: "2026-07-28T10:01:00.000Z"
+                invalidEmail:
+                  summary: Invalid contactEmail format
+                  value:
+                    success: false
+                    error:
+                      code: VALIDATION_ERROR
+                      message: Request validation failed
+                      details:
+                        - field: body.contactEmail
+                          message: contactEmail must be a valid email address
+                          code: INVALID_STRING
+                    requestId: req-tenants-create-400-email
+                    timestamp: "2026-07-28T10:02:00.000Z"
+                unknownKey:
+                  summary: Unrecognised key rejected by strict schema
+                  value:
+                    success: false
+                    error:
+                      code: VALIDATION_ERROR
+                      message: Request validation failed
+                      details:
+                        - field: body
+                          message: "Unrecognized key(s) in object: 'unsafeRole'"
+                          code: UNRECOGNIZED_KEYS
+                    requestId: req-tenants-create-400-unknown
+                    timestamp: "2026-07-28T10:03:00.000Z"
+                invalidPlan:
+                  summary: Plan value outside the allowed enum
+                  value:
+                    success: false
+                    error:
+                      code: VALIDATION_ERROR
+                      message: Request validation failed
+                      details:
+                        - field: body.plan
+                          message: "Invalid option: expected one of 'starter' | 'growth' | 'enterprise'"
+                          code: INVALID_ENUM_VALUE
+                    requestId: req-tenants-create-400-plan
+                    timestamp: "2026-07-28T10:04:00.000Z"
+        "401":
+          description: Authentication is required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                unauthorized:
+                  summary: Missing or invalid authentication
+                  value:
+                    success: false
+                    error:
+                      code: UNAUTHORIZED
+                      message: Unauthorized
+                    requestId: req-tenants-create-401
+                    timestamp: "2026-07-28T10:05:00.000Z"
+  /api/tenants/{tenantId}:
+    patch:
+      summary: Update a tenant
+      description: >
+        Partially updates an existing tenant. Both the route parameter and the
+        request body are Zod-validated; all validation errors are collected in a
+        single pass and returned together in the structured 400 envelope so the
+        client can fix all issues in one round-trip.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: >
+            Tenant identifier — 3–64 characters, letters/numbers/underscores/hyphens.
+          schema:
+            type: string
+            pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{2,63}$"
+          examples:
+            valid:
+              summary: Valid tenant ID
+              value: tenant_123
+            tooShort:
+              summary: ID too short — triggers 400
+              value: no
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TenantUpdateRequest"
+            examples:
+              updatePlan:
+                summary: Upgrade the plan
+                value:
+                  plan: enterprise
+              updateContactEmail:
+                summary: Update contact email only
+                value:
+                  contactEmail: stadium@grantfox.test
+              updateMultiple:
+                summary: Update name, plan, and metadata together
+                value:
+                  name: GrantFox Stadium Ops
+                  plan: enterprise
+                  metadata:
+                    campaign: fwc26-final
+      responses:
+        "200":
+          description: Tenant updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantResponse"
+              examples:
+                updated:
+                  summary: Updated tenant record
+                  value:
+                    success: true
+                    data:
+                      id: tenant_123
+                      name: GrantFox Stadium Ops
+                      slug: grantfox-stadium
+                      contactEmail: stadium@grantfox.test
+                      plan: enterprise
+                      metadata:
+                        campaign: fwc26-final
+                      createdBy: dev-1
+                      createdAt: "2026-07-28T00:00:00.000Z"
+                      updatedAt: "2026-07-28T11:00:00.000Z"
+                    requestId: req-tenants-update-1
+                    timestamp: "2026-07-28T11:00:00.000Z"
+        "400":
+          description: >
+            Route parameter or body failed Zod validation. All errors are
+            collected in one pass and returned in the `details` array.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                invalidParamAndEmptyBody:
+                  summary: Invalid tenantId param and empty body collected together
+                  value:
+                    success: false
+                    error:
+                      code: VALIDATION_ERROR
+                      message: Request validation failed
+                      details:
+                        - field: body
+                          message: At least one tenant field must be provided
+                          code: CUSTOM
+                        - field: params.tenantId
+                          message: >-
+                            tenantId must be 3-64 characters using letters,
+                            numbers, underscores, or hyphens
+                          code: INVALID_STRING
+                    requestId: req-tenants-update-400
+                    timestamp: "2026-07-28T11:01:00.000Z"
+                unknownKey:
+                  summary: Unrecognised key in update body
+                  value:
+                    success: false
+                    error:
+                      code: VALIDATION_ERROR
+                      message: Request validation failed
+                      details:
+                        - field: body
+                          message: "Unrecognized key(s) in object: 'slug'"
+                          code: UNRECOGNIZED_KEYS
+                    requestId: req-tenants-update-400-key
+                    timestamp: "2026-07-28T11:02:00.000Z"
+        "401":
+          description: Authentication is required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StandardErrorEnvelope"
+              examples:
+                unauthorized:
+                  summary: Missing or invalid authentication
+                  value:
+                    success: false
+                    error:
+                      code: UNAUTHORIZED
+                      message: Unauthorized
+                    requestId: req-tenants-update-401
+                    timestamp: "2026-07-28T11:03:00.000Z"
   /api/webhooks:
     post:
       summary: Register a webhook
@@ -1397,6 +1758,144 @@ components:
         description:
           type: [string, "null"]
           maxLength: 1000
+    # ---------------------------------------------------------------------------
+    # Tenant schemas
+    # ---------------------------------------------------------------------------
+    TenantPlan:
+      type: string
+      enum: [starter, growth, enterprise]
+      description: Billing plan for the tenant.
+    TenantMetadata:
+      type: object
+      description: >
+        Arbitrary key/value pairs attached to the tenant. Keys must be 1–64
+        characters; values may be strings (≤ 256 chars), finite numbers, or
+        booleans. Maximum 20 keys.
+      maxProperties: 20
+      additionalProperties:
+        oneOf:
+          - type: string
+            maxLength: 256
+          - type: number
+          - type: boolean
+    TenantRecord:
+      type: object
+      required: [id, name, slug, plan, createdBy, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          description: Tenant identifier prefixed with `ten_`.
+          example: ten_a1b2c3d4-e5f6-7890-abcd-ef1234567890
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+          description: Human-readable tenant name (leading/trailing whitespace is trimmed).
+        slug:
+          type: string
+          pattern: "^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$"
+          description: >
+            URL-safe lowercase identifier derived from the name when omitted.
+            3–63 characters; letters, numbers, and internal hyphens only.
+        contactEmail:
+          type: string
+          format: email
+          maxLength: 254
+          description: Optional primary contact address for the tenant.
+        plan:
+          $ref: "#/components/schemas/TenantPlan"
+        metadata:
+          $ref: "#/components/schemas/TenantMetadata"
+        createdBy:
+          type: string
+          description: ID of the user who created the tenant.
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    TenantResponse:
+      type: object
+      required: [success, data, requestId, timestamp]
+      description: Success envelope wrapping a single TenantRecord.
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          $ref: "#/components/schemas/TenantRecord"
+        requestId:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    TenantListResponse:
+      type: object
+      required: [success, data, requestId, timestamp]
+      description: Success envelope wrapping an array of TenantRecords.
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantRecord"
+        requestId:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    TenantCreateRequest:
+      type: object
+      required: [name]
+      description: >
+        Zod-validated at the route boundary using `createTenantSchema`. The
+        schema is `.strict()` — any unrecognised key triggers a 400 with
+        code UNRECOGNIZED_KEYS in the details array.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+          description: Tenant name. Leading/trailing whitespace is trimmed by the validator.
+        slug:
+          type: string
+          pattern: "^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$"
+          description: >
+            Optional URL-safe slug. Converted to lowercase by the validator.
+            Auto-derived from `name` when omitted.
+        contactEmail:
+          type: string
+          format: email
+          maxLength: 254
+        plan:
+          $ref: "#/components/schemas/TenantPlan"
+        metadata:
+          $ref: "#/components/schemas/TenantMetadata"
+      additionalProperties: false
+    TenantUpdateRequest:
+      type: object
+      description: >
+        Zod-validated at the route boundary using `updateTenantSchema`. The
+        schema is `.strict()` — unrecognised keys (e.g. `slug`) are rejected.
+        At least one field must be present; an empty body triggers a 400.
+      minProperties: 1
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        contactEmail:
+          type: string
+          format: email
+          maxLength: 254
+        plan:
+          $ref: "#/components/schemas/TenantPlan"
+        metadata:
+          $ref: "#/components/schemas/TenantMetadata"
+      additionalProperties: false
     # Distinct from the pre-existing flat ErrorResponse — this matches the
     # actual envelope produced by errorHandler.ts / buildErrorEnvelope():
     # { success: false, error: { code, message, details? }, requestId, timestamp }

--- a/src/routes/tenants.openapi.test.ts
+++ b/src/routes/tenants.openapi.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Contract tests for src/openapi.yaml — /api/tenants surface.
+ *
+ * Validates that the examples added for GrantFox FWC26 cover:
+ *   - POST /api/tenants  (create with Zod validation + structured 400s)
+ *   - GET  /api/tenants  (list with ETag support)
+ *   - PATCH /api/tenants/{tenantId}  (update with per-field + param errors)
+ *
+ * Follows the same pattern used by src/routes/spike.openapi.test.ts:
+ * read the YAML file as a string and assert the presence of key strings so
+ * the tests remain stable without a full YAML parse dependency.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../middleware/errorHandler.js';
+import { requestIdMiddleware } from '../middleware/requestId.js';
+import { logger } from '../logger.js';
+import { createTenantsRouter, type TenantRecord, type TenantRepository } from './tenants.js';
+import type { CreateTenantInput, UpdateTenantInput } from '../validators/tenants.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const yamlPath = path.join(process.cwd(), 'src', 'openapi.yaml');
+
+function readOpenApiYaml(): string {
+  return fs.readFileSync(yamlPath, 'utf8');
+}
+
+class MockTenantRepository implements TenantRepository {
+  list = jest.fn(async (): Promise<TenantRecord[]> => [
+    {
+      id: 'ten_a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      name: 'GrantFox Ops',
+      slug: 'grantfox-ops',
+      contactEmail: 'ops@grantfox.test',
+      plan: 'growth',
+      metadata: { campaign: 'fwc26' },
+      createdBy: 'dev-1',
+      createdAt: '2026-07-28T00:00:00.000Z',
+      updatedAt: '2026-07-28T00:00:00.000Z',
+    },
+  ]);
+
+  create = jest.fn(async (input: CreateTenantInput, actorId: string): Promise<TenantRecord> => ({
+    id: 'ten_a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    name: input.name,
+    slug: input.slug ?? 'grantfox-ops',
+    contactEmail: input.contactEmail,
+    plan: input.plan,
+    metadata: input.metadata,
+    createdBy: actorId,
+    createdAt: '2026-07-28T10:00:00.000Z',
+    updatedAt: '2026-07-28T10:00:00.000Z',
+  }));
+
+  update = jest.fn(async (tenantId: string, input: UpdateTenantInput, actorId: string): Promise<TenantRecord> => ({
+    id: tenantId,
+    name: input.name ?? 'GrantFox Ops',
+    slug: 'grantfox-ops',
+    contactEmail: input.contactEmail,
+    plan: input.plan ?? 'starter',
+    metadata: input.metadata,
+    createdBy: actorId,
+    createdAt: '2026-07-28T00:00:00.000Z',
+    updatedAt: '2026-07-28T11:00:00.000Z',
+  }));
+}
+
+function buildApp(repository = new MockTenantRepository()) {
+  const app = express();
+  app.use(express.json());
+  app.use(requestIdMiddleware);
+  app.use('/api/tenants', createTenantsRouter({ tenantRepository: repository }));
+  app.use(errorHandler);
+  return { app, repository };
+}
+
+// ---------------------------------------------------------------------------
+// Group 1 — OpenAPI YAML contract (string-presence assertions)
+// ---------------------------------------------------------------------------
+
+describe('src/openapi.yaml — /api/tenants surface', () => {
+  test('documents /api/tenants and /api/tenants/{tenantId} paths', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('/api/tenants:');
+    expect(content).toContain('/api/tenants/{tenantId}:');
+  });
+
+  test('documents GET /api/tenants list and ETag examples', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('List tenants');
+    expect(content).toContain('withTenants:');
+    expect(content).toContain('empty:');
+    // ETag conditional-GET
+    expect(content).toContain('If-None-Match');
+    expect(content).toContain('304');
+  });
+
+  test('documents POST /api/tenants create request and success example', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('Create a tenant');
+    expect(content).toContain('createFull:');
+    expect(content).toContain('createMinimal:');
+    expect(content).toContain('created:');
+    // Zod-validation callout in description
+    expect(content).toContain('Zod-validated');
+  });
+
+  test('documents structured 400 validation-error examples for POST', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('missingName:');
+    expect(content).toContain('VALIDATION_ERROR');
+    expect(content).toContain('name is required');
+    expect(content).toContain('invalidEmail:');
+    expect(content).toContain('contactEmail must be a valid email address');
+    expect(content).toContain('unknownKey:');
+    expect(content).toContain('UNRECOGNIZED_KEYS');
+    expect(content).toContain('invalidPlan:');
+    expect(content).toContain('INVALID_ENUM_VALUE');
+  });
+
+  test('documents PATCH /api/tenants/{tenantId} update request and success example', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('Update a tenant');
+    expect(content).toContain('updatePlan:');
+    expect(content).toContain('updateContactEmail:');
+    expect(content).toContain('updateMultiple:');
+    expect(content).toContain('updated:');
+  });
+
+  test('documents combined param + body 400 example for PATCH', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('invalidParamAndEmptyBody:');
+    expect(content).toContain('At least one tenant field must be provided');
+    expect(content).toContain('params.tenantId');
+    expect(content).toContain('unknownKey:');
+  });
+
+  test('documents 401 examples for all tenant operations', () => {
+    const content = readOpenApiYaml();
+
+    // Multiple 401 blocks — one per operation
+    const matches = [...content.matchAll(/code: UNAUTHORIZED/g)];
+    // At minimum POST, GET, and PATCH each contribute one UNAUTHORIZED block
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('defines typed tenant schemas in components', () => {
+    const content = readOpenApiYaml();
+
+    expect(content).toContain('TenantRecord:');
+    expect(content).toContain('TenantCreateRequest:');
+    expect(content).toContain('TenantUpdateRequest:');
+    expect(content).toContain('TenantResponse:');
+    expect(content).toContain('TenantListResponse:');
+    expect(content).toContain('TenantPlan:');
+    expect(content).toContain('TenantMetadata:');
+    // Plan enum values
+    expect(content).toContain('enum: [starter, growth, enterprise]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 2 — HTTP integration: Zod validation produces structured 400s
+// ---------------------------------------------------------------------------
+
+describe('POST /api/tenants — Zod validation integration', () => {
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  it('returns 400 with VALIDATION_ERROR and per-field details when name is missing', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('x-request-id', 'req-missing-name')
+      .send({ contactEmail: 'bad-email' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      error: { code: 'VALIDATION_ERROR', message: 'Request validation failed' },
+      requestId: 'req-missing-name',
+    });
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body.name' }),
+        expect.objectContaining({ field: 'body.contactEmail' }),
+      ]),
+    );
+  });
+
+  it('returns 400 with UNRECOGNIZED_KEYS when unknown fields are sent', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('x-request-id', 'req-unknown-key')
+      .send({ name: 'GrantFox Ops', unsafeRole: 'admin' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body', code: 'UNRECOGNIZED_KEYS' }),
+      ]),
+    );
+  });
+
+  it('returns 400 when plan is outside the allowed enum', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('x-request-id', 'req-bad-plan')
+      .send({ name: 'GrantFox Ops', plan: 'premium' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body.plan' }),
+      ]),
+    );
+  });
+
+  it('returns 201 success envelope for a valid minimal create request', async () => {
+    const { app, repository } = buildApp();
+
+    const res = await request(app)
+      .post('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('x-request-id', 'req-create-ok')
+      .send({ name: 'GrantFox Stadium' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      success: true,
+      requestId: 'req-create-ok',
+      data: expect.objectContaining({ name: 'GrantFox Stadium' }),
+    });
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'GrantFox Stadium', plan: 'starter' }),
+      'dev-1',
+    );
+  });
+
+  it('returns 201 with trimmed name and lowercased slug', async () => {
+    const { app, repository } = buildApp();
+
+    const res = await request(app)
+      .post('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .send({ name: '  GrantFox Ops  ', slug: 'GrantFox-Ops', plan: 'growth' });
+
+    expect(res.status).toBe(201);
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'GrantFox Ops', slug: 'grantfox-ops' }),
+      'dev-1',
+    );
+  });
+
+  it('returns 401 before validation when request is unauthenticated', async () => {
+    const { app, repository } = buildApp();
+
+    const res = await request(app)
+      .post('/api/tenants')
+      .send({ name: 'GrantFox Ops' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 3 — HTTP integration: PATCH validation collects param + body errors
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/tenants/:tenantId — Zod validation integration', () => {
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  it('returns 400 collecting param and body errors in one pass', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .patch('/api/tenants/no')
+      .set('x-user-id', 'dev-1')
+      .set('x-request-id', 'req-patch-multi-error')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.requestId).toBe('req-patch-multi-error');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'body' }),
+        expect.objectContaining({ field: 'params.tenantId' }),
+      ]),
+    );
+  });
+
+  it('returns 400 when slug is sent (strict schema — not an update field)', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .patch('/api/tenants/tenant_123')
+      .set('x-user-id', 'dev-1')
+      .send({ slug: 'new-slug' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'UNRECOGNIZED_KEYS' }),
+      ]),
+    );
+  });
+
+  it('returns 200 success envelope for a valid update', async () => {
+    const { app, repository } = buildApp();
+
+    const res = await request(app)
+      .patch('/api/tenants/tenant_123')
+      .set('x-user-id', 'dev-1')
+      .set('x-request-id', 'req-patch-ok')
+      .send({ plan: 'enterprise' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      requestId: 'req-patch-ok',
+      data: expect.objectContaining({ id: 'tenant_123', plan: 'enterprise' }),
+    });
+    expect(repository.update).toHaveBeenCalledWith(
+      'tenant_123',
+      expect.objectContaining({ plan: 'enterprise' }),
+      'dev-1',
+    );
+  });
+
+  it('returns 401 before validation when unauthenticated', async () => {
+    const { app, repository } = buildApp();
+
+    const res = await request(app)
+      .patch('/api/tenants/tenant_123')
+      .send({ plan: 'enterprise' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 4 — HTTP integration: GET /api/tenants
+// ---------------------------------------------------------------------------
+
+describe('GET /api/tenants — list integration', () => {
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  it('returns 200 success envelope with tenant array', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('x-request-id', 'req-list-ok');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      requestId: 'req-list-ok',
+    });
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('sets a strong ETag header on the list response', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.etag).toBeDefined();
+    expect(res.headers.etag).toMatch(/^"[0-9a-f]{64}"$/);
+  });
+
+  it('returns 304 when If-None-Match matches the ETag', async () => {
+    const { app } = buildApp();
+
+    const first = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1');
+
+    expect(first.status).toBe(200);
+    const etag = first.headers.etag as string;
+
+    const second = await request(app)
+      .get('/api/tenants')
+      .set('x-user-id', 'dev-1')
+      .set('If-None-Match', etag);
+
+    expect(second.status).toBe(304);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app).get('/api/tenants');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+});


### PR DESCRIPTION
Added /api/tenants (GET, POST) and /api/tenants/{tenantId} (PATCH) to src/openapi.yaml with 7 typed component schemas covering the request bodies, response envelopes, plan enum, and metadata shape.
Documented all 400 error cases with realistic examples including missing name, invalid email, unrecognised keys (UNRECOGNIZED_KEYS), invalid plan enum, and combined param plus body errors collected in one pass.
Added ETag and 304 conditional GET documentation for the list endpoint.
Created src/routes/tenants.openapi.test.ts with YAML contract assertions and HTTP integration tests covering all three operations, all validation failure paths, and unauthenticated 401 cases.
Closes #1089 