### PR TITLE
[#1150] Enforce OpenAPI runtime contract tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "prebuild": "npm run error-codes:check",
+    "prebuild": "npm run error-codes:check && npm run validate:openapi",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "lint": "eslint .",
@@ -14,6 +14,7 @@
     "seed:dev": "tsx scripts/seed-dev.ts",
     "typecheck": "tsc --noEmit",
     "validate:issue-9": "node scripts/validate-issue-9.mjs",
+    "validate:openapi": "node scripts/validate-openapi-contract.mjs",
     "db:check-migrations": "npx tsx scripts/check-migrations.ts",
     "error-codes:generate": "node scripts/generate-error-codes.mjs",
     "error-codes:check": "node scripts/generate-error-codes.mjs --check",

--- a/scripts/validate-openapi-contract.mjs
+++ b/scripts/validate-openapi-contract.mjs
@@ -1,0 +1,207 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const specPath = resolve(process.cwd(), "docs/openapi.json");
+const spec = JSON.parse(readFileSync(specPath, "utf8"));
+const failures = [];
+const warnings = [];
+const methods = new Set([
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "options",
+  "head",
+  "trace",
+]);
+const isResponseKey = (key) =>
+  key === "default" || /^\d{3}([Xx]{2})?$/.test(key);
+
+function fail(message) {
+  failures.push(message);
+}
+
+function warn(message) {
+  warnings.push(message);
+}
+
+function resolveRef(ref, location) {
+  if (typeof ref !== "string" || !ref.startsWith("#/")) {
+    fail(`${location}: unsupported reference ${String(ref)}`);
+    return undefined;
+  }
+
+  const value = ref
+    .slice(2)
+    .split("/")
+    .reduce((current, segment) => current?.[segment], spec);
+  if (value === undefined) fail(`${location}: unresolved reference ${ref}`);
+  return value;
+}
+
+function inspectSchema(schema, location) {
+  if (!schema || typeof schema !== "object") {
+    fail(`${location}: schema must be an object`);
+    return;
+  }
+  if (schema.$ref) {
+    inspectSchema(resolveRef(schema.$ref, location), location);
+    return;
+  }
+  if (Array.isArray(schema.enum) && schema.enum.length === 0) {
+    fail(`${location}: enum cannot be empty`);
+  }
+  if (
+    schema.required &&
+    (!Array.isArray(schema.required) || schema.required.length === 0)
+  ) {
+    fail(`${location}: required must contain at least one field`);
+  }
+  if (schema.required && schema.properties) {
+    for (const field of schema.required) {
+      if (!(field in schema.properties))
+        warn(`${location}: required field ${field} is undocumented`);
+    }
+  }
+  if (schema.properties) {
+    for (const [name, child] of Object.entries(schema.properties)) {
+      inspectSchema(child, `${location}.properties.${name}`);
+    }
+  }
+  if (schema.items) inspectSchema(schema.items, `${location}.items`);
+  for (const keyword of ["allOf", "anyOf", "oneOf"]) {
+    if (Array.isArray(schema[keyword])) {
+      schema[keyword].forEach((child, index) =>
+        inspectSchema(child, `${location}.${keyword}[${index}]`),
+      );
+    }
+  }
+}
+
+function inspectParameter(parameter, location) {
+  if (parameter?.$ref) {
+    inspectParameter(resolveRef(parameter.$ref, location), location);
+    return;
+  }
+  if (!parameter || typeof parameter !== "object") {
+    fail(`${location}: parameter must be an object`);
+    return;
+  }
+  if (
+    !parameter.name ||
+    !["path", "query", "header", "cookie"].includes(parameter.in)
+  ) {
+    fail(`${location}: parameter needs a name and valid location`);
+  }
+  if (parameter.in === "path" && parameter.required !== true) {
+    fail(`${location}: path parameters must be required`);
+  }
+  if (parameter.schema) inspectSchema(parameter.schema, `${location}.schema`);
+}
+
+function inspectResponse(response, location, status) {
+  if (response?.$ref) {
+    inspectResponse(resolveRef(response.$ref, location), location, status);
+    return;
+  }
+  if (
+    !response ||
+    typeof response !== "object" ||
+    typeof response.description !== "string"
+  ) {
+    fail(`${location}: response needs a description`);
+    return;
+  }
+  if (status !== "204") {
+    const content = response.content?.["application/json"];
+    if (!content?.schema) warn(`${location}: JSON response has no JSON schema`);
+    if (content?.schema)
+      inspectSchema(
+        content.schema,
+        `${location}.content.application/json.schema`,
+      );
+  }
+}
+
+if (spec.openapi !== "3.1.0")
+  fail(`document: expected OpenAPI 3.1.0, got ${String(spec.openapi)}`);
+if (!spec.info?.title || !spec.info?.version)
+  fail("document: info.title and info.version are required");
+if (
+  !spec.paths ||
+  typeof spec.paths !== "object" ||
+  Object.keys(spec.paths).length === 0
+) {
+  fail("document: paths must contain at least one path");
+}
+
+for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+  if (!path.startsWith("/")) fail(`paths.${path}: paths must start with /`);
+  if (pathItem.parameters) {
+    pathItem.parameters.forEach((parameter, index) =>
+      inspectParameter(parameter, `paths.${path}.parameters[${index}]`),
+    );
+  }
+  for (const [method, operation] of Object.entries(pathItem)) {
+    if (!methods.has(method)) continue;
+    const location = `paths.${path}.${method}`;
+    if (!operation.operationId)
+      warn(`${location}: operationId is missing for generated clients`);
+    if (!operation.responses || typeof operation.responses !== "object") {
+      fail(`${location}: responses are required`);
+      continue;
+    }
+    const responseKeys = Object.keys(operation.responses).filter(isResponseKey);
+    if (responseKeys.length === 0)
+      fail(`${location}: at least one HTTP response is required`);
+    if (!responseKeys.some((key) => key.startsWith("2") || key === "default")) {
+      fail(`${location}: success/default response is required`);
+    }
+    for (const [status, response] of Object.entries(operation.responses)) {
+      if (isResponseKey(status))
+        inspectResponse(response, `${location}.responses.${status}`, status);
+    }
+    if (["post", "put", "patch"].includes(method) && operation.requestBody) {
+      const body = operation.requestBody.$ref
+        ? resolveRef(operation.requestBody.$ref, `${location}.requestBody`)
+        : operation.requestBody;
+      if (!body?.content?.["application/json"]?.schema)
+        warn(`${location}: JSON request body has no schema`);
+      if (body?.content?.["application/json"]?.schema)
+        inspectSchema(
+          body.content["application/json"].schema,
+          `${location}.requestBody.schema`,
+        );
+    }
+    for (const [index, parameter] of (operation.parameters ?? []).entries()) {
+      inspectParameter(parameter, `${location}.parameters[${index}]`);
+    }
+  }
+}
+
+for (const [name, schema] of Object.entries(spec.components?.schemas ?? {})) {
+  inspectSchema(schema, `components.schemas.${name}`);
+}
+
+if (failures.length > 0) {
+  console.error(
+    `OpenAPI contract validation failed with ${failures.length} issue(s):`,
+  );
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exitCode = 1;
+} else {
+  const operationCount = Object.values(spec.paths).reduce(
+    (count, pathItem) =>
+      count +
+      Object.keys(pathItem).filter((method) => methods.has(method)).length,
+    0,
+  );
+  console.log(
+    `OpenAPI contract valid: ${Object.keys(spec.paths).length} paths, ${operationCount} operations.`,
+  );
+  if (warnings.length > 0) {
+    console.warn(`OpenAPI contract compatibility warnings: ${warnings.length}`);
+    for (const warning of warnings) console.warn(`- ${warning}`);
+  }
+}

--- a/tests/contract/openapi-runtime.test.ts
+++ b/tests/contract/openapi-runtime.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Runtime contract coverage for the highest-risk public surfaces.
+ *
+ * The production app installs express-openapi-validator for documented paths.
+ * These tests exercise the same request boundaries in small deterministic
+ * harnesses so CI does not need a database, a wallet, an upstream service, or
+ * a DNS resolver. The final assertions also enforce the canonical response
+ * envelope used by the full app.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import { z } from "zod";
+import { describe, expect, it } from "@jest/globals";
+import {
+  walletLoginSchema,
+  refreshTokenSchema,
+} from "../../src/validators/auth.js";
+import {
+  bodyValidator,
+  ValidationError,
+} from "../../src/middleware/validate.js";
+import {
+  envelopeSchema,
+  errorEnvelopeSchema,
+  successEnvelopeSchema,
+} from "../../src/middleware/envelope.js";
+import { errorHandler } from "../../src/middleware/errorHandler.js";
+import {
+  validateWebhookUrl,
+  WebhookValidationError,
+} from "../../src/webhooks/webhook.validator.js";
+
+type OpenApiDocument = {
+  openapi: string;
+  paths: Record<string, Record<string, unknown>>;
+  components?: { schemas?: Record<string, unknown> };
+};
+
+const specPath = path.join(process.cwd(), "docs", "openapi.json");
+const spec = JSON.parse(fs.readFileSync(specPath, "utf8")) as OpenApiDocument;
+
+const validWallet = "G" + "A".repeat(55);
+
+function buildSchemaApp(schema: z.ZodSchema) {
+  const app = express();
+  app.use(express.json());
+  app.post("/contract", bodyValidator(schema), (req, res) => {
+    res.status(200).json({
+      success: true,
+      data: { accepted: true, body: req.body },
+      requestId: "contract-test",
+      timestamp: new Date().toISOString(),
+    });
+  });
+  app.use(
+    (
+      error: unknown,
+      _req: express.Request,
+      res: express.Response,
+      next: express.NextFunction,
+    ) => {
+      if (error instanceof ValidationError) {
+        res.status(400).json({
+          success: false,
+          error: {
+            code: error.code,
+            message: error.message,
+            details: error.details,
+          },
+          requestId: "contract-test",
+          timestamp: new Date().toISOString(),
+        });
+        return;
+      }
+      next(error);
+    },
+  );
+  return app;
+}
+
+function assertSuccessEnvelope(body: unknown) {
+  const parsed = successEnvelopeSchema.safeParse(body);
+  expect(parsed.success).toBe(true);
+  if (parsed.success) {
+    expect(parsed.data.success).toBe(true);
+    expect(parsed.data.requestId).toEqual(expect.any(String));
+    expect(new Date(parsed.data.timestamp).toString()).not.toBe("Invalid Date");
+  }
+}
+
+function assertErrorEnvelope(body: unknown, code?: string) {
+  const parsed = errorEnvelopeSchema.safeParse(body);
+  expect(parsed.success).toBe(true);
+  if (parsed.success) {
+    expect(parsed.data.success).toBe(false);
+    expect(parsed.data.error.code).toEqual(code ?? expect.any(String));
+    expect(parsed.data.error.message).toEqual(expect.any(String));
+    expect(parsed.data.requestId).toEqual(expect.any(String));
+    expect(new Date(parsed.data.timestamp).toString()).not.toBe("Invalid Date");
+  }
+}
+
+describe("OpenAPI document integrity", () => {
+  it("is OpenAPI 3.1 and exposes the canonical JSON contract", () => {
+    expect(spec.openapi).toBe("3.1.0");
+    expect(spec.paths).toEqual(expect.any(Object));
+    expect(Object.keys(spec.paths).length).toBeGreaterThan(20);
+    expect(spec.components?.schemas).toEqual(expect.any(Object));
+  });
+
+  it("documents the response envelope schemas used by runtime handlers", () => {
+    const schemas = spec.components?.schemas ?? {};
+    const success = JSON.stringify(schemas);
+    expect(success).toContain("StandardErrorEnvelope");
+    expect(success).toContain("success");
+    expect(success).toContain("requestId");
+    expect(success).toContain("timestamp");
+  });
+
+  it("keeps billing operations and their request fields discoverable", () => {
+    for (const route of ["/api/billing/deduct", "/api/billing/deduct/bulk"]) {
+      const operation = spec.paths[route]?.post;
+      expect(operation).toEqual(expect.any(Object));
+      const value = JSON.stringify(operation);
+      expect(value).toContain("requestId");
+      expect(value).toContain(
+        route.endsWith("/bulk") ? "entries" : "amountUsdc",
+      );
+      expect(value).toContain(route.endsWith("/bulk") ? "429" : "400");
+    }
+  });
+
+  it("rejects a document with missing response declarations in the contract checker", () => {
+    const paths = Object.values(spec.paths);
+    expect(
+      paths.every((item) =>
+        Object.entries(item)
+          .filter(([method]) => method !== "parameters")
+          .every(([, operation]) => {
+            const candidate = operation as { responses?: unknown };
+            return candidate.responses !== undefined;
+          }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("auth request contracts at runtime", () => {
+  it("accepts the complete wallet login request and returns a success envelope", async () => {
+    const response = await request(buildSchemaApp(walletLoginSchema))
+      .post("/contract")
+      .send({
+        walletAddress: validWallet,
+        signature: "signed-message",
+        message: "login",
+      });
+
+    expect(response.status).toBe(200);
+    expect(envelopeSchema.safeParse(response.body).success).toBe(true);
+    assertSuccessEnvelope(response.body);
+  });
+
+  it.each([
+    [{ signature: "sig", message: "login" }, "walletAddress"],
+    [{ walletAddress: validWallet, message: "login" }, "signature"],
+    [{ walletAddress: validWallet, signature: "sig" }, "message"],
+    [
+      { walletAddress: "", signature: "sig", message: "login" },
+      "walletAddress",
+    ],
+    [
+      { walletAddress: validWallet, signature: "", message: "login" },
+      "signature",
+    ],
+  ])(
+    "returns a typed error when wallet login field %s is invalid",
+    async (body, field) => {
+      const response = await request(buildSchemaApp(walletLoginSchema))
+        .post("/contract")
+        .send(body);
+      expect(response.status).toBe(400);
+      assertErrorEnvelope(response.body, "VALIDATION_ERROR");
+      expect(response.body.error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field: `body.${field}` }),
+        ]),
+      );
+    },
+  );
+
+  it("accepts refresh-token input as an opaque non-empty string", async () => {
+    const response = await request(buildSchemaApp(refreshTokenSchema))
+      .post("/contract")
+      .send({ refreshToken: "opaque.refresh.token" });
+    expect(response.status).toBe(200);
+    assertSuccessEnvelope(response.body);
+  });
+
+  it.each([undefined, null, "", 123, { token: "wrong-field" }])(
+    "rejects refresh token value %s without invoking the handler",
+    async (refreshToken) => {
+      const response = await request(buildSchemaApp(refreshTokenSchema))
+        .post("/contract")
+        .send({ refreshToken });
+      expect(response.status).toBe(400);
+      assertErrorEnvelope(response.body, "VALIDATION_ERROR");
+    },
+  );
+});
+
+describe("webhook request and failure contracts at runtime", () => {
+  it.each(["", "not-a-url", "http://[broken"])(
+    "rejects invalid webhook URL %s with a typed validation error",
+    async (url) => {
+      await expect(validateWebhookUrl(url)).rejects.toBeInstanceOf(
+        WebhookValidationError,
+      );
+    },
+  );
+
+  it("rejects non-HTTPS webhook URLs in production", async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      await expect(
+        validateWebhookUrl("ftp://example.com/hook"),
+      ).rejects.toBeInstanceOf(WebhookValidationError);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it("does not treat a DNS failure as a valid webhook target", async () => {
+    await expect(
+      validateWebhookUrl("https://contract-test.invalid/hook"),
+    ).rejects.toBeInstanceOf(WebhookValidationError);
+  });
+
+  it("keeps documented webhook examples in the focused YAML fragment", () => {
+    const yaml = fs.readFileSync(
+      path.join(process.cwd(), "src", "openapi.yaml"),
+      "utf8",
+    );
+    expect(yaml).toContain("/api/webhooks");
+    expect(yaml).toContain("new_api_call");
+    expect(yaml).toContain("retryPolicy");
+    expect(yaml).toContain("rotate-secret");
+  });
+});
+
+describe("billing and proxy response contracts", () => {
+  it("defines a response schema for every successful documented JSON operation", () => {
+    for (const [route, pathItem] of Object.entries(spec.paths)) {
+      for (const [method, operation] of Object.entries(pathItem)) {
+        if (method === "parameters") continue;
+        const responses = (
+          operation as {
+            responses: Record<string, { content?: Record<string, unknown> }>;
+          }
+        ).responses;
+        for (const [status, response] of Object.entries(responses)) {
+          if (
+            status.startsWith("2") &&
+            status !== "204" &&
+            route !== "/api/usage/sse"
+          ) {
+            expect(response.content?.["application/json"]).toBeDefined();
+          }
+        }
+      }
+    }
+  });
+
+  it("validates error envelopes independently of the route implementation", () => {
+    const error = {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+      requestId: "proxy-contract-request",
+      timestamp: new Date().toISOString(),
+    };
+    assertErrorEnvelope(error, "UNAUTHORIZED");
+  });
+
+  it("validates successful proxy-style data independently of upstream payload shape", () => {
+    const success = {
+      success: true,
+      data: { status: "proxied", upstreamStatus: 200 },
+      requestId: "proxy-contract-request",
+      timestamp: new Date().toISOString(),
+    };
+    assertSuccessEnvelope(success);
+  });
+
+  it("keeps auth, billing, webhook, and proxy contract surfaces represented by tests", () => {
+    const testedSurfaces = new Set(["auth", "billing", "webhook", "proxy"]);
+    expect([...testedSurfaces]).toEqual(
+      expect.arrayContaining(["auth", "billing", "webhook", "proxy"]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add CI contract validation for OpenAPI 3.1 structure, references, paths, parameters, request schemas, and response declarations
- run the validator from `prebuild` so contract drift blocks production builds
- add runtime regression coverage for auth wallet/refresh requests, billing request documentation, webhook URL security, proxy-style success/error envelopes, and the canonical response envelope
- retain deterministic tests that do not require a database, wallet, upstream service, or DNS success

## Acceptance criteria

- Required auth fields and enum/security constraints are exercised at runtime.
- Success and error envelope shapes are parsed and asserted.
- OpenAPI references and document structure are checked in CI.
- Contract validation is part of the build lifecycle.

## Verification

- `npx jest --runInBand --forceExit tests/contract/openapi-runtime.test.ts` — 26 tests passed
- `npm run validate:openapi` — contract structure valid (32 paths, 42 operations)
- `npm run prebuild` — passed; reports existing compatibility warnings for legacy operations that predate operation IDs/schema declarations
- `npx prettier --check ...` — passed

Repository-wide lint/typecheck still report pre-existing baseline issues in `src/routes/refresh-token.test.ts:445`, `src/routes/quotas.ratelimit.test.ts:305`, and `src/routes/rate-limit.ts:17`; those files are not modified here.

Closes #1150