### PR TITLE
feat(rate-limit): add structured JSON access logs for /api/rate-limit

### DIFF
--- a/src/middleware/rateLimitAccessLog.test.ts
+++ b/src/middleware/rateLimitAccessLog.test.ts
@@ -1,0 +1,537 @@
+import { EventEmitter } from 'node:events';
+import type { Request, Response } from 'express';
+
+import {
+  createRateLimitAccessLogMiddleware,
+  rateLimitAccessLogger,
+  RATE_LIMIT_LOG_REDACTED_VALUE,
+  rateLimitAccessLogMiddleware,
+} from './rateLimitAccessLog.js';
+
+type FakeReq = EventEmitter &
+  Request & {
+    headers: Record<string, string | string[]>;
+    id?: string;
+  };
+
+type FakeRes = EventEmitter &
+  Response & {
+    statusCode: number;
+    writableEnded: boolean;
+    locals: Record<string, unknown>;
+    write: jest.Mock;
+    end: jest.Mock;
+    setHeader: jest.Mock;
+  };
+
+function makeReq(overrides: Partial<FakeReq> = {}): FakeReq {
+  return Object.assign(new EventEmitter(), {
+    method: 'GET',
+    path: '/api/rate-limit/health',
+    headers: {},
+    id: undefined,
+    ...overrides,
+  }) as FakeReq;
+}
+
+function makeRes(overrides: Partial<FakeRes> = {}): FakeRes {
+  return Object.assign(new EventEmitter(), {
+    statusCode: 200,
+    writableEnded: true,
+    locals: {},
+    setHeader: jest.fn(),
+    write: jest.fn(() => true),
+    end: jest.fn(() => true),
+    ...overrides,
+  }) as FakeRes;
+}
+
+describe('createRateLimitAccessLogMiddleware', () => {
+  test('emits a structured log with all base fields on 2xx', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+
+      const req = makeReq({
+        method: 'GET',
+        path: '/api/rate-limit/health',
+        headers: { 'x-request-id': 'req-rl-1' },
+        id: 'req-rl-1',
+      });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      const [payload, msg] = infoSpy.mock.calls[0];
+      expect(payload).toEqual(
+        expect.objectContaining({
+          correlationId: 'req-rl-1',
+          requestId: 'req-rl-1',
+          method: 'GET',
+          path: '/api/rate-limit/health',
+          status: 200,
+          statusCode: 200,
+          ms: expect.any(Number),
+          durationMs: expect.any(Number),
+          responseBytes: 0,
+        }),
+      );
+      expect(msg).toBe('rate-limit request completed');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('includes actor from res.locals.authenticatedUser', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+
+      const req = makeReq({
+        headers: { 'x-request-id': 'req-actor-1' },
+        id: 'req-actor-1',
+      });
+      const res = makeRes({
+        statusCode: 200,
+        locals: { authenticatedUser: { id: 'dev-xyz' } },
+      });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ actor: 'dev-xyz' }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('omits actor when unauthenticated', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-unauth' }, id: 'req-unauth' });
+      const res = makeRes({ statusCode: 200, locals: {} });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      const payload = infoSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(payload).not.toHaveProperty('actor');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('counts responseBytes from res.write and res.end', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-bytes' }, id: 'req-bytes' });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.write('hello');
+      res.end(Buffer.from(' world'));
+      res.emit('finish');
+
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ responseBytes: 11 }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('logs at warn level for 4xx responses', () => {
+    const warnSpy = jest.spyOn(rateLimitAccessLogger, 'warn').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-4xx' }, id: 'req-4xx' });
+      const res = makeRes({ statusCode: 404 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ status: 404, statusCode: 404 }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('logs at error level for 5xx responses', () => {
+    const errorSpy = jest.spyOn(rateLimitAccessLogger, 'error').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-5xx' }, id: 'req-5xx' });
+      const res = makeRes({ statusCode: 500 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ status: 500, statusCode: 500 }),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test('logs at info level for 201 responses', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-201' }, id: 'req-201' });
+      const res = makeRes({ statusCode: 201 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ status: 201 }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('logs at info level for 204 responses', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-204' }, id: 'req-204' });
+      const res = makeRes({ statusCode: 204 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ status: 204 }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('logs at warn level for 401 responses', () => {
+    const warnSpy = jest.spyOn(rateLimitAccessLogger, 'warn').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-401' }, id: 'req-401' });
+      const res = makeRes({ statusCode: 401 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ status: 401, statusCode: 401 }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('emits log on close when response is not writableEnded', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-close' }, id: 'req-close' });
+      const res = makeRes({ statusCode: 200, writableEnded: false });
+
+      middleware(req, res, jest.fn());
+      res.emit('close');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ requestId: 'req-close' }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('emits log only once when both finish and close fire', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-once' }, id: 'req-once' });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+      res.emit('close');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('does not emit a second log when close fires after finish on a writableEnded response', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-ws-end' }, id: 'req-ws-end' });
+      const res = makeRes({ statusCode: 200, writableEnded: true });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+      res.emit('close');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('prefers x-correlation-id over x-request-id for correlationId', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({
+        headers: {
+          'x-request-id': 'req-id-1',
+          'x-correlation-id': 'corr-id-1',
+        },
+        id: 'req-id-1',
+      });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          correlationId: 'corr-id-1',
+          requestId: 'req-id-1',
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('falls back to x-request-id for both correlationId and requestId when no x-correlation-id', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({
+        headers: { 'x-request-id': 'req-fallback' },
+        id: 'req-fallback',
+      });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          correlationId: 'req-fallback',
+          requestId: 'req-fallback',
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('generates a UUID requestId when no id is present and no headers', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: {}, id: undefined });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          requestId: expect.stringMatching(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+          ),
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('accepts array-valued x-request-id header and uses the first element', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({
+        headers: { 'x-request-id': ['arr-id-1', 'arr-id-2'] },
+        id: undefined,
+      });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ requestId: 'arr-id-1' }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('redacts configured fields (case-insensitive)', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware({
+        redactFields: ['path', 'requestId'],
+      });
+
+      const req = makeReq({
+        method: 'GET',
+        path: '/api/rate-limit/health',
+        headers: { 'x-request-id': 'req-redact' },
+        id: 'req-redact',
+      });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      expect(infoSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          path: RATE_LIMIT_LOG_REDACTED_VALUE,
+          requestId: RATE_LIMIT_LOG_REDACTED_VALUE,
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('redacts fields regardless of key case in options', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware({
+        redactFields: ['PATH', 'CORRELATIONID'],
+      });
+      const req = makeReq({
+        headers: { 'x-request-id': 'req-case' },
+        id: 'req-case',
+      });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      const payload = infoSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(payload.path).toBe(RATE_LIMIT_LOG_REDACTED_VALUE);
+      expect(payload.correlationId).toBe(RATE_LIMIT_LOG_REDACTED_VALUE);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test('uses a custom logger when provided', () => {
+    const customInfo = jest.fn();
+    const customLogger = { info: customInfo, warn: jest.fn(), error: jest.fn() };
+
+    const middleware = createRateLimitAccessLogMiddleware({ logger: customLogger });
+    const req = makeReq({ headers: { 'x-request-id': 'req-custom' }, id: 'req-custom' });
+    const res = makeRes({ statusCode: 200 });
+
+    middleware(req, res, jest.fn());
+    res.emit('finish');
+
+    expect(customInfo).toHaveBeenCalledTimes(1);
+  });
+
+  test('custom logger receives warn for 4xx with correct payload', () => {
+    const customWarn = jest.fn();
+    const customLogger = { info: jest.fn(), warn: customWarn, error: jest.fn() };
+
+    const middleware = createRateLimitAccessLogMiddleware({ logger: customLogger });
+    const req = makeReq({ headers: { 'x-request-id': 'req-custom-4xx' }, id: 'req-custom-4xx' });
+    const res = makeRes({ statusCode: 400 });
+
+    middleware(req, res, jest.fn());
+    res.emit('finish');
+
+    expect(customWarn).toHaveBeenCalledTimes(1);
+    expect(customWarn.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ status: 400, requestId: 'req-custom-4xx' }),
+    );
+  });
+
+  test('calls next() immediately', () => {
+    const next = jest.fn();
+    const middleware = createRateLimitAccessLogMiddleware();
+    const req = makeReq({ headers: {}, id: 'req-next' });
+    const res = makeRes({ statusCode: 200 });
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('reports non-negative latency values', () => {
+    const infoSpy = jest.spyOn(rateLimitAccessLogger, 'info').mockImplementation(() => rateLimitAccessLogger);
+
+    try {
+      const middleware = createRateLimitAccessLogMiddleware();
+      const req = makeReq({ headers: { 'x-request-id': 'req-latency' }, id: 'req-latency' });
+      const res = makeRes({ statusCode: 200 });
+
+      middleware(req, res, jest.fn());
+      res.emit('finish');
+
+      const payload = infoSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(typeof payload.ms).toBe('number');
+      expect(payload.ms as number).toBeGreaterThanOrEqual(0);
+      expect(payload.durationMs).toBe(payload.ms);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});
+
+describe('rateLimitAccessLogger', () => {
+  test('has channel=rate_limit', () => {
+    expect(rateLimitAccessLogger).toBeDefined();
+    expect(rateLimitAccessLogger.bindings?.()).toEqual(
+      expect.objectContaining({ channel: 'rate_limit' }),
+    );
+  });
+});
+
+describe('rateLimitAccessLogMiddleware', () => {
+  test('is a function', () => {
+    expect(typeof rateLimitAccessLogMiddleware).toBe('function');
+  });
+});

--- a/src/middleware/rateLimitAccessLog.ts
+++ b/src/middleware/rateLimitAccessLog.ts
@@ -1,0 +1,163 @@
+import type { NextFunction, Request, Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { getClientIp } from '../lib/clientIp.js';
+import { getRequestId } from '../utils/asyncContext.js';
+import { logger } from './logging.js';
+import { sanitizeRequestId } from './requestId.js';
+
+export const RATE_LIMIT_LOG_REDACTED_VALUE = '[REDACTED]';
+
+export const rateLimitAccessLogger = logger.child({ channel: 'rate_limit' });
+
+export interface RateLimitAccessLogPayload {
+  correlationId: string;
+  requestId: string;
+  method: string;
+  path: string;
+  status: number;
+  statusCode: number;
+  ms: number;
+  durationMs: number;
+  responseBytes: number;
+  actor?: string;
+  clientIp?: string;
+}
+
+export interface RateLimitAccessLogOptions {
+  redactFields?: readonly string[];
+  logger?: Pick<typeof logger, 'info' | 'warn' | 'error'>;
+}
+
+const TRUST_PROXY = process.env.TRUST_PROXY_HEADERS === 'true';
+
+function byteLength(chunk: unknown, encoding?: BufferEncoding): number {
+  if (chunk === null || chunk === undefined) return 0;
+  if (Buffer.isBuffer(chunk)) return chunk.length;
+  if (typeof chunk === 'string') return Buffer.byteLength(chunk, encoding);
+  return Buffer.byteLength(String(chunk));
+}
+
+function extractUserId(res: Response): string | undefined {
+  const locals = res.locals as Record<string, unknown>;
+  const user = locals.authenticatedUser as { id?: string } | undefined;
+  return user?.id;
+}
+
+export function createRateLimitAccessLogMiddleware(options: RateLimitAccessLogOptions = {}) {
+  const redactFieldsLower = options.redactFields?.map((f) => f.toLowerCase()) ?? [];
+  const loggerInstance = options.logger ?? rateLimitAccessLogger;
+
+  return function rateLimitAccessLogMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const startAt = process.hrtime.bigint();
+
+    const requestId =
+      sanitizeRequestId(req.id) ??
+      getRequestId() ??
+      sanitizeRequestId(
+        Array.isArray(req.headers['x-request-id'])
+          ? req.headers['x-request-id'][0]
+          : req.headers['x-request-id'],
+      ) ??
+      uuidv4();
+
+    const correlationId =
+      sanitizeRequestId(
+        Array.isArray(req.headers['x-correlation-id'])
+          ? req.headers['x-correlation-id'][0]
+          : req.headers['x-correlation-id'],
+      ) ??
+      sanitizeRequestId(
+        Array.isArray(req.headers['x-request-id'])
+          ? req.headers['x-request-id'][0]
+          : req.headers['x-request-id'],
+      ) ??
+      requestId;
+
+    const clientIp = getClientIp(req, TRUST_PROXY);
+
+    let responseBytes = 0;
+    let emitted = false;
+
+    const originalWrite = typeof res.write === 'function' ? res.write.bind(res) : undefined;
+    const originalEnd = typeof res.end === 'function' ? res.end.bind(res) : undefined;
+
+    if (originalWrite) {
+      res.write = ((chunk: unknown, encoding?: unknown, callback?: unknown) => {
+        responseBytes += byteLength(
+          chunk,
+          typeof encoding === 'string' ? (encoding as BufferEncoding) : undefined,
+        );
+        return originalWrite(chunk as never, encoding as never, callback as never);
+      }) as typeof res.write;
+    }
+
+    if (originalEnd) {
+      res.end = ((chunk?: unknown, encoding?: unknown, callback?: unknown) => {
+        responseBytes += byteLength(
+          chunk,
+          typeof encoding === 'string' ? (encoding as BufferEncoding) : undefined,
+        );
+        return originalEnd(chunk as never, encoding as never, callback as never);
+      }) as typeof res.end;
+    }
+
+    const emitLog = (): void => {
+      if (emitted) return;
+      emitted = true;
+
+      const elapsedMs = Number(process.hrtime.bigint() - startAt) / 1_000_000;
+      const status = res.statusCode;
+      const userId = extractUserId(res);
+
+      const payload: RateLimitAccessLogPayload = {
+        correlationId,
+        requestId,
+        method: req.method,
+        path: req.path,
+        status,
+        statusCode: status,
+        ms: Number(elapsedMs.toFixed(3)),
+        durationMs: Number(elapsedMs.toFixed(3)),
+        responseBytes,
+        ...(userId ? { actor: userId } : {}),
+        ...(clientIp ? { clientIp } : {}),
+      };
+
+      if (redactFieldsLower.length > 0) {
+        const lowerToActual = Object.keys(payload).reduce<Record<string, string>>(
+          (map, key) => {
+            map[key.toLowerCase()] = key;
+            return map;
+          },
+          {},
+        );
+        for (const field of redactFieldsLower) {
+          const actualKey = lowerToActual[field];
+          if (actualKey) {
+            (payload as unknown as Record<string, string>)[actualKey] =
+              RATE_LIMIT_LOG_REDACTED_VALUE;
+          }
+        }
+      }
+
+      if (status >= 500) {
+        loggerInstance.error({ ...payload }, 'rate-limit request completed');
+      } else if (status >= 400) {
+        loggerInstance.warn({ ...payload }, 'rate-limit request completed');
+      } else {
+        loggerInstance.info({ ...payload }, 'rate-limit request completed');
+      }
+    };
+
+    res.once('finish', emitLog);
+    res.once('close', () => {
+      if (!res.writableEnded) {
+        emitLog();
+      }
+    });
+
+    next();
+  };
+}
+
+export const rateLimitAccessLogMiddleware = createRateLimitAccessLogMiddleware();

--- a/src/routes/rate-limit.ts
+++ b/src/routes/rate-limit.ts
@@ -11,6 +11,7 @@
 
 import { Router } from 'express';
 import { correlationMiddleware } from '../middleware/correlation.js';
+import { rateLimitAccessLogMiddleware } from '../middleware/rateLimitAccessLog.js';
 import { createRateLimitHealthRouter, type RateLimitHealthDeps } from './rate-limit/health.js';
 
 export interface RateLimitRouterDeps extends Partial<RateLimitHealthDeps> {
@@ -35,6 +36,10 @@ export function createRateLimitRouter(deps: RateLimitRouterDeps = {}): Router {
   // and attaches resolved value to req.correlationId for downstream
   // handlers, structured logging, and outbound HTTP calls.
   router.use(correlationMiddleware);
+
+  // Structured JSON access log for every /api/rate-limit request.
+  // Emits req-id, latency, status, response size, and actor when available.
+  router.use(rateLimitAccessLogMiddleware);
 
   // Rate-limit health dependency probe
   router.use(


### PR DESCRIPTION
## Description

Adds structured JSON access logging for the `/api/rate-limit` route group. Every request to this endpoint now emits a `channel:rate_limit` log entry with the standard observability fields used across the codebase (matching the pattern established by `forecastAccessLog`, `exportsAccessLog`, `usageAccessLog`, and `billingAccessLog`).

## Changes

### New: `src/middleware/rateLimitAccessLog.ts`

Access-log middleware factory (`createRateLimitAccessLogMiddleware`) that emits one JSON log entry per request on the `rate_limit` Pino child channel. Each entry includes:

| Field | Source | Description |
|---|---|---|
| `requestId` | `req.id` → `getRequestId()` → `x-request-id` → UUID | Request identifier (req-id) |
| `correlationId` | `x-correlation-id` → `x-request-id` → `requestId` | End-to-end tracing ID |
| `method` | `req.method` | HTTP verb |
| `path` | `req.path` | Route path |
| `status` / `statusCode` | `res.statusCode` | Response status |
| `ms` / `durationMs` | `process.hrtime.bigint()` | Latency in ms (3dp) |
| `responseBytes` | Monkey-patched `write`/`end` | Response body size |
| `actor` | `res.locals.authenticatedUser.id` | Authenticated user (omitted when unavailable) |
| `clientIp` | `getClientIp()` | Client IP (honours `TRUST_PROXY_HEADERS`) |

Log levels: `info` (2xx), `warn` (4xx), `error` (5xx) — per project convention.

Supports field-level redaction and custom logger injection (for test isolation).

### New: `src/middleware/rateLimitAccessLog.test.ts`

24 tests covering:
- All base payload fields present on 2xx
- Actor presence/absence from `res.locals.authenticatedUser`
- Response byte counting via `write`/`end`
- Log levels: info (2xx, 201, 204), warn (4xx, 401), error (5xx)
- Emit deduplication (`finish` + `close` → single emission)
- Correlation ID priority chain
- UUID generation when no ID headers present
- Array-valued header handling
- Field redaction (case-insensitive)
- Custom logger injection
- `next()` invocation
- Non-negative latency
- Singleton export type

### Modified: `src/routes/rate-limit.ts`

Mounted `rateLimitAccessLogMiddleware` after `correlationMiddleware` and before the health sub-route, so all future `/api/rate-limit/*` sub-routes automatically inherit access logging.

## Verification

- 24 new tests pass
- All 32 existing rate-limit tests pass (4 suites: `correlation.test.ts`, `health.test.ts`, `health.openapi.test.ts`, `openapi-yaml.test.ts`)
- ESLint clean on new files
- No API contract changes — this is purely an observability addition

## Closes

Closes #767