### PR TITLE
[#1143] Make billing reconciliation idempotent

### DIFF
--- a/docs/BILLING_RECONCILIATION_IDEMPOTENCY.md
+++ b/docs/BILLING_RECONCILIATION_IDEMPOTENCY.md
@@ -1,0 +1,85 @@
+# Billing reconciliation idempotency
+
+Provider webhooks are at-least-once. The immutable key is the tuple
+`tenant_id + provider_event_id`; it must be unique in the reconciliation table
+and never be replaced when an invoice is edited. The canonical fingerprint
+binds that tuple to invoice, developer, amount, currency, timestamp, and the
+sorted payload. A repeated tuple with the same fingerprint is a replay and
+returns the original ledger entry. A different fingerprint is a conflict.
+
+`admitBillingEvent` executes lookup, ledger mutation, and reconciliation
+insert inside one transaction supplied by the store. The ledger mutation is
+not committed if the reconciliation row cannot be inserted. Database-backed
+stores should enforce a unique `(tenant_id, provider_event_id)` constraint and
+translate a unique-key race into a lookup/replay after the winning transaction
+commits.
+
+Conflicts write only non-sensitive fingerprints and identity metadata to the
+audit stream. Raw provider payloads and secrets are not copied into audit
+records. A conflict must be visible to operations and must never be treated as
+a successful replay.
+
+The in-memory store is a deterministic test adapter, not a production
+replacement. Production deployments must use a database transaction with row
+locking or an atomic insert-on-conflict operation, and must retain reconciliation
+records long enough to cover provider retry windows and chargeback review.
+
+Operational checks:
+
+- alert on conflict volume and unexpected tenant mismatches;
+- expose applied, replay, and conflict counters separately;
+- retain the original ledger entry id in provider-response metadata;
+- never retry a conflict without human or provider-side correction;
+- verify authorization before accepting a tenant-scoped provider key.
+
+Deployment note: apply the unique-key migration before enabling the consumer,
+then run a shadow pass that compares provider event counts with reconciliation
+records. During rollback keep the records and unique constraint in place; an
+older consumer may safely return a replay, but deleting the key would reopen
+the double-charge window. Operators should retain conflict fingerprints for
+forensic correlation without retaining payment secrets or complete payloads.
+
+### Acceptance mapping
+
+- Replay leaves the balance unchanged: admission regression tests.
+- Conflicts are rejected and audited: the conflict parameter matrix.
+- Ledger and record are one transaction: rollback tests in both suites.
+- Concurrent submissions are serialized: the 25-request race test.
+- Authorization remains tenant-scoped: tenant isolation cases.
+
+The adapter deliberately does not infer tenant identity from invoice or
+developer identifiers. The authenticated provider connection supplies the
+tenant, and the provider event id is accepted only in that namespace. This
+prevents an event copied between tenants from being interpreted as a replay.
+
+For a database implementation, use a parameterized insert and a unique index;
+never build SQL from the provider id. Store monetary values in the smallest
+integer unit and do not use floating point arithmetic. Compare currency after
+normalization but preserve the canonical uppercase code in the audit context.
+
+The operation is intentionally monotonic: `applied` is written once, replay
+does not rewrite its timestamp, and conflict never changes the ledger. This
+makes provider retries safe to observe and safe to reconcile after a restart.
+If a database transaction is lost after the provider call, the next delivery
+uses the same immutable event key and resolves to the existing record rather
+than issuing another ledger mutation.
+
+### Incident response
+
+When conflicts rise, first identify the provider and tenant from the audit
+entry, then compare the two fingerprints in the provider console. Do not
+delete the original record to force a retry. Correct the provider payload or
+invoice mapping, record the decision, and submit a new provider event with a
+new immutable id. For suspected duplicate charges, freeze automated retries,
+reconcile ledger entry ids against settlement records, and preserve the
+original audit trail for review.
+
+Metrics should include the tenant-independent outcome labels `applied`,
+`replay`, and `conflict`; tenant ids belong in logs with access controls, not
+metric labels. This avoids high-cardinality billing identifiers leaking into
+shared monitoring systems.
+
+Reviewers should retain this evidence with the release record and verify that
+the production adapter implements the same transaction contract.
+
+The contract is part of the billing correctness boundary.

--- a/src/services/billingReconciliationAdmission.matrix.test.ts
+++ b/src/services/billingReconciliationAdmission.matrix.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { BillingConflictError, InMemoryBillingAdmissionStore, admitBillingEvent } from './billingReconciliationAdmission.js'
+
+const event = (n: number, overrides: Record<string, unknown> = {}) => ({
+  tenantId: 'tenant-matrix', providerEventId: `provider-${n}`, invoiceId: `invoice-${n}`,
+  developerId: 'developer-matrix', amountMinor: n * 100, currency: 'USD',
+  occurredAt: `2026-08-27T10:${String(n).padStart(2, '0')}:00.000Z`, payload: { n, tags: ['billing', 'provider'] }, ...overrides,
+})
+
+describe('billing admission mutation matrix', () => {
+  it.each(Array.from({ length: 20 }, (_, index) => index + 1))('applies distinct provider event %i once', async n => {
+    const store = new InMemoryBillingAdmissionStore()
+    const first = await admitBillingEvent(store, event(n))
+    const second = await admitBillingEvent(store, event(n))
+    expect(first.outcome).toBe('applied')
+    expect(second.outcome).toBe('replay')
+    expect(store.getBalance('developer-matrix')).toBe(n * 100)
+  })
+
+  it('serializes concurrent identical submissions to one ledger mutation', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    const results = await Promise.all(Array.from({ length: 25 }, () => admitBillingEvent(store, event(21))))
+    expect(results.filter(result => result.outcome === 'applied')).toHaveLength(1)
+    expect(results.filter(result => result.outcome === 'replay')).toHaveLength(24)
+    expect(store.getBalance('developer-matrix')).toBe(2100)
+  })
+
+  it('serializes concurrent conflicting submissions and audits each loser', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, event(22))
+    const results = await Promise.allSettled(Array.from({ length: 5 }, (_, index) => admitBillingEvent(store, event(22, { amountMinor: 2201 + index }))))
+    expect(results.every(result => result.status === 'rejected')).toBe(true)
+    expect(results.every(result => result.status === 'rejected' && result.reason instanceof BillingConflictError)).toBe(true)
+    expect(store.getConflicts()).toHaveLength(5)
+    expect(store.getBalance('developer-matrix')).toBe(2200)
+  })
+
+  it.each([
+    ['tenant', { tenantId: 'tenant-other' }],
+    ['provider id', { providerEventId: 'provider-other' }],
+    ['invoice', { invoiceId: 'invoice-other' }],
+    ['developer', { developerId: 'developer-other' }],
+  ])('keeps %s identity independent', async (_label, change) => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, event(23))
+    const result = await admitBillingEvent(store, event(23, change))
+    expect(result.outcome).toBe('applied')
+  })
+
+  it.each([
+    ['zero amount', { amountMinor: 0 }],
+    ['largest safe amount', { amountMinor: Number.MAX_SAFE_INTEGER }],
+    ['lowercase currency', { currency: 'eur' }],
+    ['empty metadata', { payload: {} }],
+    ['nested metadata', { payload: { nested: { z: 1, a: [true, null, 'x'] } } }],
+  ])('accepts valid boundary %s', async (_label, change) => {
+    const store = new InMemoryBillingAdmissionStore()
+    await expect(admitBillingEvent(store, event(24, change))).resolves.toMatchObject({ outcome: 'applied' })
+  })
+
+  it.each([
+    ['unsafe amount', { amountMinor: Number.MAX_SAFE_INTEGER + 1 }],
+    ['negative string amount', { amountMinor: '-1' }],
+    ['invalid currency length', { currency: 'US' }],
+    ['numeric currency', { currency: 840 }],
+    ['invalid time', { occurredAt: '2026-99-99' }],
+    ['null payload', { payload: null }],
+  ])('rejects invalid boundary %s', async (_label, change) => {
+    const store = new InMemoryBillingAdmissionStore()
+    await expect(admitBillingEvent(store, event(25, change))).rejects.toThrow()
+    expect(store.getBalance('developer-matrix')).toBe(0)
+  })
+
+  it('rolls back a failed ledger mutation and permits a retry', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    const failingStore = {
+      ...store,
+      applyLedgerMutation: async () => { throw new Error('ledger unavailable') },
+    } as any
+    await expect(admitBillingEvent(failingStore, event(26))).rejects.toThrow('ledger unavailable')
+    await expect(admitBillingEvent(store, event(26))).resolves.toMatchObject({ outcome: 'applied' })
+    expect(store.getBalance('developer-matrix')).toBe(2600)
+  })
+
+  it('preserves the first ledger entry id on every replay', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    const first = await admitBillingEvent(store, event(27))
+    for (let index = 0; index < 10; index++) {
+      const replay = await admitBillingEvent(store, event(27))
+      expect(replay.record.ledgerEntryId).toBe(first.record.ledgerEntryId)
+    }
+  })
+
+  it('does not report a conflict as a replay when only payload changes', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, event(28))
+    const result = await Promise.allSettled([admitBillingEvent(store, event(28, { payload: { n: 28, changed: true } }))])
+    expect(result[0].status).toBe('rejected')
+    expect((result[0] as PromiseRejectedResult).reason).toBeInstanceOf(BillingConflictError)
+  })
+
+  it('maintains balances independently for tenants and developers', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, event(29, { tenantId: 'a', developerId: 'dev-a', amountMinor: 10 }))
+    await admitBillingEvent(store, event(29, { tenantId: 'b', developerId: 'dev-b', amountMinor: 20 }))
+    expect(store.getBalance('dev-a')).toBe(10)
+    expect(store.getBalance('dev-b')).toBe(20)
+  })
+
+  it('returns a copy of conflict audit records', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, event(30))
+    await expect(admitBillingEvent(store, event(30, { amountMinor: 3001 }))).rejects.toThrow()
+    const conflicts = store.getConflicts()
+    conflicts[0].tenantId = 'mutated'
+    expect(store.getConflicts()[0].tenantId).toBe('tenant-matrix')
+  })
+
+  it('can be cleared between isolated test lifecycles', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, event(31))
+    store.clear()
+    expect(store.getBalance('developer-matrix')).toBe(0)
+    expect(store.getRecord('tenant-matrix', 'provider-31')).toBeUndefined()
+    await expect(admitBillingEvent(store, event(31))).resolves.toMatchObject({ outcome: 'applied' })
+  })
+})

--- a/src/services/billingReconciliationAdmission.test.ts
+++ b/src/services/billingReconciliationAdmission.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { BillingConflictError, InMemoryBillingAdmissionStore, admitBillingEvent, providerEventFingerprint } from './billingReconciliationAdmission.js'
+
+const base = (overrides: Record<string, unknown> = {}) => ({
+  tenantId: 'tenant-a', providerEventId: 'evt-001', invoiceId: 'invoice-1', developerId: 'dev-1', amountMinor: 1250,
+  currency: 'usd', occurredAt: '2026-08-27T10:00:00.000Z', payload: { lineItems: [{ amount: 1250, sku: 'api' }], metadata: { region: 'us' } }, ...overrides,
+})
+
+describe('billing reconciliation admission', () => {
+  it('applies a provider event and writes the ledger record', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    const result = await admitBillingEvent(store, base())
+    expect(result.outcome).toBe('applied')
+    expect(store.getBalance('dev-1')).toBe(1250)
+    expect(store.getRecord('tenant-a', 'evt-001')?.fingerprint).toBe(providerEventFingerprint(base()))
+  })
+
+  it('returns the original result on an identical replay', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    const first = await admitBillingEvent(store, base())
+    const replay = await admitBillingEvent(store, base())
+    expect(replay.outcome).toBe('replay')
+    expect(replay.record.ledgerEntryId).toBe(first.record.ledgerEntryId)
+    expect(store.getBalance('dev-1')).toBe(1250)
+  })
+
+  it.each([
+    ['amount', { amountMinor: 1251 }],
+    ['invoice', { invoiceId: 'invoice-2' }],
+    ['developer', { developerId: 'dev-2' }],
+    ['payload', { payload: { lineItems: [{ amount: 999 }] } }],
+    ['timestamp', { occurredAt: '2026-08-27T11:00:00.000Z' }],
+  ])('audits and rejects a conflicting %s replay', async (_name, change) => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, base())
+    await expect(admitBillingEvent(store, base(change))).rejects.toBeInstanceOf(BillingConflictError)
+    expect(store.getBalance('dev-1')).toBe(1250)
+    expect(store.getConflicts()).toHaveLength(1)
+    expect(store.getConflicts()[0].providerEventId).toBe('evt-001')
+  })
+
+  it('does not allow a cross-tenant event to replay', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, base())
+    const result = await admitBillingEvent(store, base({ tenantId: 'tenant-b' }))
+    expect(result.outcome).toBe('applied')
+    expect(store.getBalance('dev-1')).toBe(2500)
+  })
+
+  it('keeps the same provider event isolated by tenant', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, base({ tenantId: 'tenant-a' }))
+    await admitBillingEvent(store, base({ tenantId: 'tenant-b', developerId: 'dev-2' }))
+    expect(store.getRecord('tenant-a', 'evt-001')).toBeDefined()
+    expect(store.getRecord('tenant-b', 'evt-001')).toBeDefined()
+  })
+
+  it.each([
+    ['empty tenant', { tenantId: '' }],
+    ['empty event id', { providerEventId: '' }],
+    ['empty invoice', { invoiceId: ' ' }],
+    ['negative amount', { amountMinor: -1 }],
+    ['fractional amount', { amountMinor: 1.5 }],
+    ['invalid currency', { currency: 'dollars' }],
+    ['invalid timestamp', { occurredAt: 'not-a-date' }],
+    ['array payload', { payload: [] }],
+  ])('rejects %s before opening a transaction', async (_name, invalid) => {
+    const store = new InMemoryBillingAdmissionStore()
+    await expect(admitBillingEvent(store, base(invalid))).rejects.toThrow()
+    expect(store.getConflicts()).toHaveLength(0)
+  })
+
+  it('rolls back both ledger and reconciliation record when insert fails', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    const failing = { ...store, insertReconciliation: async () => { throw new Error('write failed') } } as any
+    await expect(admitBillingEvent(failing, base())).rejects.toThrow('write failed')
+    expect(store.getBalance('dev-1')).toBe(0)
+    expect(store.getRecord('tenant-a', 'evt-001')).toBeUndefined()
+  })
+
+  it('uses canonical payload ordering for fingerprints', () => {
+    expect(providerEventFingerprint(base({ payload: { b: 2, a: 1 } }))).toBe(providerEventFingerprint(base({ payload: { a: 1, b: 2 } })))
+  })
+
+  it('keeps amount representation stable across string and bigint inputs', () => {
+    expect(providerEventFingerprint(base({ amountMinor: '1250' }))).toBe(providerEventFingerprint(base({ amountMinor: 1250n })))
+  })
+
+  it('records sanitized conflict metadata without the raw payload', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, base({ payload: { secret: 'do-not-store' } }))
+    await expect(admitBillingEvent(store, base({ payload: { secret: 'changed' } }))).rejects.toThrow()
+    expect(JSON.stringify(store.getConflicts())).not.toContain('do-not-store')
+    expect(JSON.stringify(store.getConflicts())).not.toContain('changed')
+  })
+
+  it('does not mutate the event object while canonicalizing it', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    const input = base({ payload: { z: 1, a: 2 } })
+    const snapshot = JSON.stringify(input)
+    await admitBillingEvent(store, input)
+    expect(JSON.stringify(input)).toBe(snapshot)
+  })
+
+  it('supports independent events for one invoice', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, base({ providerEventId: 'evt-1', amountMinor: 10 }))
+    await admitBillingEvent(store, base({ providerEventId: 'evt-2', amountMinor: 20 }))
+    expect(store.getBalance('dev-1')).toBe(30)
+  })
+
+  it('reports identity mismatch when a same fingerprint has changed identity', async () => {
+    const store = new InMemoryBillingAdmissionStore()
+    await admitBillingEvent(store, base())
+    const altered = base({ invoiceId: 'invoice-2', payload: base().payload })
+    await expect(admitBillingEvent(store, altered)).rejects.toMatchObject({ audit: { reason: 'payload_mismatch' } })
+  })
+})

--- a/src/services/billingReconciliationAdmission.ts
+++ b/src/services/billingReconciliationAdmission.ts
@@ -1,0 +1,171 @@
+import { createHash } from 'node:crypto'
+
+export interface ProviderBillingEvent {
+  tenantId: string
+  providerEventId: string
+  invoiceId: string
+  developerId: string
+  amountMinor: bigint | number | string
+  currency: string
+  occurredAt: string
+  payload: Record<string, unknown>
+}
+
+export interface BillingReconciliationRecord {
+  tenantId: string
+  providerEventId: string
+  invoiceId: string
+  developerId: string
+  fingerprint: string
+  status: 'applied' | 'replay'
+  appliedAt: string
+  ledgerEntryId: string
+}
+
+export interface BillingConflictAudit {
+  tenantId: string
+  providerEventId: string
+  existingFingerprint: string
+  receivedFingerprint: string
+  reason: 'payload_mismatch' | 'identity_mismatch'
+  observedAt: string
+}
+
+export interface BillingAdmissionResult {
+  outcome: 'applied' | 'replay'
+  record: BillingReconciliationRecord
+}
+
+export class BillingConflictError extends Error {
+  readonly code = 'BILLING_RECONCILIATION_CONFLICT'
+  readonly statusCode = 409
+
+  constructor(public readonly audit: BillingConflictAudit) {
+    super('Provider billing event conflicts with an existing reconciliation record')
+    this.name = 'BillingConflictError'
+  }
+}
+
+export interface BillingAdmissionTransaction {
+  findReconciliation(tenantId: string, providerEventId: string): Promise<BillingReconciliationRecord | undefined>
+  applyLedgerMutation(event: ProviderBillingEvent): Promise<{ ledgerEntryId: string }>
+  insertReconciliation(record: BillingReconciliationRecord): Promise<void>
+  insertConflictAudit(audit: BillingConflictAudit): Promise<void>
+}
+
+export interface BillingAdmissionStore {
+  withTransaction<T>(callback: (transaction: BillingAdmissionTransaction) => Promise<T>): Promise<T>
+}
+
+export function providerEventFingerprint(event: ProviderBillingEvent): string {
+  const canonical = JSON.stringify({
+    tenantId: event.tenantId,
+    providerEventId: event.providerEventId,
+    invoiceId: event.invoiceId,
+    developerId: event.developerId,
+    amountMinor: String(event.amountMinor),
+    currency: event.currency.toUpperCase(),
+    occurredAt: event.occurredAt,
+    payload: canonicalize(event.payload),
+  })
+  return createHash('sha256').update(canonical, 'utf8').digest('hex')
+}
+
+export async function admitBillingEvent(
+  store: BillingAdmissionStore,
+  event: ProviderBillingEvent,
+  now: () => Date = () => new Date()
+): Promise<BillingAdmissionResult> {
+  validateProviderEvent(event)
+  const fingerprint = providerEventFingerprint(event)
+
+  return store.withTransaction(async transaction => {
+    const existing = await transaction.findReconciliation(event.tenantId, event.providerEventId)
+    if (existing) {
+      if (existing.fingerprint !== fingerprint || existing.invoiceId !== event.invoiceId || existing.developerId !== event.developerId) {
+        const audit: BillingConflictAudit = {
+          tenantId: event.tenantId,
+          providerEventId: event.providerEventId,
+          existingFingerprint: existing.fingerprint,
+          receivedFingerprint: fingerprint,
+          reason: existing.fingerprint === fingerprint ? 'identity_mismatch' : 'payload_mismatch',
+          observedAt: now().toISOString(),
+        }
+        await transaction.insertConflictAudit(audit)
+        throw new BillingConflictError(audit)
+      }
+      return { outcome: 'replay', record: { ...existing, status: 'replay' } }
+    }
+
+    const ledger = await transaction.applyLedgerMutation(event)
+    const record: BillingReconciliationRecord = {
+      tenantId: event.tenantId,
+      providerEventId: event.providerEventId,
+      invoiceId: event.invoiceId,
+      developerId: event.developerId,
+      fingerprint,
+      status: 'applied',
+      appliedAt: now().toISOString(),
+      ledgerEntryId: ledger.ledgerEntryId,
+    }
+    await transaction.insertReconciliation(record)
+    return { outcome: 'applied', record }
+  })
+}
+
+export class InMemoryBillingAdmissionStore implements BillingAdmissionStore, BillingAdmissionTransaction {
+  private readonly records = new Map<string, BillingReconciliationRecord>()
+  private readonly conflicts: BillingConflictAudit[] = []
+  private readonly ledger = new Map<string, number>()
+  private nextLedgerEntry = 1
+  private transactionTail: Promise<void> = Promise.resolve()
+
+  withTransaction<T>(callback: (transaction: BillingAdmissionTransaction) => Promise<T>): Promise<T> {
+    const run = this.transactionTail.then(() => this.executeTransaction(callback))
+    this.transactionTail = run.then(() => undefined, () => undefined)
+    return run
+  }
+
+  private async executeTransaction<T>(callback: (transaction: BillingAdmissionTransaction) => Promise<T>): Promise<T> {
+    const records = new Map(this.records)
+    const ledger = new Map(this.ledger)
+    const conflicts = this.conflicts.length
+    try {
+      return await callback(this)
+    } catch (error) {
+      this.records.clear(); for (const [key, value] of records) this.records.set(key, value)
+      this.ledger.clear(); for (const [key, value] of ledger) this.ledger.set(key, value)
+      this.conflicts.splice(conflicts)
+      throw error
+    }
+  }
+
+  async findReconciliation(tenantId: string, providerEventId: string) { return this.records.get(key(tenantId, providerEventId)) }
+  async applyLedgerMutation(event: ProviderBillingEvent) {
+    const current = this.ledger.get(event.developerId) ?? 0
+    this.ledger.set(event.developerId, current + Number(event.amountMinor))
+    return { ledgerEntryId: `ledger-${this.nextLedgerEntry++}` }
+  }
+  async insertReconciliation(record: BillingReconciliationRecord) { this.records.set(key(record.tenantId, record.providerEventId), { ...record }) }
+  async insertConflictAudit(audit: BillingConflictAudit) { this.conflicts.push({ ...audit }) }
+  getBalance(developerId: string) { return this.ledger.get(developerId) ?? 0 }
+  getConflicts() { return this.conflicts.map(conflict => ({ ...conflict })) }
+  getRecord(tenantId: string, providerEventId: string) { return this.records.get(key(tenantId, providerEventId)) }
+  clear() { this.records.clear(); this.conflicts.length = 0; this.ledger.clear(); this.nextLedgerEntry = 1 }
+}
+
+function key(tenantId: string, providerEventId: string) { return `${tenantId}:${providerEventId}` }
+
+function validateProviderEvent(event: ProviderBillingEvent): void {
+  if (!event.tenantId.trim() || !event.providerEventId.trim() || !event.invoiceId.trim() || !event.developerId.trim()) throw new Error('Billing event identity is required')
+  if (!Number.isSafeInteger(Number(event.amountMinor)) || Number(event.amountMinor) < 0) throw new Error('Billing amount must be a non-negative safe integer')
+  if (!/^[A-Z]{3}$/.test(event.currency.toUpperCase())) throw new Error('Billing currency must be an ISO-4217 code')
+  if (Number.isNaN(Date.parse(event.occurredAt))) throw new Error('Billing event occurredAt must be an ISO timestamp')
+  if (!event.payload || typeof event.payload !== 'object' || Array.isArray(event.payload)) throw new Error('Billing event payload must be an object')
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') return Object.fromEntries(Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => [key, canonicalize(item)]))
+  return value
+}


### PR DESCRIPTION
## Summary
- add immutable tenant-scoped provider-event admission and SHA-256 fingerprints
- return the original ledger entry for exact replays without reapplying the charge
- reject and audit conflicting payload or identity changes
- coordinate ledger mutation and reconciliation insertion through one transaction
- add concurrent, rollback, boundary, isolation, and replay regression coverage

## Acceptance criteria
- repeated events leave the ledger unchanged after first application
- conflicting payloads are rejected and audited
- ledger and reconciliation record are committed atomically
- replay, conflict, rollback, and concurrent submissions are covered

## Validation
- `git diff --check`
- focused Vitest execution is unavailable because this checkout has no dependencies and shared disk space is exhausted during install

Closes #1143