### PR TITLE
[#1146] Enforce tenant ownership on tenant routes

### DIFF
--- a/src/routes/tenants.test.ts
+++ b/src/routes/tenants.test.ts
@@ -258,6 +258,24 @@ describe('createTenantsRouter', () => {
     );
   });
 
+  it('does not list or update another developer\'s tenant', async () => {
+    const app = buildDefaultRepositoryApp();
+    const own = await request(app).post('/api/tenants').set('x-user-id', 'dev-1').send({ name: 'Own tenant' });
+    const foreign = await request(app).post('/api/tenants').set('x-user-id', 'dev-2').send({ name: 'Foreign tenant' });
+
+    const list = await request(app).get('/api/tenants').set('x-user-id', 'dev-1');
+    expect(list.status).toBe(200);
+    expect(list.body.data).toHaveLength(1);
+    expect(list.body.data[0].id).toBe(own.body.data.id);
+
+    const crossTenantUpdate = await request(app)
+      .patch(`/api/tenants/${foreign.body.data.id}`)
+      .set('x-user-id', 'dev-1')
+      .send({ name: 'Attempted takeover' });
+    expect(crossTenantUpdate.status).toBe(404);
+    expect(crossTenantUpdate.body.error.code).toBe('NOT_FOUND');
+  });
+
   it('routes repository errors through the error handler', async () => {
     const repository = new MockTenantRepository();
     repository.create.mockRejectedValueOnce(new Error('tenant store unavailable'));

--- a/src/routes/tenants.ts
+++ b/src/routes/tenants.ts
@@ -5,6 +5,7 @@ import { bodyValidator, validate } from '../middleware/validate.js';
 import { buildSuccessEnvelope } from '../middleware/envelope.js';
 import { etagMiddleware, generateETag } from '../middleware/etag.js';
 import { logger } from '../logger.js';
+import { NotFoundError } from '../errors/index.js';
 import {
   createTenantSchema,
   tenantParamsSchema,
@@ -26,7 +27,7 @@ export interface TenantRecord {
 }
 
 export interface TenantRepository {
-  list(): Promise<TenantRecord[]>;
+  list(actorId: string): Promise<TenantRecord[]>;
   create(input: CreateTenantInput, actorId: string): Promise<TenantRecord>;
   update(tenantId: string, input: UpdateTenantInput, actorId: string): Promise<TenantRecord>;
 }
@@ -34,8 +35,8 @@ export interface TenantRepository {
 class InMemoryTenantRepository implements TenantRepository {
   private tenants = new Map<string, TenantRecord>();
 
-  async list(): Promise<TenantRecord[]> {
-    return Array.from(this.tenants.values());
+  async list(actorId: string): Promise<TenantRecord[]> {
+    return Array.from(this.tenants.values()).filter((tenant) => tenant.createdBy === actorId);
   }
 
   async create(input: CreateTenantInput, actorId: string): Promise<TenantRecord> {
@@ -57,15 +58,13 @@ class InMemoryTenantRepository implements TenantRepository {
   }
 
   async update(tenantId: string, input: UpdateTenantInput, _actorId: string): Promise<TenantRecord> {
-    const existing = this.tenants.get(tenantId) ?? {
-      id: tenantId,
-      name: 'Existing tenant',
-      slug: slugify(tenantId),
-      plan: 'starter' as const,
-      createdBy: 'system',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
+    const existing = this.tenants.get(tenantId);
+    // Do not create or reveal arbitrary IDs during an update. Both unknown
+    // and cross-tenant IDs use the same not-found response to avoid existence
+    // probing.
+    if (!existing || existing.createdBy !== _actorId) {
+      throw new NotFoundError('Tenant not found');
+    }
 
     const updated: TenantRecord = {
       ...existing,
@@ -159,7 +158,8 @@ export function createTenantsRouter(deps: TenantsRouterDeps = {}): Router {
     etagMiddleware,
     async (req: Request, res: Response<unknown, AuthenticatedLocals>, next) => {
       try {
-        const tenants = await tenantRepository.list();
+        const actorId = res.locals.authenticatedUser!.id;
+        const tenants = await tenantRepository.list(actorId);
 
         logger.info('[tenants] tenants listed', {
           requestId: requestId(req),


### PR DESCRIPTION
## Summary
- scope tenant listings to the authenticated developer
- reject unknown and cross-tenant tenant IDs with the same not-found response
- prevent update requests from creating arbitrary tenant records
- add an end-to-end regression test for cross-tenant listing and update attempts

## Acceptance criteria
- [x] Tenant list results are owner-scoped
- [x] Tenant updates require ownership
- [x] Cross-tenant and unknown IDs do not reveal resource existence
- [x] Authentication remains required before tenant access checks

## Validation
- `git diff --check` passed
- Runtime tests were not run because dependencies are not installed in the isolated worktree

Closes #1146